### PR TITLE
Add Playwright E2E tests with mock ESI and Docker CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,44 @@ jobs:
           docker images | grep industry-tool-frontend
           echo "✅ Production images verified"
 
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run E2E tests
+        env:
+          DOCKER_COMPOSE: docker compose
+        run: make test-e2e-ci
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: artifacts/e2e-report/
+          retention-days: 7
+
+      - name: Upload test screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: e2e-screenshots
+          path: e2e/test-results/
+          retention-days: 7
+
+      - name: Clean up
+        if: always()
+        env:
+          DOCKER_COMPOSE: docker compose
+        run: make test-e2e-clean
+
   coveralls-finish:
     name: Finalize Coveralls
     runs-on: ubuntu-latest
@@ -123,18 +161,24 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [backend-tests, frontend-tests, production-builds]
+    needs: [backend-tests, frontend-tests, production-builds, e2e-tests]
     if: always()
 
     steps:
       - name: Check test results
+        env:
+          BACKEND_RESULT: ${{ needs.backend-tests.result }}
+          FRONTEND_RESULT: ${{ needs.frontend-tests.result }}
+          PRODUCTION_RESULT: ${{ needs.production-builds.result }}
+          E2E_RESULT: ${{ needs.e2e-tests.result }}
         run: |
-          if [ "${{ needs.backend-tests.result }}" != "success" ] || [ "${{ needs.frontend-tests.result }}" != "success" ] || [ "${{ needs.production-builds.result }}" != "success" ]; then
-            echo "❌ CI checks failed!"
-            echo "Backend Tests: ${{ needs.backend-tests.result }}"
-            echo "Frontend Tests: ${{ needs.frontend-tests.result }}"
-            echo "Production Builds: ${{ needs.production-builds.result }}"
+          if [ "$BACKEND_RESULT" != "success" ] || [ "$FRONTEND_RESULT" != "success" ] || [ "$PRODUCTION_RESULT" != "success" ] || [ "$E2E_RESULT" != "success" ]; then
+            echo "CI checks failed!"
+            echo "Backend Tests: $BACKEND_RESULT"
+            echo "Frontend Tests: $FRONTEND_RESULT"
+            echo "Production Builds: $PRODUCTION_RESULT"
+            echo "E2E Tests: $E2E_RESULT"
             exit 1
           else
-            echo "✅ All CI checks passed!"
+            echo "All CI checks passed!"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,18 @@ coverage/
 .DS_Store
 Thumbs.db
 
+# E2E test artifacts
+e2e/test-results/
+e2e/playwright-report/
+e2e/auth-state.json
+e2e/node_modules/
+
 # Claude
 .claude/
+
+# go binaries in case they sneak in
 industry-tool
+!cmd/industry-tool/
 industry-tool-test
+mock-esi
+!cmd/mock-esi/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@context.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ CMD go test -race -coverprofile=/artifacts/coverage.txt -covermode=atomic -p 1 .
 # final image
 FROM ubuntu:26.04 as final-backend
 
-RUN apt update && apt install -y ca-certificates
+RUN apt update && apt install -y ca-certificates curl
 WORKDIR /app
 
 COPY --from=0 /build/industry-tool /app/

--- a/Dockerfile.mock-esi
+++ b/Dockerfile.mock-esi
@@ -1,0 +1,21 @@
+FROM golang:1.25 as build
+
+WORKDIR /build
+
+COPY go.mod ./
+COPY go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN go build -o ./mock-esi ./cmd/mock-esi
+
+FROM ubuntu:26.04
+
+RUN apt update && apt install -y ca-certificates curl
+WORKDIR /app
+
+COPY --from=0 /build/mock-esi /app/
+
+CMD ["/app/mock-esi"]

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -24,7 +24,7 @@ FROM node:24.9.0-slim as publish-ui
 
 # Install CA certificates for HTTPS requests
 RUN apt-get update && \
-    apt-get install -y ca-certificates && \
+    apt-get install -y ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -75,7 +75,12 @@ var rootCmd = &cobra.Command{
 		buyOrdersRepository := repositories.NewBuyOrders(db)
 		salesAnalyticsRepository := repositories.NewSalesAnalytics(db)
 
-		esiClient := client.NewEsiClient(settings.OAuthClientID, settings.OAuthClientSecret)
+		var esiClient *client.EsiClient
+		if settings.EsiBaseURL != "" {
+			esiClient = client.NewEsiClientWithHTTPClient(settings.OAuthClientID, settings.OAuthClientSecret, &http.Client{}, settings.EsiBaseURL)
+		} else {
+			esiClient = client.NewEsiClient(settings.OAuthClientID, settings.OAuthClientSecret)
+		}
 
 		assetUpdater := updaters.NewAssets(charactersAssetRepository, charactersRepository, stationsRepository, playerCorporationRepostiory, playerCorporationAssetsRepository, esiClient)
 		staticUpdater := updaters.NewStatic(fuzzWorks, itemTypesRepository, regionsRepository, constellationsRepository, systemRepository, stationsRepository)

--- a/cmd/industry-tool/cmd/settings.go
+++ b/cmd/industry-tool/cmd/settings.go
@@ -15,6 +15,7 @@ type Settings struct {
 	DatabaseSettings  database.PostgresDatabaseSettings
 	OAuthClientID     string
 	OAuthClientSecret string
+	EsiBaseURL        string
 }
 
 func GetSettings() (*Settings, error) {
@@ -36,6 +37,7 @@ func GetSettings() (*Settings, error) {
 	settings.DatabaseSettings.Name = os.Getenv("DATABASE_NAME")
 	settings.OAuthClientID = os.Getenv("OAUTH_CLIENT_ID")
 	settings.OAuthClientSecret = os.Getenv("OAUTH_CLIENT_SECRET")
+	settings.EsiBaseURL = os.Getenv("ESI_BASE_URL")
 
 	s = os.Getenv("DATABASE_PORT")
 	settings.DatabaseSettings.Port, err = strconv.Atoi(s)

--- a/cmd/mock-esi/main.go
+++ b/cmd/mock-esi/main.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type asset struct {
+	ItemID       int64  `json:"item_id"`
+	IsBPC        bool   `json:"is_blueprint_copy"`
+	IsSingleton  bool   `json:"is_singleton"`
+	LocationFlag string `json:"location_flag"`
+	LocationID   int64  `json:"location_id"`
+	LocationType string `json:"location_type"`
+	Quantity     int64  `json:"quantity"`
+	TypeID       int64  `json:"type_id"`
+}
+
+type nameEntry struct {
+	ItemID int64  `json:"item_id"`
+	Name   string `json:"name"`
+}
+
+type affiliation struct {
+	CorporationID int64 `json:"corporation_id"`
+	CharacterID   int64 `json:"character_id"`
+}
+
+type corpInfo struct {
+	Name string `json:"name"`
+}
+
+type divisionEntry struct {
+	Division int    `json:"division"`
+	Name     string `json:"name"`
+}
+
+type divisionsResponse struct {
+	Hangar []divisionEntry `json:"hangar"`
+	Wallet []divisionEntry `json:"wallet"`
+}
+
+type structureInfo struct {
+	Name          string `json:"name"`
+	OwnerID       int64  `json:"owner_id"`
+	SolarSystemID int64  `json:"solar_system_id"`
+}
+
+type marketOrder struct {
+	OrderID      int64   `json:"order_id"`
+	TypeID       int64   `json:"type_id"`
+	LocationID   int64   `json:"location_id"`
+	VolumeTotal  int64   `json:"volume_total"`
+	VolumeRemain int64   `json:"volume_remain"`
+	MinVolume    int64   `json:"min_volume"`
+	Price        float64 `json:"price"`
+	IsBuyOrder   bool    `json:"is_buy_order"`
+	Duration     int     `json:"duration"`
+	Issued       string  `json:"issued"`
+	Range        string  `json:"range"`
+}
+
+// Character assets keyed by character ID
+var characterAssets = map[int64][]asset{
+	// Alice Alpha — assets in Jita
+	2001001: {
+		{ItemID: 100001, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 50000, TypeID: 34},  // Tritanium
+		{ItemID: 100002, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 25000, TypeID: 35},  // Pyerite
+		{ItemID: 100003, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 10000, TypeID: 36},  // Mexallon
+		{ItemID: 100004, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 1, TypeID: 11399, IsSingleton: true},    // Raven Navy Issue
+		{ItemID: 100010, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 1, TypeID: 17703, IsSingleton: true},    // Container
+		{ItemID: 100011, LocationFlag: "Hangar", LocationID: 100010, LocationType: "item", Quantity: 5000, TypeID: 37},        // Isogen in container
+	},
+	// Alice Beta — assets in Amarr
+	2001002: {
+		{ItemID: 110001, LocationFlag: "Hangar", LocationID: 60008494, LocationType: "station", Quantity: 3, TypeID: 587, IsSingleton: true},  // Rifter
+		{ItemID: 110002, LocationFlag: "Hangar", LocationID: 60008494, LocationType: "station", Quantity: 5000, TypeID: 38},   // Nocxium
+	},
+	// Bob Bravo — assets in Jita
+	2002001: {
+		{ItemID: 200001, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 30000, TypeID: 34},  // Tritanium
+		{ItemID: 200002, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 10, TypeID: 587, IsSingleton: true},     // Rifter
+	},
+	// Charlie Charlie — assets in Jita
+	2003001: {
+		{ItemID: 300001, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 1000, TypeID: 35},   // Pyerite
+	},
+	// Diana Delta — assets in Amarr
+	2004001: {
+		{ItemID: 400001, LocationFlag: "Hangar", LocationID: 60008494, LocationType: "station", Quantity: 15000, TypeID: 34},  // Tritanium
+	},
+}
+
+// Character asset names (container names)
+var characterNames = map[int64][]nameEntry{
+	2001001: {
+		{ItemID: 100010, Name: "Minerals Box"},
+	},
+}
+
+// Corporation assets keyed by corp ID
+var corpAssets = map[int64][]asset{
+	3001001: { // Stargazer Industries
+		{ItemID: 500001, LocationFlag: "CorpSAG1", LocationID: 60003760, LocationType: "station", Quantity: 100000, TypeID: 34}, // Tritanium
+		{ItemID: 500002, LocationFlag: "CorpSAG2", LocationID: 60003760, LocationType: "station", Quantity: 5, TypeID: 587, IsSingleton: true},    // Rifter
+		{ItemID: 500000, LocationFlag: "OfficeFolder", LocationID: 60003760, LocationType: "station", Quantity: 1, TypeID: 27},  // Office
+	},
+}
+
+var corpDivisions = map[int64]divisionsResponse{
+	3001001: {
+		Hangar: []divisionEntry{
+			{Division: 1, Name: "Main Hangar"},
+			{Division: 2, Name: "Production Materials"},
+		},
+		Wallet: []divisionEntry{
+			{Division: 1, Name: "Master Wallet"},
+		},
+	},
+}
+
+// Character to corporation mapping
+var charToCorp = map[int64]int64{
+	2001001: 3001001,
+	2001002: 3001001,
+	2002001: 3002001,
+	2003001: 3003001,
+	2004001: 3004001,
+}
+
+var corpNames = map[int64]string{
+	3001001: "Stargazer Industries",
+	3002001: "Bob's Mining Co",
+	3003001: "Charlie Trade Corp",
+	3004001: "Scout Fleet",
+}
+
+var marketOrders = []marketOrder{
+	// Tritanium sell
+	{OrderID: 1, TypeID: 34, LocationID: 60003760, VolumeTotal: 10000000, VolumeRemain: 5000000, MinVolume: 1, Price: 6.00, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+	// Tritanium buy
+	{OrderID: 2, TypeID: 34, LocationID: 60003760, VolumeTotal: 10000000, VolumeRemain: 5000000, MinVolume: 1, Price: 5.50, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+	// Pyerite sell
+	{OrderID: 3, TypeID: 35, LocationID: 60003760, VolumeTotal: 5000000, VolumeRemain: 2000000, MinVolume: 1, Price: 11.50, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+	// Pyerite buy
+	{OrderID: 4, TypeID: 35, LocationID: 60003760, VolumeTotal: 5000000, VolumeRemain: 2000000, MinVolume: 1, Price: 10.00, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+	// Mexallon sell
+	{OrderID: 5, TypeID: 36, LocationID: 60003760, VolumeTotal: 1000000, VolumeRemain: 500000, MinVolume: 1, Price: 75.00, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+	// Mexallon buy
+	{OrderID: 6, TypeID: 36, LocationID: 60003760, VolumeTotal: 1000000, VolumeRemain: 500000, MinVolume: 1, Price: 70.00, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+	// Rifter sell
+	{OrderID: 7, TypeID: 587, LocationID: 60003760, VolumeTotal: 100, VolumeRemain: 50, MinVolume: 1, Price: 600000, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
+	// Rifter buy
+	{OrderID: 8, TypeID: 587, LocationID: 60003760, VolumeTotal: 100, VolumeRemain: 50, MinVolume: 1, Price: 500000, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
+	// Raven Navy Issue sell
+	{OrderID: 9, TypeID: 11399, LocationID: 60003760, VolumeTotal: 10, VolumeRemain: 5, MinVolume: 1, Price: 520000000, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
+	// Raven Navy Issue buy
+	{OrderID: 10, TypeID: 11399, LocationID: 60003760, VolumeTotal: 10, VolumeRemain: 5, MinVolume: 1, Price: 500000000, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
+}
+
+func writeJSON(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(data)
+}
+
+func extractID(path, prefix, suffix string) (int64, bool) {
+	path = strings.TrimPrefix(path, prefix)
+	if suffix != "" {
+		path = strings.TrimSuffix(path, suffix)
+	}
+	// Remove query params
+	if idx := strings.Index(path, "?"); idx != -1 {
+		path = path[:idx]
+	}
+	// Remove trailing slashes
+	path = strings.TrimRight(path, "/")
+	id, err := strconv.ParseInt(path, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return id, true
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8090"
+	}
+
+	mux := http.NewServeMux()
+
+	// GET /characters/{id}/assets
+	mux.HandleFunc("/characters/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		// POST /characters/affiliation
+		if strings.HasSuffix(path, "/affiliation") && r.Method == "POST" {
+			var charIDs []int64
+			json.NewDecoder(r.Body).Decode(&charIDs)
+			result := []affiliation{}
+			for _, id := range charIDs {
+				corpID, ok := charToCorp[id]
+				if !ok {
+					corpID = 98000001
+				}
+				result = append(result, affiliation{CorporationID: corpID, CharacterID: id})
+			}
+			writeJSON(w, result)
+			return
+		}
+
+		// POST /characters/{id}/assets/names
+		if strings.HasSuffix(path, "/assets/names") && r.Method == "POST" {
+			charID, ok := extractID(path, "/characters/", "/assets/names")
+			if !ok {
+				http.Error(w, "invalid character id", 400)
+				return
+			}
+			names, ok := characterNames[charID]
+			if !ok {
+				names = []nameEntry{}
+			}
+			writeJSON(w, names)
+			return
+		}
+
+		// GET /characters/{id}/assets
+		if strings.Contains(path, "/assets") && r.Method == "GET" {
+			charID, ok := extractID(path, "/characters/", "/assets")
+			if !ok {
+				http.Error(w, "invalid character id", 400)
+				return
+			}
+			assets, ok := characterAssets[charID]
+			if !ok {
+				assets = []asset{}
+			}
+			w.Header().Set("X-Pages", "1")
+			writeJSON(w, assets)
+			return
+		}
+
+		http.Error(w, "not found", 404)
+	})
+
+	// Corporation endpoints
+	mux.HandleFunc("/corporations/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		// POST /corporations/{id}/assets/names
+		if strings.HasSuffix(path, "/assets/names") && r.Method == "POST" {
+			// No named corp containers in our test data
+			writeJSON(w, []nameEntry{})
+			return
+		}
+
+		// GET /corporations/{id}/assets
+		if strings.Contains(path, "/assets") && r.Method == "GET" {
+			corpID, ok := extractID(path, "/corporations/", "/assets")
+			if !ok {
+				http.Error(w, "invalid corp id", 400)
+				return
+			}
+			assets, ok := corpAssets[corpID]
+			if !ok {
+				assets = []asset{}
+			}
+			w.Header().Set("X-Pages", "1")
+			writeJSON(w, assets)
+			return
+		}
+
+		// GET /corporations/{id}/divisions
+		if strings.HasSuffix(path, "/divisions") {
+			corpID, ok := extractID(path, "/corporations/", "/divisions")
+			if !ok {
+				http.Error(w, "invalid corp id", 400)
+				return
+			}
+			divs, ok := corpDivisions[corpID]
+			if !ok {
+				divs = divisionsResponse{Hangar: []divisionEntry{}, Wallet: []divisionEntry{}}
+			}
+			writeJSON(w, divs)
+			return
+		}
+
+		// GET /corporations/{id} — corporation info
+		corpID, ok := extractID(path, "/corporations/", "")
+		if !ok {
+			http.Error(w, "invalid corp id", 400)
+			return
+		}
+		name, ok := corpNames[corpID]
+		if !ok {
+			name = fmt.Sprintf("Unknown Corp %d", corpID)
+		}
+		writeJSON(w, corpInfo{Name: name})
+	})
+
+	// GET /universe/structures/{id}
+	mux.HandleFunc("/universe/structures/", func(w http.ResponseWriter, r *http.Request) {
+		// No player-owned structures in test data, return 403 (access denied)
+		http.Error(w, `{"error":"Forbidden"}`, 403)
+	})
+
+	// GET /latest/markets/{regionID}/orders/
+	mux.HandleFunc("/latest/markets/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Pages", "1")
+		writeJSON(w, marketOrders)
+	})
+
+	log.Printf("Mock ESI server starting on port %s", port)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/context.md
+++ b/context.md
@@ -388,6 +388,21 @@ export default function Page(props: PageProps) {
 
 ## Testing
 
+**IMPORTANT**: Always prefer using the Makefile targets to run all tests. Do not run test commands directly — the Makefile handles Docker Compose orchestration, environment setup, and cleanup.
+
+```bash
+# Unit/integration tests
+make test-backend        # Backend Go tests with coverage
+make test-frontend       # Frontend Jest tests with coverage
+make test-all            # Run both backend and frontend tests
+make test-clean          # Clean up test containers
+
+# End-to-end tests (Playwright)
+make test-e2e            # Run E2E tests headless
+make test-e2e-ui         # Run E2E tests with Playwright UI
+make test-e2e-clean      # Clean up E2E containers
+```
+
 ### Integration Tests
 - Located in `internal/repositories/*_test.go`
 - Use testcontainers pattern (random DB names)
@@ -482,11 +497,12 @@ export default function Page(props: PageProps) {
 - For multi-file changes or architectural decisions, use plan mode first
 - Present options to the user when multiple approaches are valid
 - Break down large features into phases with clear verification steps
-- **Feature Documentation**: Check and update `docs/features/` directory
+- **Feature Documentation**: All feature plans MUST be documented in `docs/features/`
   - Always check for existing feature plans before starting work
-  - Create new feature docs for complex features (include schema, phases, verification)
-  - Examples: `contact-marketplace.md`, `jita-market-pricing.md`, `landing-page.md`
-  - Store in repo, not in local `.claude/plans/` directory
+  - Create a feature doc for every new feature or significant change (include overview, design decisions, schema, file structure, verification steps)
+  - Update existing docs when modifying a feature
+  - Examples: `contact-marketplace.md`, `jita-market-pricing.md`, `e2e-testing.md`
+  - Store in repo (`docs/features/`), not in local `.claude/plans/` directory
 
 **Code Quality Standards**
 
@@ -616,5 +632,5 @@ formatCompact(value)
 - **EVE Character Images**: `https://image.eveonline.com/Character/{id}_128.jpg`
 - **Corporation Logos**: `https://images.evetech.net/corporations/{id}/logo`
 - **Item Icons**: `https://images.evetech.net/types/{type_id}/icon`
-- **Test Data**: Use ID 42 for users, 1337 for characters, 60003760 for Jita station
+- **Test Data**: See E2E test users in `docs/features/e2e-testing.md`; Jita station ID: 60003760
 - **Division Types**: `hangar` and `wallet` stored separately in `corporation_divisions`

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -1,0 +1,111 @@
+services:
+  database:
+    image: debezium/postgres:17
+    environment:
+      POSTGRES_DB: "app"
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
+      POSTGRES_HOST_AUTH_METHOD: "password"
+    command: postgres -c max_connections=200 -c shared_buffers=256MB
+    tmpfs:
+      - /var/lib/postgresql/data
+    ports:
+      - "19237:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+
+  mock-esi:
+    build:
+      context: .
+      dockerfile: Dockerfile.mock-esi
+    environment:
+      PORT: "8090"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8090/latest/markets/10000002/orders/ || exit 1"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build:
+      context: .
+      target: final-backend
+      dockerfile: Dockerfile
+    environment:
+      PORT: "80"
+      DATABASE_HOST: "database"
+      DATABASE_PORT: "5432"
+      DATABASE_USER: "postgres"
+      DATABASE_PASSWORD: "postgres"
+      DATABASE_NAME: "app"
+      BACKEND_KEY: "e2e-test-key"
+      OAUTH_CLIENT_ID: "e2e-dummy"
+      OAUTH_CLIENT_SECRET: "e2e-dummy"
+      ESI_BASE_URL: "http://mock-esi:8090"
+    depends_on:
+      database:
+        condition: service_healthy
+      mock-esi:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:80/v1/characters/ -H 'BACKEND-KEY: e2e-test-key' -H 'USER-ID: 1' || exit 1"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
+  seed-runner:
+    image: debezium/postgres:17
+    volumes:
+      - ./e2e/seed.sql:/seed.sql:ro
+    environment:
+      PGPASSWORD: "postgres"
+    entrypoint: ["sh", "-c", "until pg_isready -h database -U postgres; do sleep 1; done && sleep 2 && psql -h database -U postgres -d app -f /seed.sql"]
+    depends_on:
+      backend:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.ui
+    environment:
+      E2E_TESTING: "true"
+      BACKEND_URL: "http://backend:80/"
+      NEXT_PUBLIC_BACKEND_URL: "http://backend:80/"
+      BACKEND_KEY: "e2e-test-key"
+      NEXTAUTH_SECRET: "e2e-test-secret-key-for-jwt"
+      NEXTAUTH_URL: "http://localhost:3000"
+      EVE_CLIENT_ID: "e2e-dummy"
+      EVE_CLIENT_SECRET: "e2e-dummy"
+    ports:
+      - "3000:3000"
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/ || exit 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+
+  # Playwright test runner for CI — not started by `docker compose up`,
+  # only via `docker compose run --rm playwright`
+  # NOTE: Image tag must match @playwright/test version in e2e/package-lock.json
+  playwright:
+    profiles: [ci]
+    image: mcr.microsoft.com/playwright:v1.58.2-noble
+    working_dir: /work/e2e
+    volumes:
+      - .:/work
+    environment:
+      CI: "true"
+      BASE_URL: "http://frontend:3000"
+    depends_on:
+      frontend:
+        condition: service_healthy
+      seed-runner:
+        condition: service_completed_successfully
+    command: sh -c "npm ci && npx playwright test"

--- a/docs/features/e2e-testing.md
+++ b/docs/features/e2e-testing.md
@@ -1,0 +1,169 @@
+# End-to-End Testing
+
+## Overview
+
+Full-stack browser-based end-to-end testing using Playwright. Tests exercise the entire application through a real browser: Next.js frontend, Go backend, PostgreSQL database, and a mock ESI service. All external dependencies (EVE Online ESI API, EVE OAuth) are mocked for deterministic, self-contained tests.
+
+**Status:** Implemented
+
+---
+
+## Architecture
+
+```
+Playwright (browser) → Next.js Frontend → Go Backend → Mock ESI Server
+                                              ↓
+                                         PostgreSQL
+```
+
+All services run via `docker-compose.e2e.yaml`. Auth is mocked via a NextAuth CredentialsProvider (no EVE OAuth needed). The ESI client points at a mock Go HTTP server instead of the real `esi.evetech.net`.
+
+---
+
+## Key Design Decisions
+
+### 1. Mock ESI Service (not real ESI)
+
+The backend's ESI client (`internal/client/esiClient.go`) has a configurable `baseURL` field (via `ESI_BASE_URL` env var). In E2E mode, this points to `cmd/mock-esi/main.go` — a lightweight Go HTTP server that returns deterministic canned responses for all ESI endpoints.
+
+When `ESI_BASE_URL` is set, the backend uses a plain `http.Client` instead of the OAuth token client, bypassing ESI token refresh entirely.
+
+### 2. Mock Auth (not real EVE OAuth)
+
+When `E2E_TESTING=true`, the NextAuth config (`frontend/pages/api/auth/[...nextauth].ts`) adds a `CredentialsProvider` that accepts `userId` + `userName` fields. This creates a real NextAuth JWT session without going through EVE OAuth. The JWT callback sets `token.providerAccountId` from `user.id`, so all downstream API routes work identically.
+
+### 3. Mock API First (not pre-seeded game data)
+
+Game data (assets, market prices, corp divisions) is NOT pre-seeded into the database. Instead, tests trigger app actions (Refresh Assets, Update Market Prices) which hit the mock ESI to populate data. This tests the full data pipeline.
+
+Only bootstrap data that can't be created through the app is seeded via SQL:
+- Static universe data (regions, systems, stations, item types)
+- Characters and corporations with fake ESI tokens
+- Users (created when Playwright logs in via CredentialsProvider)
+
+---
+
+## Running E2E Tests
+
+### Prerequisites
+
+```bash
+cd e2e
+npm install
+npx playwright install chromium
+```
+
+### Local (headless)
+
+```bash
+make test-e2e
+```
+
+### Local (interactive UI)
+
+```bash
+make test-e2e-ui
+```
+
+### Cleanup
+
+```bash
+make test-e2e-clean
+```
+
+### CI
+
+Runs automatically via the `e2e-tests` job in `.github/workflows/ci.yml`. Uploads Playwright HTML report and failure screenshots as artifacts.
+
+---
+
+## Test Users
+
+| User ID | Name | Characters | Role |
+|---|---|---|---|
+| 1001 | Alice Stargazer | Alice Alpha (2001001), Alice Beta (2001002) | Primary test user, logged in by default |
+| 1002 | Bob Miner | Bob Bravo (2002001) | Contact/marketplace partner |
+| 1003 | Charlie Trader | Charlie Charlie (2003001) | Pending contact tests |
+| 1004 | Diana Scout | Diana Delta (2004001) | Isolation tests (no relationships) |
+
+**Corporation:** Stargazer Industries (3001001), owned by Alice (user 1001)
+
+---
+
+## Test Flows
+
+1. **Landing + Auth** — Login via CredentialsProvider, verify authenticated landing page
+2. **Navigation** — All navbar links resolve to working pages
+3. **Characters** — Character list shows seeded characters
+4. **Asset Refresh** — Refresh Assets triggers mock ESI, assets populate by station (Jita, Amarr), containers, corp divisions
+5. **Stockpile Workflow** — Set/edit/delete stockpile markers from assets page, verify deficit calculations on stockpiles page
+6. **Contacts Workflow** — Send contact request (Alice → Bob), accept, verify bidirectional connection
+7. **Marketplace Workflow** — Create listing (Bob), browse (Alice), purchase, buy orders
+
+---
+
+## Mock ESI Endpoints
+
+| Endpoint | Data Returned |
+|---|---|
+| `GET /characters/{id}/assets` | Character assets (per-character canned data) |
+| `POST /characters/{id}/assets/names` | Container name mappings |
+| `POST /characters/affiliation` | Character → corporation mapping |
+| `GET /corporations/{id}` | Corporation name/info |
+| `GET /corporations/{id}/assets` | Corporation assets |
+| `POST /corporations/{id}/assets/names` | Corp container names |
+| `GET /corporations/{id}/divisions` | Hangar/wallet divisions |
+| `GET /universe/structures/{id}` | Returns 403 (no player-owned structures in test data) |
+| `GET /latest/markets/{regionID}/orders/` | Market buy/sell orders for The Forge |
+
+---
+
+## File Structure
+
+```
+e2e/
+  package.json              # Playwright dependency
+  tsconfig.json             # TypeScript config
+  playwright.config.ts      # Chromium only, workers: 1, sequential
+  global-setup.ts           # Authenticates as Alice Stargazer
+  seed.sql                  # Bootstrap data (static universe, characters, corps)
+  fixtures/
+    auth.ts                 # Multi-user auth fixtures (Alice, Bob, Charlie, Diana)
+  tests/
+    landing.spec.ts
+    navigation.spec.ts
+    characters.spec.ts
+    assets.spec.ts
+    stockpiles.spec.ts
+    contacts.spec.ts
+    marketplace.spec.ts
+
+cmd/mock-esi/
+  main.go                   # Mock ESI HTTP server
+
+Dockerfile.mock-esi         # Docker build for mock ESI
+docker-compose.e2e.yaml     # Full stack E2E environment
+```
+
+---
+
+## Modified Existing Files
+
+| File | Change |
+|---|---|
+| `internal/client/esiClient.go` | Added configurable `baseURL` field (default: `https://esi.evetech.net`) |
+| `cmd/industry-tool/cmd/settings.go` | Added `EsiBaseURL` from `ESI_BASE_URL` env var |
+| `cmd/industry-tool/cmd/root.go` | When `ESI_BASE_URL` is set, uses plain HTTP client (bypasses OAuth) |
+| `frontend/pages/api/auth/[...nextauth].ts` | Added CredentialsProvider when `E2E_TESTING=true` |
+| `makefile` | Added `test-e2e`, `test-e2e-ui`, `test-e2e-clean` targets |
+| `.github/workflows/ci.yml` | Added `e2e-tests` job, updated `test-summary` |
+
+---
+
+## Adding New Tests
+
+1. Create a new `.spec.ts` file in `e2e/tests/`
+2. Import from `@playwright/test` for single-user tests, or from `../fixtures/auth` for multi-user tests
+3. Tests run sequentially (shared database state) — design tests to be additive
+4. If new mock ESI data is needed, update `cmd/mock-esi/main.go`
+5. If new seed data is needed, update `e2e/seed.sql`

--- a/docs/features/stockpile-markers.md
+++ b/docs/features/stockpile-markers.md
@@ -1,0 +1,295 @@
+# Stockpile Markers Feature
+
+## Overview
+
+Stockpile markers let players set desired quantity targets on individual items in their inventory and track "deficits" — items whose current quantity falls below the target. The feature spans the full stack: a database table for marker storage, backend CRUD + deficit aggregation endpoints, and two frontend surfaces (inline markers on the assets page, dedicated deficits dashboard).
+
+**Key pages:**
+- `/inventory` — set, edit, and delete stockpile markers on any asset row
+- `/stockpiles` — view all items below target with deficit quantities and ISK costs
+
+## Business Context
+
+Industrial players in EVE Online maintain material buffers (minerals, components, ships) across multiple characters, corporations, stations, and containers. Manually tracking what needs restocking is tedious. Stockpile markers turn the asset list into a live "shopping list" by flagging items that need replenishment.
+
+### User Stories
+
+**As an industrial player, I want to:**
+1. Set a desired quantity on any item in my inventory so I know when I'm running low
+2. See at a glance which items are below target, grouped by location
+3. Know the ISK cost to fill all my deficits at current Jita buy prices
+4. Export my deficit list to Janice for quick appraisal
+5. Set markers on both personal character assets and corporation division assets
+
+## Architecture
+
+### Data Flow
+
+```
+User sets marker on /inventory page
+    ↓
+POST /api/stockpiles/upsert → POST /v1/stockpiles (backend)
+    ↓
+StockpileMarkers repository → UPSERT stockpile_markers table
+    ↓
+Asset queries LEFT JOIN stockpile_markers → inline delta display
+    ↓
+GET /v1/stockpiles/deficits → CTE query across all asset types
+    ↓
+/stockpiles page renders deficit table with ISK costs
+```
+
+### Key Design Decisions
+
+#### 1. Marker Granularity
+
+**Decision:** Markers are scoped to the combination of `(user, type, owner, location, container, division)`.
+
+A player can set different targets for the same item type in different locations. For example:
+- 50,000 Tritanium at Jita IV in character hangar
+- 100,000 Tritanium at Jita IV in corp division "Production Materials"
+- 10,000 Tritanium at Amarr VIII in character hangar
+
+This uses a composite unique index with `COALESCE` for nullable columns (container_id, division_number).
+
+#### 2. Inline Display vs Separate Page
+
+**Decision:** Both. Markers are set and displayed inline on the `/inventory` page (next to each asset row), and a dedicated `/stockpiles` page shows only items below target.
+
+- **Inline** — set markers while browsing assets, see delta immediately
+- **Dedicated** — view all deficits at once, export to Janice, see total ISK cost
+
+#### 3. Deficit Cost Calculation
+
+**Decision:** Use Jita buy price (best bid) for deficit cost.
+
+When you need to acquire missing items, you'll pay the buy price, not the sell price. The deficit query LEFT JOINs `market_prices` and multiplies `ABS(deficit) * buy_price`.
+
+#### 4. Owner Type Support
+
+**Decision:** Markers support both `character` and `corporation` owner types.
+
+- **Character assets** — matched by `owner_id = character_id`
+- **Corporation assets** — matched by `owner_id = corporation_id` + `division_number`
+
+## Database Schema
+
+### Table: `stockpile_markers`
+
+```sql
+CREATE TABLE stockpile_markers (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    type_id BIGINT NOT NULL REFERENCES asset_item_types(type_id),
+    owner_type VARCHAR(20) NOT NULL,       -- 'character' or 'corporation'
+    owner_id BIGINT NOT NULL,              -- character ID or corporation ID
+    location_id BIGINT NOT NULL,           -- station ID
+    container_id BIGINT,                   -- NULL for hangar items, item_id for container items
+    division_number INT,                   -- NULL for characters, 1-7 for corp divisions
+    desired_quantity BIGINT NOT NULL,
+    notes TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_stockpile_unique ON stockpile_markers(
+    user_id, type_id, owner_type, owner_id, location_id,
+    COALESCE(container_id, 0), COALESCE(division_number, 0)
+);
+
+CREATE INDEX idx_stockpile_user ON stockpile_markers(user_id);
+CREATE INDEX idx_stockpile_type ON stockpile_markers(type_id);
+```
+
+### Schema Notes
+
+- **Composite unique index** uses `COALESCE` to handle NULL container_id and division_number — two markers with NULL container are considered the same location
+- **owner_type** distinguishes character vs corporation ownership (different JOIN paths in queries)
+- **division_number** maps to EVE's CorpSAG1-7 location flags for corporation hangars
+- **notes** is optional free-text for user annotations (not currently displayed in UI)
+
+### Migration Files
+
+- **Up:** `internal/database/migrations/20250101120000_stockpile_markers.up.sql`
+- **Down:** `internal/database/migrations/20250101120000_stockpile_markers.down.sql`
+
+## Backend Implementation
+
+### Model
+
+**File:** `internal/models/models.go`
+
+```go
+type StockpileMarker struct {
+    UserID          int64   `json:"userId"`
+    TypeID          int64   `json:"typeId"`
+    OwnerType       string  `json:"ownerType"`
+    OwnerID         int64   `json:"ownerId"`
+    LocationID      int64   `json:"locationId"`
+    ContainerID     *int64  `json:"containerId"`
+    DivisionNumber  *int    `json:"divisionNumber"`
+    DesiredQuantity int64   `json:"desiredQuantity"`
+    Notes           *string `json:"notes"`
+}
+```
+
+### Repository: StockpileMarkers
+
+**File:** `internal/repositories/stockpileMarkers.go`
+
+CRUD operations for the `stockpile_markers` table.
+
+| Method | SQL Operation | Notes |
+|--------|--------------|-------|
+| `GetByUser(ctx, userID)` | `SELECT ... WHERE user_id = $1` | Returns all markers for a user |
+| `Upsert(ctx, marker)` | `INSERT ... ON CONFLICT DO UPDATE` | Creates or updates marker, conflict on composite unique index |
+| `Delete(ctx, marker)` | `DELETE ... WHERE` | Matches on all composite key columns using `COALESCE` for NULLs |
+
+### Deficit Aggregation
+
+**File:** `internal/repositories/assets.go` — `GetStockpileDeficits(ctx, user)`
+
+This is the most complex query in the system. It uses a CTE (`WITH all_deficits AS`) that combines four UNION ALL subqueries:
+
+1. **Personal hangar items** — `character_assets` WHERE `location_flag IN ('Hangar', 'Deliveries', 'AssetSafety')`
+2. **Personal container items** — `character_assets` WHERE `location_type = 'item'` (items inside containers)
+3. **Corporation hangar items** — `corporation_asset_locations` WHERE `location_flag LIKE 'CorpSAG%'`
+4. **Corporation container items** — `corporation_asset_locations` WHERE `location_type = 'item'`
+
+Each subquery:
+- LEFT JOINs `stockpile_markers` (matching on type, location, container, owner)
+- LEFT JOINs `market_prices` (Jita region 10000002) for deficit cost
+- Filters to `(quantity - desired_quantity) < 0` (only deficit items)
+- Calculates `deficit_value = ABS(delta) * buy_price`
+
+Results are ordered by `deficit_value DESC` (most expensive deficits first).
+
+### Summary Aggregation
+
+**File:** `internal/repositories/assets.go` — `GetUserAssetsSummary(ctx, user)`
+
+Used by the landing page to show total deficit ISK. Similar four-way UNION ALL but returns only aggregate `SUM(deficit_value)`.
+
+### Controllers
+
+**File:** `internal/controllers/stockpileMarkers.go`
+
+| Endpoint | Method | Handler | Description |
+|----------|--------|---------|-------------|
+| `/v1/stockpiles` | GET | `GetStockpiles` | List all markers for authenticated user |
+| `/v1/stockpiles` | POST | `UpsertStockpile` | Create or update a marker |
+| `/v1/stockpiles` | DELETE | `DeleteStockpile` | Delete a marker |
+
+All endpoints require `web.AuthAccessUser`. The `UserID` is always set from the auth context (not the request body) for security.
+
+**File:** `internal/controllers/stockpiles.go`
+
+| Endpoint | Method | Handler | Description |
+|----------|--------|---------|-------------|
+| `/v1/stockpiles/deficits` | GET | `GetDeficits` | Get all items below target with costs |
+
+## Frontend Implementation
+
+### Assets Page Integration
+
+**File:** `frontend/packages/components/assets/AssetsList.tsx`
+
+Each asset row in the table shows:
+- **Current quantity** and **desired quantity** side by side (e.g., "1,000 / 5,000")
+- **Delta indicator** — green (+) if above target, red if below
+- **Set/Edit stockpile** button (pencil icon) — opens a dialog to set desired quantity
+- **Delete stockpile** button (trash icon) — confirms with `window.confirm()` then removes marker
+- **Below target filter** — toggle to show only items with negative delta
+
+The stockpile dialog collects:
+- `desiredQuantity` — target quantity
+- Automatically populates `typeId`, `ownerId`, `ownerType`, `locationId`, `containerId`, `divisionNumber` from the asset context
+
+After upsert/delete, the local state is updated immediately (optimistic update) without refetching all assets.
+
+### Stockpiles Deficits Page
+
+**File:** `frontend/packages/components/stockpiles/StockpilesList.tsx`
+
+Displays a table of all items below target across all characters and corporations.
+
+**Summary cards (sticky header):**
+- Items Below Target — count of deficit items
+- Total Deficit — sum of all deficit quantities
+- Total Volume — estimated volume of deficit items (m3)
+- Total Cost (ISK) — sum of deficit values at Jita buy prices
+
+**Table columns:** Item, Structure, Location, Container, Current, Target, Deficit, Cost (ISK), Owner
+
+**Actions:**
+- **Search** — filter by item name, structure, solar system, region, or container
+- **Copy for Janice** — copies deficit list as "ItemName quantity" text to clipboard
+- **Create Janice Appraisal** — POSTs to Janice API and opens appraisal in new tab
+
+**Page file:** `frontend/packages/pages/stockpiles.tsx` (wrapper with auth check)
+
+### Next.js API Routes
+
+**Files:** `frontend/pages/api/stockpiles/`
+
+| Route | Method | Backend Proxy |
+|-------|--------|---------------|
+| `/api/stockpiles/upsert` | POST | `POST /v1/stockpiles` |
+| `/api/stockpiles/delete` | DELETE | `DELETE /v1/stockpiles` |
+| `/api/stockpiles/deficits` | GET | `GET /v1/stockpiles/deficits` |
+
+## Testing
+
+### Backend Unit Tests
+
+**Controller tests:** `internal/controllers/stockpiles_test.go` (6 tests)
+- Get deficits success, empty result, repository error, multiple deficits, route registration, context propagation
+
+**Marker controller tests:** `internal/controllers/stockpileMarkers_test.go` (7 tests)
+- Get/upsert/delete success, invalid JSON, repository errors
+
+**Repository tests:** `internal/repositories/stockpileMarkers_test.go`
+- Upsert, get by user, delete, conflict handling
+
+**Deficit tests:** `internal/repositories/stockpileDeficits_test.go`
+- Deficit query correctness across character and corporation assets
+
+### E2E Tests
+
+**File:** `e2e/tests/05-stockpiles.spec.ts` (5 tests)
+- Empty state initially
+- Set stockpile marker from assets page (via dialog)
+- Stockpiles page shows deficit after marker is set
+- Edit stockpile marker (change desired quantity)
+- Delete stockpile marker (confirm dialog, verify removal)
+
+## Files
+
+### Backend
+- `internal/models/models.go` — `StockpileMarker` struct
+- `internal/database/migrations/20250101120000_stockpile_markers.up.sql` — Schema
+- `internal/database/migrations/20250101120000_stockpile_markers.down.sql` — Rollback
+- `internal/repositories/stockpileMarkers.go` — CRUD repository
+- `internal/repositories/assets.go` — `GetStockpileDeficits()`, `GetUserAssetsSummary()`
+- `internal/controllers/stockpileMarkers.go` — Marker CRUD controller
+- `internal/controllers/stockpiles.go` — Deficit aggregation controller
+
+### Frontend
+- `frontend/packages/components/assets/AssetsList.tsx` — Inline marker UI
+- `frontend/packages/components/stockpiles/StockpilesList.tsx` — Deficits dashboard
+- `frontend/packages/pages/stockpiles.tsx` — Page wrapper
+- `frontend/pages/stockpiles.tsx` — Next.js page entry
+- `frontend/pages/api/stockpiles/upsert.ts` — API proxy
+- `frontend/pages/api/stockpiles/delete.ts` — API proxy
+- `frontend/pages/api/stockpiles/deficits.ts` — API proxy
+
+### Tests
+- `internal/controllers/stockpiles_test.go` — Deficit controller tests
+- `internal/controllers/stockpileMarkers_test.go` — Marker controller tests
+- `internal/repositories/stockpileMarkers_test.go` — Repository tests
+- `internal/repositories/stockpileDeficits_test.go` — Deficit query tests
+- `e2e/tests/05-stockpiles.spec.ts` — End-to-end tests
+
+---
+
+**Status:** Complete

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,65 @@
+import { test as base, Page, BrowserContext } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+async function loginAs(context: BrowserContext, userId: string, userName: string): Promise<Page> {
+  const page = await context.newPage();
+
+  // Get CSRF token
+  const csrfResponse = await page.request.get(`${BASE_URL}/api/auth/csrf`);
+  const { csrfToken } = await csrfResponse.json();
+
+  // Sign in via CredentialsProvider
+  // maxRedirects: 0 prevents following NextAuth's redirect to NEXTAUTH_URL,
+  // which may differ from BASE_URL when running in Docker
+  await page.request.post(`${BASE_URL}/api/auth/callback/credentials`, {
+    form: {
+      userId,
+      userName,
+      csrfToken,
+    },
+    maxRedirects: 0,
+  });
+
+  return page;
+}
+
+type AuthFixtures = {
+  alicePage: Page;
+  bobPage: Page;
+  charliePage: Page;
+  dianaPage: Page;
+};
+
+export const test = base.extend<AuthFixtures>({
+  // Alice Stargazer (user 1001) — uses default storageState
+  alicePage: async ({ page }, use) => {
+    await use(page);
+  },
+
+  // Bob Miner (user 1002) — fresh context with separate login
+  bobPage: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    const page = await loginAs(context, '1002', 'Bob Miner');
+    await use(page);
+    await context.close();
+  },
+
+  // Charlie Trader (user 1003)
+  charliePage: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    const page = await loginAs(context, '1003', 'Charlie Trader');
+    await use(page);
+    await context.close();
+  },
+
+  // Diana Scout (user 1004)
+  dianaPage: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    const page = await loginAs(context, '1004', 'Diana Scout');
+    await use(page);
+    await context.close();
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,35 @@
+import { chromium, FullConfig } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+async function globalSetup(config: FullConfig) {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Get CSRF token
+  const csrfResponse = await page.request.get(`${BASE_URL}/api/auth/csrf`);
+  const { csrfToken } = await csrfResponse.json();
+
+  // Sign in as Alice Stargazer (primary test user)
+  // maxRedirects: 0 prevents following NextAuth's redirect to NEXTAUTH_URL,
+  // which may differ from BASE_URL when running in Docker
+  await page.request.post(`${BASE_URL}/api/auth/callback/credentials`, {
+    form: {
+      userId: '1001',
+      userName: 'Alice Stargazer',
+      csrfToken,
+    },
+    maxRedirects: 0,
+  });
+
+  // Load the app to verify sign-in and populate cookies
+  await page.goto(`${BASE_URL}/`);
+
+  // Save authenticated state
+  await context.storageState({ path: './auth-state.json' });
+
+  await browser.close();
+}
+
+export default globalSetup;

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,88 @@
+{
+  "name": "industry-tool-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "industry-tool-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "industry-tool-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "npx playwright test",
+    "test:headed": "npx playwright test --headed",
+    "test:ui": "npx playwright test --ui",
+    "test:debug": "npx playwright test --debug",
+    "install-browsers": "npx playwright install --with-deps chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [['html', { outputFolder: '../artifacts/e2e-report' }], ['github']]
+    : [['html', { open: 'never' }]],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'on-first-retry',
+    storageState: './auth-state.json',
+  },
+
+  globalSetup: './global-setup.ts',
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/e2e/seed.sql
+++ b/e2e/seed.sql
@@ -1,0 +1,80 @@
+-- E2E Test Seed Data
+-- Only bootstraps data that cannot be created through the app without real EVE OAuth.
+-- Game data (assets, market prices, divisions) comes from the mock ESI during tests.
+
+BEGIN;
+
+-- ===========================================
+-- Static Universe Data (reference data)
+-- ===========================================
+
+INSERT INTO regions (region_id, name) VALUES
+  (10000002, 'The Forge'),
+  (10000043, 'Domain');
+
+INSERT INTO constellations (constellation_id, name, region_id) VALUES
+  (20000020, 'Kimotoro', 10000002),
+  (20000322, 'Throne Worlds', 10000043);
+
+INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES
+  (30000142, 'Jita', 20000020, 0.9),
+  (30002187, 'Amarr', 20000322, 1.0);
+
+INSERT INTO stations (station_id, name, solar_system_id, corporation_id, is_npc_station) VALUES
+  (60003760, 'Jita IV - Moon 4 - Caldari Navy Assembly Plant', 30000142, 1000035, true),
+  (60008494, 'Amarr VIII (Oris) - Emperor Family Academy', 30002187, 1000066, true);
+
+INSERT INTO asset_item_types (type_id, type_name, volume, icon_id) VALUES
+  (34, 'Tritanium', 0.01, 34),
+  (35, 'Pyerite', 0.01, 35),
+  (36, 'Mexallon', 0.01, 36),
+  (37, 'Isogen', 0.01, 37),
+  (38, 'Nocxium', 0.01, 38),
+  (587, 'Rifter', 16500, 587),
+  (11399, 'Raven Navy Issue', 486000, 11399),
+  (17703, 'Medium Standard Container', 65, 17703),
+  (27, 'Office', 0, NULL);
+
+-- ===========================================
+-- Users (created via NextAuth CredentialsProvider login, but characters need to pre-exist)
+-- ===========================================
+
+INSERT INTO users (id, name) VALUES
+  (1001, 'Alice Stargazer'),
+  (1002, 'Bob Miner'),
+  (1003, 'Charlie Trader'),
+  (1004, 'Diana Scout');
+
+-- ===========================================
+-- Characters with fake ESI tokens
+-- (Adding characters requires EVE OAuth which we mock out entirely)
+-- ===========================================
+
+-- Alice Stargazer's characters
+INSERT INTO characters (id, user_id, name, esi_token, esi_refresh_token, esi_token_expires_on) VALUES
+  (2001001, 1001, 'Alice Alpha', 'fake-token-alice-alpha', 'fake-refresh-alice-alpha', NOW() + INTERVAL '1 hour'),
+  (2001002, 1001, 'Alice Beta', 'fake-token-alice-beta', 'fake-refresh-alice-beta', NOW() + INTERVAL '1 hour');
+
+-- Bob Miner's character
+INSERT INTO characters (id, user_id, name, esi_token, esi_refresh_token, esi_token_expires_on) VALUES
+  (2002001, 1002, 'Bob Bravo', 'fake-token-bob-bravo', 'fake-refresh-bob-bravo', NOW() + INTERVAL '1 hour');
+
+-- Charlie Trader's character
+INSERT INTO characters (id, user_id, name, esi_token, esi_refresh_token, esi_token_expires_on) VALUES
+  (2003001, 1003, 'Charlie Charlie', 'fake-token-charlie', 'fake-refresh-charlie', NOW() + INTERVAL '1 hour');
+
+-- Diana Scout's character
+INSERT INTO characters (id, user_id, name, esi_token, esi_refresh_token, esi_token_expires_on) VALUES
+  (2004001, 1004, 'Diana Delta', 'fake-token-diana', 'fake-refresh-diana', NOW() + INTERVAL '1 hour');
+
+-- ===========================================
+-- Corporations with fake ESI tokens
+-- ===========================================
+
+INSERT INTO corporations (id, name) VALUES
+  (3001001, 'Stargazer Industries');
+
+INSERT INTO player_corporations (id, user_id, name, esi_token, esi_refresh_token, esi_token_expires_on) VALUES
+  (3001001, 1001, 'Stargazer Industries', 'fake-token-stargazer-corp', 'fake-refresh-stargazer-corp', NOW() + INTERVAL '1 hour');
+
+COMMIT;

--- a/e2e/tests/01-landing.spec.ts
+++ b/e2e/tests/01-landing.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Landing Page', () => {
+  test('shows authenticated landing page', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByText('Master Your EVE Online Assets')).toBeVisible();
+    await expect(page.getByText('Real-time asset tracking')).toBeVisible();
+  });
+
+  test('displays metric cards', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByText('Total Asset Value')).toBeVisible({ timeout: 10000 });
+    // Deficit card label is either "Stockpile Deficit Cost" or "All Stockpiles Met"
+    await expect(page.getByText(/Stockpile Deficit Cost|All Stockpiles Met/)).toBeVisible();
+  });
+
+  test('shows navigation buttons for authenticated user', async ({ page }) => {
+    await page.goto('/');
+
+    // Characters link exists in both navbar and landing page; use .first()
+    await expect(page.getByRole('link', { name: 'Characters' }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: 'View Assets' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Manage Stockpiles' })).toBeVisible();
+  });
+
+  test('characters link navigates to characters page', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'Characters' }).first().click();
+    await page.waitForURL('**/characters');
+    await expect(page).toHaveURL(/\/characters/);
+  });
+});

--- a/e2e/tests/02-characters.spec.ts
+++ b/e2e/tests/02-characters.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Characters Page', () => {
+  test('displays seeded characters for Alice', async ({ page }) => {
+    await page.goto('/characters');
+
+    await expect(page.getByText('Alice Alpha')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Alice Beta')).toBeVisible();
+  });
+
+  test('shows Add Character and Refresh Assets buttons', async ({ page }) => {
+    await page.goto('/characters');
+
+    await expect(page.getByRole('link', { name: /Add Character/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('link', { name: /Refresh Assets/i })).toBeVisible();
+  });
+});

--- a/e2e/tests/03-assets.spec.ts
+++ b/e2e/tests/03-assets.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Assets Page', () => {
+  // Clear localStorage before each test so tree expansion state is fresh
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/inventory');
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('shows empty state before refresh', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Before refreshing assets, the empty state is shown
+    await expect(page.getByText('No Assets Found')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('refresh assets populates data from mock ESI', async ({ page }) => {
+    // Trigger asset refresh via the characters page
+    await page.goto('/characters');
+    await expect(page.getByRole('link', { name: /Refresh Assets/i })).toBeVisible({ timeout: 10000 });
+    await page.getByRole('link', { name: /Refresh Assets/i }).click();
+
+    // Wait for refresh to complete
+    await page.waitForTimeout(5000);
+
+    // Navigate to inventory
+    await page.goto('/inventory');
+
+    // Jita station should appear with Alice Alpha's assets
+    await expect(page.getByText('Jita IV - Moon 4')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('displays character assets grouped by station', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Jita station
+    await expect(page.getByText('Jita IV - Moon 4')).toBeVisible({ timeout: 10000 });
+
+    // Expand Jita to see hangars
+    await page.getByText('Jita IV - Moon 4').click();
+
+    // Expand Personal Hangar to see items
+    await page.getByText('Personal Hangar').first().click();
+
+    // Check for asset types from mock ESI
+    await expect(page.getByText('Tritanium')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Pyerite')).toBeVisible();
+    await expect(page.getByText('Mexallon')).toBeVisible();
+  });
+
+  test('displays container with nested assets', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Expand Jita
+    await page.getByText('Jita IV - Moon 4').click();
+
+    // Container name from mock ESI
+    await expect(page.getByText('Minerals Box')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('displays corporation assets under station', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Expand Jita to see corp hangars
+    await page.getByText('Jita IV - Moon 4').click();
+
+    // Corp hangars appear as sub-nodes (use .first() since multiple hangars match)
+    await expect(page.getByText(/Stargazer Industries/).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('displays Amarr station assets from Alice Beta', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Amarr station should appear with Alice Beta's assets
+    await expect(page.getByText('Amarr VIII')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('search filters assets', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Wait for assets to load
+    await expect(page.getByText('Jita IV - Moon 4')).toBeVisible({ timeout: 10000 });
+
+    // Use search to filter
+    const searchInput = page.getByPlaceholder('Search items...');
+    await searchInput.fill('Tritanium');
+
+    // Wait for search results to render
+    await page.waitForTimeout(1000);
+
+    // Tritanium should be visible in search results (auto-expanded)
+    await expect(page.getByText('Tritanium').first()).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/e2e/tests/04-navigation.spec.ts
+++ b/e2e/tests/04-navigation.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  test('navbar displays all navigation links', async ({ page }) => {
+    await page.goto('/');
+
+    const navbar = page.locator('header');
+    await expect(navbar.getByText('EVE Industry Tool')).toBeVisible();
+    await expect(navbar.getByRole('link', { name: 'Characters' })).toBeVisible();
+    await expect(navbar.getByRole('link', { name: 'Corporations' })).toBeVisible();
+    await expect(navbar.getByRole('link', { name: 'Inventory' })).toBeVisible();
+    await expect(navbar.getByRole('link', { name: 'Stockpiles' })).toBeVisible();
+    await expect(navbar.getByRole('link', { name: /Contacts/ })).toBeVisible();
+    await expect(navbar.getByRole('link', { name: 'Marketplace' })).toBeVisible();
+  });
+
+  test('characters page loads', async ({ page }) => {
+    await page.goto('/characters');
+    await expect(page.getByRole('heading', { name: /Characters/ })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('corporations page loads', async ({ page }) => {
+    await page.goto('/corporations');
+    await expect(page.getByRole('heading', { name: /Corporations/ })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('inventory page loads', async ({ page }) => {
+    await page.goto('/inventory');
+    // Shows "Asset Inventory" when assets exist, "No Assets Found" when empty
+    await expect(page.getByText(/Asset Inventory|No Assets Found/)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('stockpiles page loads', async ({ page }) => {
+    await page.goto('/stockpiles');
+    await expect(page.getByText('Stockpiles Needing Replenishment')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('contacts page loads', async ({ page }) => {
+    await page.goto('/contacts');
+    await expect(page.getByRole('heading', { name: /Contacts/ })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('marketplace page loads', async ({ page }) => {
+    await page.goto('/marketplace');
+    await expect(page.getByRole('tab', { name: 'My Listings' })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/e2e/tests/05-stockpiles.spec.ts
+++ b/e2e/tests/05-stockpiles.spec.ts
@@ -1,0 +1,238 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Stockpiles', () => {
+  // Clear localStorage before each test so tree expansion state is fresh
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/inventory');
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('stockpiles page shows empty state initially', async ({ page }) => {
+    await page.goto('/stockpiles');
+
+    await expect(page.getByText('Stockpiles Needing Replenishment')).toBeVisible({ timeout: 10000 });
+    // No stockpile markers set yet
+    await expect(page.getByText('No stockpiles need replenishment')).toBeVisible();
+  });
+
+  test('set stockpile marker on character asset', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Expand Jita station to see hangars
+    await expect(page.getByText('Jita IV - Moon 4')).toBeVisible({ timeout: 10000 });
+    await page.getByText('Jita IV - Moon 4').click();
+
+    // Expand Personal Hangar to see items
+    await page.getByText('Personal Hangar').first().click();
+    await expect(page.getByText('Tritanium')).toBeVisible({ timeout: 5000 });
+
+    // Find the Tritanium row and click the first button (set stockpile)
+    const tritaniumRow = page.getByRole('row').filter({ hasText: 'Tritanium' }).first();
+    await tritaniumRow.getByRole('button').first().click();
+
+    // Dialog should appear with "Set Stockpile Marker"
+    await expect(page.getByText('Set Stockpile Marker')).toBeVisible({ timeout: 5000 });
+
+    // Dialog shows item name and current quantity (scope to dialog to avoid table matches)
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText(/Tritanium/)).toBeVisible();
+    await expect(dialog.getByText(/50,000/)).toBeVisible();
+
+    // Enter desired quantity (higher than current 50000 to create a deficit)
+    const desiredQtyInput = page.getByLabel(/Desired Quantity/i);
+    await desiredQtyInput.clear();
+    await desiredQtyInput.fill('100000');
+
+    // Click Save
+    await page.getByRole('button', { name: /Save/i }).click();
+
+    // Dialog should close
+    await expect(page.getByText('Set Stockpile Marker')).not.toBeVisible({ timeout: 5000 });
+
+    // Verify inline delta is displayed on the Tritanium row
+    // The stockpile column shows delta / desired (e.g., "-50,000 / 100,000")
+    await expect(tritaniumRow.getByText('100,000')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('stockpiles page shows deficit with correct values', async ({ page }) => {
+    await page.goto('/stockpiles');
+
+    // Should show the Tritanium deficit
+    await expect(page.getByText('Tritanium')).toBeVisible({ timeout: 10000 });
+
+    // Summary cards should show values
+    await expect(page.getByText('Items Below Target')).toBeVisible();
+    await expect(page.getByText('Total Deficit')).toBeVisible();
+    await expect(page.getByText('Total Cost (ISK)')).toBeVisible();
+
+    // Verify the deficit table row has current and target quantities
+    const tritaniumRow = page.getByRole('row').filter({ hasText: 'Tritanium' });
+    await expect(tritaniumRow).toBeVisible();
+    await expect(tritaniumRow.getByText('100,000')).toBeVisible();
+
+    // Verify location info appears (use specific text to avoid matching both structure and system columns)
+    await expect(tritaniumRow.getByText(/Jita IV/)).toBeVisible();
+  });
+
+  test('set stockpile marker on corporation asset', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Expand Jita station
+    await expect(page.getByText('Jita IV - Moon 4')).toBeVisible({ timeout: 10000 });
+    await page.getByText('Jita IV - Moon 4').click();
+
+    // Expand Stargazer Industries - Main Hangar (corp division 1 has Tritanium x100,000)
+    await expect(page.getByText(/Stargazer Industries - Main Hangar/).first()).toBeVisible({ timeout: 5000 });
+    await page.getByText(/Stargazer Industries - Main Hangar/).first().click();
+
+    // Corp Tritanium should be visible (100,000 units)
+    await page.waitForTimeout(500);
+
+    // Find the Tritanium row in the corp hangar and set a stockpile marker
+    // Use last() since the personal hangar Tritanium row may also be in the DOM
+    const corpTritaniumRow = page.getByRole('row').filter({ hasText: 'Tritanium' }).last();
+    await corpTritaniumRow.getByRole('button').first().click();
+
+    // Dialog should appear
+    await expect(page.getByText('Set Stockpile Marker')).toBeVisible({ timeout: 5000 });
+
+    // Should show corp Tritanium's current quantity (100,000) - scope to dialog
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText(/100,000/)).toBeVisible();
+
+    // Set desired quantity higher
+    const desiredQtyInput = page.getByLabel(/Desired Quantity/i);
+    await desiredQtyInput.clear();
+    await desiredQtyInput.fill('200000');
+
+    await page.getByRole('button', { name: /Save/i }).click();
+    await expect(page.getByText('Set Stockpile Marker')).not.toBeVisible({ timeout: 5000 });
+
+    // Verify both deficits appear on the stockpiles page
+    await page.goto('/stockpiles');
+    await expect(page.getByText('Tritanium').first()).toBeVisible({ timeout: 10000 });
+
+    // Should show 2 deficit rows for Tritanium (personal + corp)
+    const rows = page.getByRole('row').filter({ hasText: 'Tritanium' });
+    await expect(rows).toHaveCount(2, { timeout: 5000 });
+
+    // One row should show Stargazer Industries as owner
+    await expect(page.getByText('Stargazer Industries')).toBeVisible();
+  });
+
+  test('edit stockpile marker changes desired quantity', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Expand Jita station
+    await expect(page.getByText('Jita IV - Moon 4')).toBeVisible({ timeout: 10000 });
+    await page.getByText('Jita IV - Moon 4').click();
+
+    // Expand Personal Hangar to see items
+    await page.getByText('Personal Hangar').first().click();
+    await expect(page.getByText('Tritanium')).toBeVisible({ timeout: 5000 });
+
+    // Find Tritanium row and click the edit stockpile button (first button in row)
+    const tritaniumRow = page.getByRole('row').filter({ hasText: 'Tritanium' }).first();
+    await tritaniumRow.getByRole('button').first().click();
+
+    // Dialog should show "Edit Stockpile Marker" (marker already exists)
+    await expect(page.getByText('Edit Stockpile Marker')).toBeVisible({ timeout: 5000 });
+
+    // Change desired quantity
+    const desiredQtyInput = page.getByLabel(/Desired Quantity/i);
+    await desiredQtyInput.clear();
+    await desiredQtyInput.fill('75000');
+
+    await page.getByRole('button', { name: /Save/i }).click();
+    await expect(page.getByText('Edit Stockpile Marker')).not.toBeVisible({ timeout: 5000 });
+
+    // Verify updated value on stockpiles page
+    await page.goto('/stockpiles');
+    await expect(page.getByText('Tritanium').first()).toBeVisible({ timeout: 10000 });
+
+    // Character Tritanium row should now show target of 75,000
+    const personalRow = page.getByRole('row').filter({ hasText: 'Alice' });
+    await expect(personalRow.getByText('75,000')).toBeVisible();
+  });
+
+  test('below target filter shows only deficit items on assets page', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Wait for assets to load
+    await expect(page.getByText('Jita IV - Moon 4')).toBeVisible({ timeout: 10000 });
+
+    // Toggle the "Below target only" switch
+    await page.getByText('Below target only').click();
+
+    // Expand Jita to see filtered results
+    await page.getByText('Jita IV - Moon 4').click();
+
+    // Personal Hangar should appear (Tritanium has a marker with deficit)
+    await page.getByText('Personal Hangar').first().click();
+    await expect(page.getByText('Tritanium')).toBeVisible({ timeout: 5000 });
+
+    // Pyerite should NOT be visible (no stockpile marker set on it)
+    await expect(page.getByText('Pyerite')).not.toBeVisible();
+    await expect(page.getByText('Mexallon')).not.toBeVisible();
+  });
+
+  test('stockpiles page search filters deficit items', async ({ page }) => {
+    await page.goto('/stockpiles');
+
+    // Wait for deficits to load
+    await expect(page.getByText('Tritanium').first()).toBeVisible({ timeout: 10000 });
+
+    // Search filters by item name, structure, solar system, region, and container
+    const searchInput = page.getByPlaceholder(/Search items, structures/i);
+
+    // Search for "Tritanium" to verify filter shows matching items
+    await searchInput.fill('Tritanium');
+    await page.waitForTimeout(500);
+    await expect(page.getByText('Tritanium').first()).toBeVisible({ timeout: 5000 });
+
+    // Search for something that won't match
+    await searchInput.clear();
+    await searchInput.fill('Nonexistent Item');
+    await page.waitForTimeout(500);
+
+    // Should show no items message
+    await expect(page.getByText('No items match your search')).toBeVisible({ timeout: 5000 });
+
+    // Search by solar system name
+    await searchInput.clear();
+    await searchInput.fill('Jita');
+    await page.waitForTimeout(500);
+    await expect(page.getByText('Tritanium').first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('delete stockpile markers', async ({ page }) => {
+    await page.goto('/inventory');
+
+    // Accept all confirm dialogs in this test
+    page.on('dialog', dialog => dialog.accept());
+
+    // Expand Jita station
+    await expect(page.getByText('Jita IV - Moon 4')).toBeVisible({ timeout: 10000 });
+    await page.getByText('Jita IV - Moon 4').click();
+
+    // Delete the character Tritanium marker
+    await page.getByText('Personal Hangar').first().click();
+    await expect(page.getByText('Tritanium')).toBeVisible({ timeout: 5000 });
+
+    const tritaniumRow = page.getByRole('row').filter({ hasText: 'Tritanium' }).first();
+    await tritaniumRow.getByTitle('Remove stockpile target').click();
+    await page.waitForTimeout(1000);
+
+    // Delete the corp Tritanium marker
+    await page.getByText(/Stargazer Industries - Main Hangar/).first().click();
+    await page.waitForTimeout(500);
+
+    const corpTritaniumRow = page.getByRole('row').filter({ hasText: 'Tritanium' }).last();
+    await corpTritaniumRow.getByTitle('Remove stockpile target').click();
+    await page.waitForTimeout(1000);
+
+    // Verify on stockpiles page - should be empty again
+    await page.goto('/stockpiles');
+    await expect(page.getByText('No stockpiles need replenishment')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/e2e/tests/06-contacts.spec.ts
+++ b/e2e/tests/06-contacts.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '../fixtures/auth';
+
+test.describe('Contacts Workflow', () => {
+  test('Alice sends contact request to Bob', async ({ alicePage }) => {
+    await alicePage.goto('/contacts');
+
+    // Click "Add Contact" button
+    await expect(alicePage.getByRole('button', { name: /Add Contact/i })).toBeVisible({ timeout: 10000 });
+    await alicePage.getByRole('button', { name: /Add Contact/i }).click();
+
+    // Fill in Bob's character name
+    await expect(alicePage.getByLabel(/Character Name/i)).toBeVisible();
+    await alicePage.getByLabel(/Character Name/i).fill('Bob Bravo');
+
+    // Click Send Request
+    await alicePage.getByRole('button', { name: /Send Request/i }).click();
+
+    // Wait for request to be processed
+    await alicePage.waitForTimeout(2000);
+
+    // Switch to Sent Requests tab
+    await alicePage.getByRole('tab', { name: /Sent/i }).click();
+    await expect(alicePage.getByText('Bob')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Bob sees pending request from Alice', async ({ bobPage }) => {
+    await bobPage.goto('/contacts');
+
+    // Switch to Pending Requests tab
+    await bobPage.getByRole('tab', { name: /Pending/i }).click();
+
+    // Should see Alice's request
+    await expect(bobPage.getByText('Alice')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Bob accepts contact request from Alice', async ({ bobPage }) => {
+    await bobPage.goto('/contacts');
+
+    // Switch to Pending Requests tab
+    await bobPage.getByRole('tab', { name: /Pending/i }).click();
+    await expect(bobPage.getByText('Alice')).toBeVisible({ timeout: 10000 });
+
+    // Click accept button (first button in the row — CheckIcon)
+    const aliceRow = bobPage.getByRole('row').filter({ hasText: 'Alice' });
+    await aliceRow.getByRole('button').first().click();
+
+    // Wait for acceptance to process
+    await bobPage.waitForTimeout(2000);
+
+    // Verify on My Contacts tab - Alice should now appear as connected
+    await bobPage.getByRole('tab', { name: /My Contacts/i }).click();
+    await expect(bobPage.getByText('Alice')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Bob grants Alice browse permission for marketplace', async ({ bobPage }) => {
+    await bobPage.goto('/contacts');
+
+    // Go to My Contacts tab
+    await bobPage.getByRole('tab', { name: /My Contacts/i }).click();
+    await expect(bobPage.getByText('Alice')).toBeVisible({ timeout: 10000 });
+
+    // Click Manage Permissions (settings icon) on Alice's row
+    const aliceRow = bobPage.getByRole('row').filter({ hasText: 'Alice' });
+    await aliceRow.getByTitle('Manage Permissions').click();
+
+    // Wait for permissions dialog to load
+    await expect(bobPage.getByText(/Manage Permissions/)).toBeVisible({ timeout: 5000 });
+    await bobPage.waitForTimeout(1000);
+
+    // Toggle "Browse For-Sale Items" switch under "Permissions I Grant to Alice"
+    // The first switch in the dialog is the editable one (grants to Alice)
+    const dialog = bobPage.getByRole('dialog');
+    await dialog.getByRole('switch').first().click();
+    await bobPage.waitForTimeout(1000);
+
+    // Close dialog
+    await bobPage.getByRole('button', { name: /Close/i }).click();
+  });
+
+  test('Alice sees Bob as accepted contact', async ({ alicePage }) => {
+    await alicePage.goto('/contacts');
+
+    // My Contacts tab should show Bob
+    await expect(alicePage.getByText('Bob')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/e2e/tests/07-marketplace.spec.ts
+++ b/e2e/tests/07-marketplace.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from '../fixtures/auth';
+
+test.describe('Marketplace', () => {
+  test('marketplace page shows all tabs', async ({ alicePage }) => {
+    await alicePage.goto('/marketplace');
+
+    await expect(alicePage.getByRole('tab', { name: 'My Listings' })).toBeVisible();
+    await expect(alicePage.getByRole('tab', { name: 'Browse' })).toBeVisible();
+    await expect(alicePage.getByRole('tab', { name: 'Pending Sales' })).toBeVisible();
+    await expect(alicePage.getByRole('tab', { name: 'History' })).toBeVisible();
+    await expect(alicePage.getByRole('tab', { name: 'My Buy Orders' })).toBeVisible();
+    await expect(alicePage.getByRole('tab', { name: 'Demand' })).toBeVisible();
+    await expect(alicePage.getByRole('tab', { name: 'Analytics' })).toBeVisible();
+  });
+
+  test('Bob refreshes his assets and creates a for-sale listing', async ({ bobPage }) => {
+    // Clear localStorage so tree expansion state is fresh
+    await bobPage.goto('/inventory');
+    await bobPage.evaluate(() => localStorage.clear());
+
+    // Bob first needs to refresh his assets
+    await bobPage.goto('/characters');
+    await expect(bobPage.getByRole('link', { name: /Refresh Assets/i })).toBeVisible({ timeout: 10000 });
+    await bobPage.getByRole('link', { name: /Refresh Assets/i }).click();
+    await bobPage.waitForTimeout(5000);
+
+    // Now go to inventory to create a listing
+    await bobPage.goto('/inventory');
+    await expect(bobPage.getByText('Jita IV - Moon 4')).toBeVisible({ timeout: 15000 });
+
+    // Expand Jita station
+    await bobPage.getByText('Jita IV - Moon 4').click();
+
+    // Expand Personal Hangar to see items
+    await bobPage.getByText('Personal Hangar').first().click();
+    await expect(bobPage.getByText('Rifter')).toBeVisible({ timeout: 5000 });
+
+    // Click sell button on Rifter row (title="List for sale")
+    const rifterRow = bobPage.getByRole('row').filter({ hasText: 'Rifter' }).first();
+    await rifterRow.getByTitle('List for sale').click();
+
+    // Fill in listing details
+    await expect(bobPage.getByText(/List Item for Sale/i)).toBeVisible({ timeout: 5000 });
+
+    const qtyInput = bobPage.getByLabel(/Quantity/i).first();
+    await qtyInput.clear();
+    await qtyInput.fill('5');
+
+    const priceInput = bobPage.getByLabel(/Price/i).first();
+    await priceInput.clear();
+    await priceInput.fill('550000');
+
+    // Save listing
+    await bobPage.getByRole('button', { name: /Create Listing/i }).click();
+    await bobPage.waitForTimeout(2000);
+
+    // Verify listing appears on marketplace
+    await bobPage.goto('/marketplace');
+    await expect(bobPage.getByRole('tab', { name: 'My Listings' })).toBeVisible();
+    await expect(bobPage.getByText('Rifter')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Alice can browse marketplace and see Bob listings', async ({ alicePage }) => {
+    await alicePage.goto('/marketplace');
+
+    // Click Browse tab
+    await alicePage.getByRole('tab', { name: 'Browse' }).click();
+
+    // Should see Bob's Rifter listing
+    await expect(alicePage.getByText('Rifter')).toBeVisible({ timeout: 10000 });
+    await expect(alicePage.getByText('Bob')).toBeVisible();
+  });
+
+  test('Alice purchases from Bob listing', async ({ alicePage }) => {
+    await alicePage.goto('/marketplace');
+
+    // Click Browse tab
+    await alicePage.getByRole('tab', { name: 'Browse' }).click();
+    await expect(alicePage.getByText('Rifter')).toBeVisible({ timeout: 10000 });
+
+    // Click Buy button
+    await alicePage.getByRole('button', { name: /Buy/i }).click();
+
+    // Fill in purchase quantity
+    await expect(alicePage.getByText(/Quantity to Purchase/i).first()).toBeVisible();
+    const qtyInput = alicePage.getByLabel(/Quantity/i).first();
+    await qtyInput.clear();
+    await qtyInput.fill('2');
+
+    // Confirm purchase
+    await alicePage.getByRole('button', { name: /Confirm Purchase/i }).click();
+    await alicePage.waitForTimeout(1000);
+
+    // Check purchase appears in history
+    await alicePage.getByRole('tab', { name: 'History' }).click();
+    await expect(alicePage.getByText('Rifter')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Alice can create a buy order', async ({ alicePage }) => {
+    await alicePage.goto('/marketplace');
+
+    // Click My Buy Orders tab
+    await alicePage.getByRole('tab', { name: 'My Buy Orders' }).click();
+
+    // Click Create Buy Order button
+    await alicePage.getByRole('button', { name: /Create Buy Order/i }).click();
+
+    // Search for item
+    const itemSearch = alicePage.getByPlaceholder(/Start typing/i);
+    await itemSearch.fill('Pyerite');
+    await alicePage.waitForTimeout(500);
+
+    // Select from autocomplete dropdown
+    await alicePage.getByRole('option', { name: /Pyerite/i }).click();
+
+    // Fill in quantity and price
+    const qtyInput = alicePage.getByLabel(/Quantity Desired/i);
+    await qtyInput.fill('10000');
+
+    const priceInput = alicePage.getByLabel(/Max Price/i);
+    await priceInput.fill('10');
+
+    // Create the order
+    await alicePage.getByRole('button', { name: /Create/i }).click();
+    await alicePage.waitForTimeout(1000);
+
+    // Verify buy order appears
+    await expect(alicePage.getByText('Pyerite').first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('can switch between all marketplace tabs', async ({ alicePage }) => {
+    await alicePage.goto('/marketplace');
+
+    const tabs = ['My Listings', 'Browse', 'Pending Sales', 'History', 'My Buy Orders', 'Demand', 'Analytics'];
+
+    for (const tabName of tabs) {
+      await alicePage.getByRole('tab', { name: tabName }).click();
+      await alicePage.waitForTimeout(300);
+    }
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": "."
+  },
+  "include": ["**/*.ts"]
+}

--- a/internal/client/esiClient_test.go
+++ b/internal/client/esiClient_test.go
@@ -58,7 +58,7 @@ func Test_ClientShouldGetCharacterAssets(t *testing.T) {
 		Times(1)
 
 	// Create ESI client with mock HTTP client
-	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient)
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "")
 
 	// Test GetCharacterAssets
 	assets, err := esiClient.GetCharacterAssets(context.Background(), 12345, "test-token", "test-refresh", time.Now())
@@ -115,7 +115,7 @@ func Test_ClientShouldGetMarketOrders(t *testing.T) {
 		Times(1)
 
 	// Create ESI client with mock HTTP client
-	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient)
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "")
 
 	// Test GetMarketOrders
 	orders, err := esiClient.GetMarketOrders(context.Background(), 10000002)


### PR DESCRIPTION
## Summary
- Adds 39 Playwright E2E tests across 7 spec files covering landing, navigation, characters, assets, stockpiles, contacts, and marketplace
- Mock ESI server with deterministic canned responses for all ESI endpoints
- Docker Compose E2E stack with Dockerized Playwright for CI
- NextAuth CredentialsProvider for browser auth without EVE OAuth
- Configurable ESI base URL to swap real ESI for mock in tests
- GitHub Actions e2e-tests job with Playwright report artifacts
- Feature documentation for E2E testing and stockpile markers

## Test plan
- [x] `make test-e2e-ci` passes all 39 tests (Dockerized Playwright)
- [x] `make test-e2e` passes all 39 tests (local Playwright)
- [x] Stockpile tests cover character + corp markers, edit, delete, filter, search (8 tests)
- [ ] Verify GitHub Actions e2e-tests job passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)