### PR TITLE
Fix integer overflow when updating large item quantities

### DIFF
--- a/internal/repositories/forSaleItems.go
+++ b/internal/repositories/forSaleItems.go
@@ -256,7 +256,7 @@ func (r *ForSaleItems) UpdateQuantity(ctx context.Context, tx *sql.Tx, itemID in
 	query := `
 		UPDATE for_sale_items
 		SET quantity_available = CASE
-		                           WHEN $2 > 0 THEN $2
+		                           WHEN $2::bigint > 0 THEN $2::bigint
 		                           ELSE quantity_available
 		                         END,
 		    is_active = ($2::bigint > 0),


### PR DESCRIPTION
## Summary
- Fixes `pq: value "2156402191" is out of range for type integer` error when purchasing items with quantities exceeding ~2.1 billion (e.g. Tritanium)
- The `lib/pq` driver infers uncast `$2` parameter as PostgreSQL `integer` (int4) in the `CASE` expression, despite the `quantity_available` column being `bigint`
- Adds explicit `::bigint` casts to the `$2` parameter in `UpdateQuantity`

## Test plan
- [x] `make test-backend` passes
- [ ] Verify large-quantity purchases (>2.1B) no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)