### PR TITLE
Support decimal prices end-to-end (#21)

### DIFF
--- a/frontend/packages/components/assets/AssetsList.tsx
+++ b/frontend/packages/components/assets/AssetsList.tsx
@@ -719,16 +719,29 @@ export default function AssetsList(props: AssetsListProps) {
     const quantity = listingQuantityRef.current?.value.replace(/,/g, '') || '0';
     const price = listingPriceRef.current?.value.replace(/,/g, '') || '0';
     const quantityNum = parseInt(quantity) || 0;
-    const priceNum = parseInt(price) || 0;
+    const priceNum = parseFloat(price) || 0;
     const total = quantityNum * priceNum;
-    setListingTotalValue(total > 0 ? total.toLocaleString() : '');
+    setListingTotalValue(total > 0 ? total.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 }) : '');
   };
 
-  const handleListingInputChange = (ref: React.RefObject<HTMLInputElement | null>) => {
+  const handleListingInputChange = (ref: React.RefObject<HTMLInputElement | null>, allowDecimals = false) => {
     if (!ref.current) return;
-    const numericValue = ref.current.value.replace(/\D/g, '');
-    const formatted = numericValue ? parseInt(numericValue).toLocaleString() : '';
-    ref.current.value = formatted;
+    const stripped = ref.current.value.replace(/,/g, '');
+    if (allowDecimals) {
+      const num = parseFloat(stripped);
+      if (isNaN(num) || num <= 0) {
+        ref.current.value = '';
+      } else {
+        ref.current.value = num.toLocaleString(undefined, {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2,
+        });
+      }
+    } else {
+      const numericValue = stripped.replace(/\D/g, '');
+      const formatted = numericValue ? parseInt(numericValue).toLocaleString() : '';
+      ref.current.value = formatted;
+    }
     updateTotalValue();
   };
 
@@ -739,7 +752,7 @@ export default function AssetsList(props: AssetsListProps) {
     const priceValue = listingPriceRef.current?.value.replace(/,/g, '') || '0';
 
     const quantity = parseInt(quantityValue);
-    const price = parseInt(priceValue);
+    const price = parseFloat(priceValue);
     const notes = listingNotesRef.current?.value || '';
 
     if (!quantity || !price) return;
@@ -1556,7 +1569,7 @@ export default function AssetsList(props: AssetsListProps) {
                 label="Price Per Unit (ISK)"
                 type="text"
                 inputRef={listingPriceRef}
-                onBlur={() => handleListingInputChange(listingPriceRef)}
+                onBlur={() => handleListingInputChange(listingPriceRef, true)}
                 sx={{ mb: 2 }}
                 required
                 placeholder="0"

--- a/frontend/packages/components/marketplace/BuyOrders.tsx
+++ b/frontend/packages/components/marketplace/BuyOrders.tsx
@@ -387,7 +387,7 @@ export default function BuyOrders() {
               label="Max Price Per Unit (ISK)"
               type="number"
               value={formData.maxPricePerUnit || ''}
-              onChange={(e) => setFormData({ ...formData, maxPricePerUnit: parseInt(e.target.value) })}
+              onChange={(e) => setFormData({ ...formData, maxPricePerUnit: parseFloat(e.target.value) || 0 })}
               fullWidth
               required
             />

--- a/internal/controllers/analytics_test.go
+++ b/internal/controllers/analytics_test.go
@@ -71,7 +71,7 @@ func TestAnalyticsController_GetSalesMetrics(t *testing.T) {
 		require.NotNil(t, result)
 
 		metrics := result.(*models.SalesMetrics)
-		assert.Equal(t, int64(100000), metrics.TotalRevenue)
+		assert.Equal(t, float64(100000), metrics.TotalRevenue)
 		assert.Equal(t, int64(1), metrics.TotalTransactions)
 		assert.Equal(t, int64(100), metrics.TotalQuantitySold)
 	})
@@ -90,7 +90,7 @@ func TestAnalyticsController_GetSalesMetrics(t *testing.T) {
 		require.NotNil(t, result)
 
 		metrics := result.(*models.SalesMetrics)
-		assert.Equal(t, int64(100000), metrics.TotalRevenue)
+		assert.Equal(t, float64(100000), metrics.TotalRevenue)
 	})
 }
 

--- a/internal/controllers/buyOrders.go
+++ b/internal/controllers/buyOrders.go
@@ -72,7 +72,7 @@ func (c *BuyOrdersController) CreateOrder(args *web.HandlerArgs) (any, *web.Http
 	var req struct {
 		TypeID          int64   `json:"typeId"`
 		QuantityDesired int64   `json:"quantityDesired"`
-		MaxPricePerUnit int64   `json:"maxPricePerUnit"`
+		MaxPricePerUnit float64 `json:"maxPricePerUnit"`
 		Notes           *string `json:"notes"`
 	}
 
@@ -161,7 +161,7 @@ func (c *BuyOrdersController) UpdateOrder(args *web.HandlerArgs) (any, *web.Http
 
 	var req struct {
 		QuantityDesired int64   `json:"quantityDesired"`
-		MaxPricePerUnit int64   `json:"maxPricePerUnit"`
+		MaxPricePerUnit float64 `json:"maxPricePerUnit"`
 		Notes           *string `json:"notes"`
 		IsActive        *bool   `json:"isActive"`
 	}

--- a/internal/controllers/buyOrders_test.go
+++ b/internal/controllers/buyOrders_test.go
@@ -58,7 +58,7 @@ func Test_BuyOrders_CreateOrder_Success(t *testing.T) {
 	assert.Equal(t, userID, order.BuyerUserID)
 	assert.Equal(t, int64(70), order.TypeID)
 	assert.Equal(t, int64(100000), order.QuantityDesired)
-	assert.Equal(t, int64(6), order.MaxPricePerUnit)
+	assert.Equal(t, float64(6), order.MaxPricePerUnit)
 	assert.True(t, order.IsActive)
 }
 
@@ -118,7 +118,7 @@ func Test_BuyOrders_GetMyOrders(t *testing.T) {
 			BuyerUserID:     userID,
 			TypeID:          71 + int64(i%2),
 			QuantityDesired: int64(10000 * (i + 1)),
-			MaxPricePerUnit: int64(10 + i),
+			MaxPricePerUnit: float64(10 + i),
 			IsActive:        true,
 		}
 		assert.NoError(t, buyOrdersRepo.Create(context.Background(), order))
@@ -192,7 +192,7 @@ func Test_BuyOrders_UpdateOrder_Success(t *testing.T) {
 
 	updated := result.(*models.BuyOrder)
 	assert.Equal(t, int64(75000), updated.QuantityDesired)
-	assert.Equal(t, int64(25), updated.MaxPricePerUnit)
+	assert.Equal(t, float64(25), updated.MaxPricePerUnit)
 }
 
 func Test_BuyOrders_UpdateOrder_NotOwner(t *testing.T) {
@@ -358,7 +358,7 @@ func Test_BuyOrders_GetDemand(t *testing.T) {
 			BuyerUserID:     buyerID,
 			TypeID:          76,
 			QuantityDesired: int64(5000 * (i + 1)),
-			MaxPricePerUnit: int64(50 + i*10),
+			MaxPricePerUnit: float64(50 + i*10),
 			IsActive:        true,
 		}
 		assert.NoError(t, buyOrdersRepo.Create(context.Background(), order))

--- a/internal/controllers/forSaleItems.go
+++ b/internal/controllers/forSaleItems.go
@@ -111,7 +111,7 @@ func (c *ForSaleItems) CreateListing(args *web.HandlerArgs) (any, *web.HttpError
 		ContainerID       *int64  `json:"containerId"`
 		DivisionNumber    *int    `json:"divisionNumber"`
 		QuantityAvailable int64   `json:"quantityAvailable"`
-		PricePerUnit      int64   `json:"pricePerUnit"`
+		PricePerUnit      float64 `json:"pricePerUnit"`
 		Notes             *string `json:"notes"`
 	}
 
@@ -196,7 +196,7 @@ func (c *ForSaleItems) UpdateListing(args *web.HandlerArgs) (any, *web.HttpError
 
 	var req struct {
 		QuantityAvailable int64   `json:"quantityAvailable"`
-		PricePerUnit      int64   `json:"pricePerUnit"`
+		PricePerUnit      float64 `json:"pricePerUnit"`
 		Notes             *string `json:"notes"`
 		IsActive          *bool   `json:"isActive"`
 	}

--- a/internal/controllers/purchases.go
+++ b/internal/controllers/purchases.go
@@ -138,7 +138,7 @@ func (c *Purchases) PurchaseItem(args *web.HandlerArgs) (any, *web.HttpError) {
 		TypeID:            item.TypeID,
 		QuantityPurchased: req.QuantityPurchased,
 		PricePerUnit:      item.PricePerUnit,
-		TotalPrice:        req.QuantityPurchased * item.PricePerUnit,
+		TotalPrice:        float64(req.QuantityPurchased) * item.PricePerUnit,
 		Status:            "pending",
 		TransactionNotes:  notes,
 	}

--- a/internal/controllers/purchases_test.go
+++ b/internal/controllers/purchases_test.go
@@ -127,7 +127,7 @@ func Test_PurchaseItem_Success(t *testing.T) {
 	assert.Equal(t, buyerID, purchase.BuyerUserID)
 	assert.Equal(t, sellerID, purchase.SellerUserID)
 	assert.Equal(t, int64(250), purchase.QuantityPurchased)
-	assert.Equal(t, int64(25000), purchase.TotalPrice)
+	assert.Equal(t, float64(25000), purchase.TotalPrice)
 	assert.Equal(t, "pending", purchase.Status)
 
 	// Verify quantity was reduced

--- a/internal/database/migrations/20260217183856_decimal_prices.down.sql
+++ b/internal/database/migrations/20260217183856_decimal_prices.down.sql
@@ -1,0 +1,7 @@
+-- Migration: decimal_prices
+-- Created: Tue Feb 17 06:38:56 PM PST 2026
+
+alter table for_sale_items alter column price_per_unit type bigint;
+alter table purchase_transactions alter column price_per_unit type bigint;
+alter table purchase_transactions alter column total_price type bigint;
+alter table buy_orders alter column max_price_per_unit type bigint;

--- a/internal/database/migrations/20260217183856_decimal_prices.up.sql
+++ b/internal/database/migrations/20260217183856_decimal_prices.up.sql
@@ -1,0 +1,7 @@
+-- Migration: decimal_prices
+-- Created: Tue Feb 17 06:38:56 PM PST 2026
+
+alter table for_sale_items alter column price_per_unit type numeric(20,2);
+alter table purchase_transactions alter column price_per_unit type numeric(20,2);
+alter table purchase_transactions alter column total_price type numeric(20,2);
+alter table buy_orders alter column max_price_per_unit type numeric(20,2);

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -120,7 +120,7 @@ type ForSaleItem struct {
 	ContainerID       *int64    `json:"containerId"`
 	DivisionNumber    *int      `json:"divisionNumber"`
 	QuantityAvailable int64     `json:"quantityAvailable"`
-	PricePerUnit      int64     `json:"pricePerUnit"`
+	PricePerUnit      float64   `json:"pricePerUnit"`
 	Notes             *string   `json:"notes"`
 	IsActive          bool      `json:"isActive"`
 	CreatedAt         time.Time `json:"createdAt"`
@@ -138,8 +138,8 @@ type PurchaseTransaction struct {
 	LocationID        int64     `json:"locationId"`
 	LocationName      string    `json:"locationName"`
 	QuantityPurchased int64     `json:"quantityPurchased"`
-	PricePerUnit      int64     `json:"pricePerUnit"`
-	TotalPrice        int64     `json:"totalPrice"`
+	PricePerUnit      float64   `json:"pricePerUnit"`
+	TotalPrice        float64   `json:"totalPrice"`
 	Status            string    `json:"status"`
 	ContractKey       *string   `json:"contractKey,omitempty"`
 	TransactionNotes  *string   `json:"transactionNotes"`
@@ -152,7 +152,7 @@ type BuyOrder struct {
 	TypeID           int64     `json:"typeId"`
 	TypeName         string    `json:"typeName"`
 	QuantityDesired  int64     `json:"quantityDesired"`
-	MaxPricePerUnit  int64     `json:"maxPricePerUnit"`
+	MaxPricePerUnit  float64   `json:"maxPricePerUnit"`
 	Notes            *string   `json:"notes"`
 	IsActive         bool      `json:"isActive"`
 	CreatedAt        time.Time `json:"createdAt"`
@@ -162,7 +162,7 @@ type BuyOrder struct {
 // Sales Analytics Models
 
 type SalesMetrics struct {
-	TotalRevenue      int64          `json:"totalRevenue"`
+	TotalRevenue      float64        `json:"totalRevenue"`
 	TotalTransactions int64          `json:"totalTransactions"`
 	TotalQuantitySold int64          `json:"totalQuantitySold"`
 	UniqueItemTypes   int64          `json:"uniqueItemTypes"`
@@ -173,8 +173,8 @@ type SalesMetrics struct {
 
 type TimeSeriesData struct {
 	Date              string `json:"date"`
-	Revenue           int64  `json:"revenue"`
-	Transactions      int64  `json:"transactions"`
+	Revenue           float64 `json:"revenue"`
+	Transactions      int64   `json:"transactions"`
 	QuantitySold      int64  `json:"quantitySold"`
 }
 
@@ -182,15 +182,15 @@ type ItemSalesData struct {
 	TypeID            int64   `json:"typeId"`
 	TypeName          string  `json:"typeName"`
 	QuantitySold      int64   `json:"quantitySold"`
-	Revenue           int64   `json:"revenue"`
-	TransactionCount  int64   `json:"transactionCount"`
-	AveragePricePerUnit int64 `json:"averagePricePerUnit"`
+	Revenue             float64 `json:"revenue"`
+	TransactionCount    int64   `json:"transactionCount"`
+	AveragePricePerUnit float64 `json:"averagePricePerUnit"`
 }
 
 type BuyerAnalytics struct {
 	BuyerUserID       int64     `json:"buyerUserId"`
 	BuyerName         string    `json:"buyerName"`
-	TotalSpent        int64     `json:"totalSpent"`
+	TotalSpent        float64   `json:"totalSpent"`
 	TotalPurchases    int64     `json:"totalPurchases"`
 	TotalQuantity     int64     `json:"totalQuantity"`
 	FirstPurchaseDate time.Time `json:"firstPurchaseDate"`

--- a/internal/repositories/buyOrders_test.go
+++ b/internal/repositories/buyOrders_test.go
@@ -52,7 +52,7 @@ func Test_BuyOrders_CreateAndGet(t *testing.T) {
 	assert.Equal(t, int64(60), retrieved.TypeID)
 	assert.Equal(t, "Mexallon", retrieved.TypeName)
 	assert.Equal(t, int64(100000), retrieved.QuantityDesired)
-	assert.Equal(t, int64(50), retrieved.MaxPricePerUnit)
+	assert.Equal(t, float64(50), retrieved.MaxPricePerUnit)
 	assert.True(t, retrieved.IsActive)
 }
 
@@ -83,7 +83,7 @@ func Test_BuyOrders_GetByUser(t *testing.T) {
 			BuyerUserID:     5010,
 			TypeID:          61 + int64(i%2),
 			QuantityDesired: int64(10000 * (i + 1)),
-			MaxPricePerUnit: int64(50 + i),
+			MaxPricePerUnit: float64(50 + i),
 			IsActive:        true,
 		}
 		err = repo.Create(context.Background(), order)
@@ -147,7 +147,7 @@ func Test_BuyOrders_Update(t *testing.T) {
 	retrieved, err := repo.GetByID(context.Background(), order.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(75000), retrieved.QuantityDesired)
-	assert.Equal(t, int64(120), retrieved.MaxPricePerUnit)
+	assert.Equal(t, float64(120), retrieved.MaxPricePerUnit)
 	assert.NotNil(t, retrieved.Notes)
 	assert.Equal(t, "Urgent order", *retrieved.Notes)
 }

--- a/internal/repositories/forSaleItems_test.go
+++ b/internal/repositories/forSaleItems_test.go
@@ -97,7 +97,7 @@ func Test_ForSaleItemsShouldGetByUser(t *testing.T) {
 	assert.Equal(t, "Test Character", items[0].OwnerName)
 	assert.Equal(t, "Jita", items[0].LocationName)
 	assert.Equal(t, int64(2000), items[0].QuantityAvailable)
-	assert.Equal(t, int64(100), items[0].PricePerUnit)
+	assert.Equal(t, float64(100), items[0].PricePerUnit)
 }
 
 func Test_ForSaleItemsShouldDelete(t *testing.T) {

--- a/internal/repositories/purchaseTransactions_test.go
+++ b/internal/repositories/purchaseTransactions_test.go
@@ -247,8 +247,8 @@ func Test_PurchaseTransactions_GetByBuyer(t *testing.T) {
 			SellerUserID:      3031,
 			TypeID:            43,
 			QuantityPurchased: int64(10 + i),
-			PricePerUnit:      100,
-			TotalPrice:        int64((10 + i) * 100),
+			PricePerUnit:      100.0,
+			TotalPrice:        float64((10 + i) * 100),
 			Status:            "pending",
 		}
 		err = repo.Create(context.Background(), tx, purchase)
@@ -291,8 +291,8 @@ func Test_PurchaseTransactions_GetBySeller(t *testing.T) {
 			SellerUserID:      3041,
 			TypeID:            44,
 			QuantityPurchased: int64(20 + i),
-			PricePerUnit:      100,
-			TotalPrice:        int64((20 + i) * 100),
+			PricePerUnit:      100.0,
+			TotalPrice:        float64((20 + i) * 100),
 			Status:            "completed",
 		}
 		err = repo.Create(context.Background(), tx, purchase)

--- a/internal/repositories/salesAnalytics.go
+++ b/internal/repositories/salesAnalytics.go
@@ -121,7 +121,7 @@ func (r *SalesAnalytics) GetTopItems(ctx context.Context, sellerUserID int64, pe
 			COALESCE(SUM(pt.quantity_purchased), 0) as quantity_sold,
 			COALESCE(SUM(pt.total_price), 0) as revenue,
 			COUNT(*) as transaction_count,
-			COALESCE(AVG(pt.price_per_unit), 0)::BIGINT as avg_price_per_unit
+			COALESCE(AVG(pt.price_per_unit), 0) as avg_price_per_unit
 		FROM purchase_transactions pt
 		JOIN asset_item_types t ON pt.type_id = t.type_id
 		WHERE pt.seller_user_id = $1
@@ -245,7 +245,7 @@ func (r *SalesAnalytics) GetItemSalesHistory(ctx context.Context, sellerUserID i
 			COALESCE(SUM(pt.quantity_purchased), 0) as quantity_sold,
 			COALESCE(SUM(pt.total_price), 0) as revenue,
 			COUNT(*) as transaction_count,
-			COALESCE(AVG(pt.price_per_unit), 0)::BIGINT as avg_price_per_unit
+			COALESCE(AVG(pt.price_per_unit), 0) as avg_price_per_unit
 		FROM purchase_transactions pt
 		JOIN asset_item_types t ON pt.type_id = t.type_id
 		WHERE pt.seller_user_id = $1

--- a/internal/repositories/salesAnalytics_test.go
+++ b/internal/repositories/salesAnalytics_test.go
@@ -74,7 +74,7 @@ func TestSalesAnalytics_GetSalesMetrics(t *testing.T) {
 		metrics, err := analyticsRepo.GetSalesMetrics(ctx, sellerUser.ID, 0)
 		require.NoError(t, err)
 
-		assert.Equal(t, int64(200000), metrics.TotalRevenue)
+		assert.Equal(t, float64(200000), metrics.TotalRevenue)
 		assert.Equal(t, int64(2), metrics.TotalTransactions)
 		assert.Equal(t, int64(150), metrics.TotalQuantitySold)
 		assert.Equal(t, int64(2), metrics.UniqueItemTypes)
@@ -87,7 +87,7 @@ func TestSalesAnalytics_GetSalesMetrics(t *testing.T) {
 		metrics, err := analyticsRepo.GetSalesMetrics(ctx, sellerUser.ID, 30)
 		require.NoError(t, err)
 
-		assert.Equal(t, int64(200000), metrics.TotalRevenue)
+		assert.Equal(t, float64(200000), metrics.TotalRevenue)
 		assert.Equal(t, int64(2), metrics.TotalTransactions)
 	})
 }
@@ -170,14 +170,14 @@ func TestSalesAnalytics_GetTopItems(t *testing.T) {
 		assert.Equal(t, int64(34), items[0].TypeID)
 		assert.Equal(t, "Tritanium", items[0].TypeName)
 		assert.Equal(t, int64(3000), items[0].QuantitySold)
-		assert.Equal(t, int64(40000), items[0].Revenue)
+		assert.Equal(t, float64(40000), items[0].Revenue)
 		assert.Equal(t, int64(2), items[0].TransactionCount)
 
 		// Second item should be Pyerite
 		assert.Equal(t, int64(35), items[1].TypeID)
 		assert.Equal(t, "Pyerite", items[1].TypeName)
 		assert.Equal(t, int64(500), items[1].QuantitySold)
-		assert.Equal(t, int64(10000), items[1].Revenue)
+		assert.Equal(t, float64(10000), items[1].Revenue)
 		assert.Equal(t, int64(1), items[1].TransactionCount)
 	})
 
@@ -273,14 +273,14 @@ func TestSalesAnalytics_GetBuyerAnalytics(t *testing.T) {
 
 		// First buyer should be buyer1 (higher total spent)
 		assert.Equal(t, buyer1.ID, buyers[0].BuyerUserID)
-		assert.Equal(t, int64(200000), buyers[0].TotalSpent)
+		assert.Equal(t, float64(200000), buyers[0].TotalSpent)
 		assert.Equal(t, int64(2), buyers[0].TotalPurchases)
 		assert.Equal(t, int64(150), buyers[0].TotalQuantity)
 		assert.True(t, buyers[0].RepeatCustomer)
 
 		// Second buyer should be buyer2
 		assert.Equal(t, buyer2.ID, buyers[1].BuyerUserID)
-		assert.Equal(t, int64(25000), buyers[1].TotalSpent)
+		assert.Equal(t, float64(25000), buyers[1].TotalSpent)
 		assert.Equal(t, int64(1), buyers[1].TotalPurchases)
 		assert.Equal(t, int64(25), buyers[1].TotalQuantity)
 		assert.False(t, buyers[1].RepeatCustomer)
@@ -370,9 +370,9 @@ func TestSalesAnalytics_GetItemSalesHistory(t *testing.T) {
 		assert.Equal(t, int64(34), item.TypeID)
 		assert.Equal(t, "Tritanium", item.TypeName)
 		assert.Equal(t, int64(3000), item.QuantitySold)
-		assert.Equal(t, int64(34000), item.Revenue)
+		assert.Equal(t, float64(34000), item.Revenue)
 		assert.Equal(t, int64(2), item.TransactionCount)
-		assert.Equal(t, int64(11), item.AveragePricePerUnit) // (10 + 12) / 2 = 11
+		assert.Equal(t, float64(11), item.AveragePricePerUnit) // (10 + 12) / 2 = 11
 	})
 
 	t.Run("Get item sales history for Pyerite", func(t *testing.T) {
@@ -382,9 +382,9 @@ func TestSalesAnalytics_GetItemSalesHistory(t *testing.T) {
 		assert.Equal(t, int64(35), item.TypeID)
 		assert.Equal(t, "Pyerite", item.TypeName)
 		assert.Equal(t, int64(500), item.QuantitySold)
-		assert.Equal(t, int64(10000), item.Revenue)
+		assert.Equal(t, float64(10000), item.Revenue)
 		assert.Equal(t, int64(1), item.TransactionCount)
-		assert.Equal(t, int64(20), item.AveragePricePerUnit)
+		assert.Equal(t, float64(20), item.AveragePricePerUnit)
 	})
 
 	t.Run("Get item sales history for non-existent item", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Migrate price columns (`price_per_unit`, `total_price`, `max_price_per_unit`) from `BIGINT` to `NUMERIC(20,2)` to support cents
- Update Go models from `int64` to `float64` for all price/revenue fields across `ForSaleItem`, `PurchaseTransaction`, `BuyOrder`, and analytics models
- Update Go controllers request structs and total price calculation to use `float64`
- Remove `::BIGINT` cast from AVG queries in sales analytics
- Make the frontend sell order price input preserve decimals (pasting "19090.00" from Janice now works correctly instead of becoming "1,909,000")
- Update buy orders form to use `parseFloat` for max price input

## Test plan
- [x] `make test-backend` — all tests pass
- [x] `make test-frontend` — all 86 tests pass, 13 snapshots match
- [ ] Manual test: paste "19090.00" into sell order price field, verify it shows "19,090" (not "1,909,000")
- [ ] Manual test: enter "19090.50" and verify decimal is preserved through to listing
- [ ] `make test-e2e-ci` — existing marketplace E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)