### PR TITLE
Resolve NPC station names from ESI during SDE refresh

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -85,7 +85,7 @@ var rootCmd = &cobra.Command{
 		sdeClient := client.NewSdeClient(&http.Client{})
 
 		assetUpdater := updaters.NewAssets(charactersAssetRepository, charactersRepository, stationsRepository, playerCorporationRepostiory, playerCorporationAssetsRepository, esiClient)
-		sdeUpdater := updaters.NewSde(sdeClient, sdeDataRepository, itemTypesRepository, regionsRepository, constellationsRepository, systemRepository, stationsRepository)
+		sdeUpdater := updaters.NewSde(sdeClient, esiClient, sdeDataRepository, itemTypesRepository, regionsRepository, constellationsRepository, systemRepository, stationsRepository)
 		marketPricesUpdater := updaters.NewMarketPrices(marketPricesRepository, esiClient)
 		ccpPricesUpdater := updaters.NewCcpPrices(esiClient, marketPricesRepository)
 		costIndicesUpdater := updaters.NewIndustryCostIndices(esiClient, industryCostIndicesRepository)

--- a/docs/features/npc-station-names.md
+++ b/docs/features/npc-station-names.md
@@ -1,0 +1,35 @@
+# NPC Station Name Resolution
+
+## Status: Implemented
+
+## Overview
+
+NPC station names (e.g., "Jita IV - Moon 4 - Caldari Navy Assembly Plant") were not displaying on the inventory page. The SDE's `npcStations.yaml` file does not include station names, so stations were inserted into the database with empty names.
+
+## Solution
+
+After the SDE upserts station records, the system queries for any NPC stations with empty names and resolves them using ESI's public `POST /universe/names/` bulk endpoint. This endpoint accepts up to 1000 IDs per call and returns names for stations, solar systems, and other universe entities.
+
+## How It Works
+
+1. SDE updater imports stations from `npcStations.yaml` (IDs, solar system, corporation — but no names)
+2. After station upsert, queries `stations` table for rows where `name = '' AND is_npc_station = true`
+3. Sends station IDs to ESI `POST /universe/names/` in batches of 1000
+4. Updates station names in the database
+5. Subsequent asset queries now return proper station names via INNER JOIN
+
+## Key Details
+
+- **Frequency**: Runs during SDE refresh (every 24 hours), not on every asset refresh
+- **Efficiency**: Only fetches names for stations that are missing them; once resolved, they persist
+- **Authentication**: The `/universe/names/` endpoint is public (no OAuth required)
+- **Batching**: IDs are sent in chunks of 1000 (ESI limit per request)
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `internal/client/esiClient.go` | `GetUniverseNames()` — bulk name resolution via ESI |
+| `internal/repositories/stations.go` | `GetStationsWithEmptyNames()`, `UpdateNames()` |
+| `internal/updaters/sde.go` | Name resolution logic after station upsert |
+| `cmd/mock-esi/main.go` | Mock `POST /universe/names/` for E2E tests |

--- a/internal/repositories/stations_test.go
+++ b/internal/repositories/stations_test.go
@@ -73,6 +73,151 @@ func Test_StationsShouldUpsert(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func Test_StationsShouldGetStationsWithEmptyNames(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	regionsRepo := repositories.NewRegions(db)
+	constellationsRepo := repositories.NewConstellations(db)
+	solarSystemsRepo := repositories.NewSolarSystems(db)
+	stationsRepo := repositories.NewStations(db)
+
+	// Create parent hierarchy
+	err = regionsRepo.Upsert(context.Background(), []models.Region{
+		{ID: 10000002, Name: "The Forge"},
+	})
+	assert.NoError(t, err)
+
+	err = constellationsRepo.Upsert(context.Background(), []models.Constellation{
+		{ID: 20000020, Name: "Kimotoro", RegionID: 10000002},
+	})
+	assert.NoError(t, err)
+
+	err = solarSystemsRepo.Upsert(context.Background(), []models.SolarSystem{
+		{ID: 30000142, Name: "Jita", ConstellationID: 20000020, Security: 0.9},
+	})
+	assert.NoError(t, err)
+
+	// Insert stations: two NPC with empty names, one NPC with a name, one non-NPC with empty name
+	stations := []models.Station{
+		{ID: 60003760, Name: "", SolarSystemID: 30000142, CorporationID: 1000035, IsNPC: true},
+		{ID: 60003761, Name: "", SolarSystemID: 30000142, CorporationID: 1000035, IsNPC: true},
+		{ID: 60003762, Name: "Already Named Station", SolarSystemID: 30000142, CorporationID: 1000035, IsNPC: true},
+		{ID: 60003763, Name: "", SolarSystemID: 30000142, CorporationID: 1000036, IsNPC: false}, // player-owned, should be excluded
+	}
+	err = stationsRepo.Upsert(context.Background(), stations)
+	assert.NoError(t, err)
+
+	// Get stations with empty names — should only return NPC stations with empty names
+	ids, err := stationsRepo.GetStationsWithEmptyNames(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, ids, 2)
+	assert.ElementsMatch(t, []int64{60003760, 60003761}, ids)
+}
+
+func Test_StationsShouldReturnEmptySliceWhenNoEmptyNames(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	regionsRepo := repositories.NewRegions(db)
+	constellationsRepo := repositories.NewConstellations(db)
+	solarSystemsRepo := repositories.NewSolarSystems(db)
+	stationsRepo := repositories.NewStations(db)
+
+	// Create parent hierarchy
+	err = regionsRepo.Upsert(context.Background(), []models.Region{
+		{ID: 10000002, Name: "The Forge"},
+	})
+	assert.NoError(t, err)
+
+	err = constellationsRepo.Upsert(context.Background(), []models.Constellation{
+		{ID: 20000020, Name: "Kimotoro", RegionID: 10000002},
+	})
+	assert.NoError(t, err)
+
+	err = solarSystemsRepo.Upsert(context.Background(), []models.SolarSystem{
+		{ID: 30000142, Name: "Jita", ConstellationID: 20000020, Security: 0.9},
+	})
+	assert.NoError(t, err)
+
+	// All stations have names
+	stations := []models.Station{
+		{ID: 60003760, Name: "Jita IV - Moon 4 - Caldari Navy Assembly Plant", SolarSystemID: 30000142, CorporationID: 1000035, IsNPC: true},
+	}
+	err = stationsRepo.Upsert(context.Background(), stations)
+	assert.NoError(t, err)
+
+	ids, err := stationsRepo.GetStationsWithEmptyNames(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
+func Test_StationsShouldUpdateNames(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	regionsRepo := repositories.NewRegions(db)
+	constellationsRepo := repositories.NewConstellations(db)
+	solarSystemsRepo := repositories.NewSolarSystems(db)
+	stationsRepo := repositories.NewStations(db)
+
+	// Create parent hierarchy
+	err = regionsRepo.Upsert(context.Background(), []models.Region{
+		{ID: 10000002, Name: "The Forge"},
+	})
+	assert.NoError(t, err)
+
+	err = constellationsRepo.Upsert(context.Background(), []models.Constellation{
+		{ID: 20000020, Name: "Kimotoro", RegionID: 10000002},
+	})
+	assert.NoError(t, err)
+
+	err = solarSystemsRepo.Upsert(context.Background(), []models.SolarSystem{
+		{ID: 30000142, Name: "Jita", ConstellationID: 20000020, Security: 0.9},
+	})
+	assert.NoError(t, err)
+
+	// Insert stations with empty names
+	stations := []models.Station{
+		{ID: 60003760, Name: "", SolarSystemID: 30000142, CorporationID: 1000035, IsNPC: true},
+		{ID: 60003761, Name: "", SolarSystemID: 30000142, CorporationID: 1000035, IsNPC: true},
+	}
+	err = stationsRepo.Upsert(context.Background(), stations)
+	assert.NoError(t, err)
+
+	// Verify they have empty names
+	ids, err := stationsRepo.GetStationsWithEmptyNames(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, ids, 2)
+
+	// Update names
+	names := map[int64]string{
+		60003760: "Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+		60003761: "Jita IV - Moon 5 - Some Other Station",
+	}
+	err = stationsRepo.UpdateNames(context.Background(), names)
+	assert.NoError(t, err)
+
+	// Verify no more empty names
+	ids, err = stationsRepo.GetStationsWithEmptyNames(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
+func Test_StationsShouldHandleEmptyUpdateNames(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	stationsRepo := repositories.NewStations(db)
+
+	// Should be a no-op, no error
+	err = stationsRepo.UpdateNames(context.Background(), map[int64]string{})
+	assert.NoError(t, err)
+
+	err = stationsRepo.UpdateNames(context.Background(), nil)
+	assert.NoError(t, err)
+}
+
 func Test_StationsShouldHandleEmptyUpsert(t *testing.T) {
 	db, err := setupDatabase(t)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
- After SDE station upsert, queries for NPC stations with empty names and resolves them via ESI's public `POST /universe/names/` endpoint (batched in chunks of 1000)
- Adds `GetUniverseNames()` to ESI client, `GetStationsWithEmptyNames()` and `UpdateNames()` to station repository
- Includes unit tests for ESI client and integration tests for station repository

Closes #15

## Test plan
- [x] `make test-backend` — all tests pass (ESI client unit tests + station repo integration tests)
- [x] `make test-frontend` — all tests pass
- [ ] `make test-e2e-ci` — verify station names appear on inventory page

🤖 Generated with [Claude Code](https://claude.com/claude-code)