### PR TITLE
Fix duplicate items in seller pending sales view

### DIFF
--- a/e2e/tests/08-marketplace.spec.ts
+++ b/e2e/tests/08-marketplace.spec.ts
@@ -93,6 +93,26 @@ test.describe('Marketplace', () => {
     await expect(alicePage.getByText('Rifter')).toBeVisible({ timeout: 5000 });
   });
 
+  test('Bob sees no duplicate items in pending sales', async ({ bobPage }) => {
+    // Alice (user 1001) has 2 characters (Alice Alpha + Alice Beta).
+    // The bug caused a LEFT JOIN to the characters table to produce one row
+    // per character, duplicating every pending sale for multi-character buyers.
+    await bobPage.goto('/marketplace');
+
+    // Click Pending Sales tab
+    await bobPage.getByRole('tab', { name: 'Pending Sales' }).click();
+
+    // Wait for the pending sale from Alice's Rifter purchase to load
+    await expect(bobPage.getByText('Rifter')).toBeVisible({ timeout: 10000 });
+
+    // The header should show exactly 1 item in 1 group — not 2 items (which would mean duplication)
+    await expect(bobPage.getByText(/1 items? in 1 groups?/)).toBeVisible();
+
+    // Rifter should appear exactly once in the table body
+    const rifterRows = bobPage.getByRole('cell', { name: 'Rifter' });
+    await expect(rifterRows).toHaveCount(1);
+  });
+
   test('Alice can create a buy order', async ({ alicePage }) => {
     await alicePage.goto('/marketplace');
 

--- a/internal/repositories/purchaseTransactions.go
+++ b/internal/repositories/purchaseTransactions.go
@@ -101,7 +101,7 @@ func (r *PurchaseTransactions) GetByBuyer(ctx context.Context, buyerUserID int64
 	}
 	defer rows.Close()
 
-	var transactions []*models.PurchaseTransaction
+	transactions := []*models.PurchaseTransaction{}
 	for rows.Next() {
 		var tx models.PurchaseTransaction
 		err = rows.Scan(
@@ -157,7 +157,7 @@ func (r *PurchaseTransactions) GetBySeller(ctx context.Context, sellerUserID int
 	}
 	defer rows.Close()
 
-	var transactions []*models.PurchaseTransaction
+	transactions := []*models.PurchaseTransaction{}
 	for rows.Next() {
 		var tx models.PurchaseTransaction
 		err = rows.Scan(
@@ -191,7 +191,7 @@ func (r *PurchaseTransactions) GetPendingForSeller(ctx context.Context, sellerUs
 			pt.id,
 			pt.for_sale_item_id,
 			pt.buyer_user_id,
-			COALESCE(buyer_char.name, CONCAT('User ', pt.buyer_user_id)) AS buyer_name,
+			COALESCE(buyer_user.name, CONCAT('User ', pt.buyer_user_id)) AS buyer_name,
 			pt.seller_user_id,
 			pt.type_id,
 			t.type_name,
@@ -207,11 +207,11 @@ func (r *PurchaseTransactions) GetPendingForSeller(ctx context.Context, sellerUs
 		FROM purchase_transactions pt
 		JOIN asset_item_types t ON pt.type_id = t.type_id
 		JOIN for_sale_items fsi ON pt.for_sale_item_id = fsi.id
-		LEFT JOIN characters buyer_char ON pt.buyer_user_id = buyer_char.user_id
+		LEFT JOIN users buyer_user ON pt.buyer_user_id = buyer_user.id
 		LEFT JOIN solar_systems s ON fsi.location_id = s.solar_system_id
 		LEFT JOIN stations st ON fsi.location_id = st.station_id
 		WHERE pt.seller_user_id = $1 AND pt.status = 'pending'
-		ORDER BY fsi.location_id, COALESCE(buyer_char.name, CONCAT('User ', pt.buyer_user_id)), pt.purchased_at DESC
+		ORDER BY fsi.location_id, COALESCE(buyer_user.name, CONCAT('User ', pt.buyer_user_id)), pt.purchased_at DESC
 	`
 
 	rows, err := r.db.QueryContext(ctx, query, sellerUserID)
@@ -220,7 +220,7 @@ func (r *PurchaseTransactions) GetPendingForSeller(ctx context.Context, sellerUs
 	}
 	defer rows.Close()
 
-	var transactions []*models.PurchaseTransaction
+	transactions := []*models.PurchaseTransaction{}
 	for rows.Next() {
 		var tx models.PurchaseTransaction
 		err = rows.Scan(

--- a/internal/repositories/purchaseTransactions_test.go
+++ b/internal/repositories/purchaseTransactions_test.go
@@ -360,8 +360,8 @@ func Test_PurchaseTransactions_GetPendingForSeller(t *testing.T) {
 	assert.Equal(t, "pending", pending[0].Status)
 	assert.Equal(t, int64(30), pending[0].QuantityPurchased)
 
-	// Verify buyer name is populated
-	assert.Equal(t, "Buyer Character", pending[0].BuyerName)
+	// Verify buyer name is populated (from users table, not characters)
+	assert.Equal(t, "Test Buyer", pending[0].BuyerName)
 
 	// Verify location name is populated
 	assert.Equal(t, "Test System", pending[0].LocationName)


### PR DESCRIPTION
## Summary
- `GetPendingForSeller()` joined to `characters` on `user_id`, but users can have multiple characters — causing row multiplication per buyer character count
- Replaced with `LEFT JOIN users` (1:1 by primary key), eliminating duplicates
- Fixed nil slice initialization (`var` → `:=`) in 3 places to prevent JSON `null` marshaling
- Added E2E regression test: verifies a multi-character buyer's purchase shows exactly once in seller's pending sales

Closes #17

## Test plan
- [x] `make test-backend` — all tests pass (including updated `GetPendingForSeller` assertion)
- [x] `make test-frontend` — 86 tests, 13 snapshots pass
- [ ] `make test-e2e-ci` — new "Bob sees no duplicate items in pending sales" test

🤖 Generated with [Claude Code](https://claude.com/claude-code)