### PR TITLE
Add Jita Sell and Split pricing options to auto-sell containers

### DIFF
--- a/internal/database/migrations/20260219155015_add_price_source_to_auto_sell.down.sql
+++ b/internal/database/migrations/20260219155015_add_price_source_to_auto_sell.down.sql
@@ -1,0 +1,2 @@
+alter table auto_sell_containers
+	drop column price_source;

--- a/internal/database/migrations/20260219155015_add_price_source_to_auto_sell.up.sql
+++ b/internal/database/migrations/20260219155015_add_price_source_to_auto_sell.up.sql
@@ -1,0 +1,2 @@
+alter table auto_sell_containers
+	add column price_source varchar(20) not null default 'jita_buy';

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -152,6 +152,7 @@ type AutoSellContainer struct {
 	ContainerID     int64     `json:"containerId"`
 	DivisionNumber  *int      `json:"divisionNumber"`
 	PricePercentage float64   `json:"pricePercentage"`
+	PriceSource     string    `json:"priceSource"`
 	IsActive        bool      `json:"isActive"`
 	CreatedAt       time.Time `json:"createdAt"`
 	UpdatedAt       time.Time `json:"updatedAt"`


### PR DESCRIPTION
## Summary
- Adds a `price_source` column to `auto_sell_containers` with three options: Jita Buy (best bid), Jita Sell (lowest ask), and Jita Split (buy+sell average)
- Frontend auto-sell dialog now includes a price source dropdown; container chip labels reflect the selected source (JBV/JSV/JSplit)
- Sync logic uses `resolveBasePrice` helper to compute the correct base price per source, with proper nil handling for split when either price is missing

## Test plan
- [x] Backend unit tests pass — 3 new updater tests (sell, split, split-missing-sell) + 3 new controller tests (jita_sell, invalid source, update with source)
- [x] Frontend tests pass (86 tests, 13 snapshots)
- [ ] E2E tests — 3 new Playwright tests added: enable with Jita Sell, switch to Jita Split, disable cleanup

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)