### PR TITLE
Add station/location field to buy orders (#23)

### DIFF
--- a/docs/features/contact-marketplace.md
+++ b/docs/features/contact-marketplace.md
@@ -85,10 +85,12 @@ Complete contact system with granular permissions and extensible industrial serv
 - `id` (PK)
 - `buyer_user_id` (FK → users)
 - `type_id` (FK → asset_item_types)
+- `location_id` (bigint NOT NULL) — station/structure where buyer wants delivery
 - `quantity_desired`, `max_price_per_unit`
 - `notes`, `is_active`
 - Indexes on (buyer_user_id), (type_id), (is_active)
 - CHECK constraint positive quantity and price
+- Location name resolved via LEFT JOIN to `stations` and `solar_systems`
 
 ---
 
@@ -125,9 +127,13 @@ Complete contact system with granular permissions and extensible industrial serv
 - `GET /v1/buy-orders` - Get user's buy orders
 - `GET /v1/buy-orders/demand` - View buy orders from contacts (seller view)
 - `POST /v1/buy-orders` - Create buy order
-  - Body: `{ "typeId": 34, "quantityDesired": 1000, "maxPricePerUnit": 50000, "notes": "Urgent" }`
+  - Body: `{ "typeId": 34, "locationId": 60003760, "quantityDesired": 1000, "maxPricePerUnit": 50000, "notes": "Urgent" }`
 - `PUT /v1/buy-orders/{id}` - Update buy order
+  - Body: `{ "locationId": 60003760, "quantityDesired": 1000, "maxPricePerUnit": 50000, "notes": "Urgent", "isActive": true }`
 - `DELETE /v1/buy-orders/{id}` - Cancel buy order
+
+### Station Search Endpoint
+- `GET /v1/stations/search?q=...` - Search stations by name (partial, case-insensitive)
 
 ### Analytics Endpoints (Phase 6)
 - `GET /v1/analytics/sales` - Sales metrics with time filter

--- a/e2e/tests/08-marketplace.spec.ts
+++ b/e2e/tests/08-marketplace.spec.ts
@@ -119,11 +119,18 @@ test.describe('Marketplace', () => {
     await alicePage.getByRole('button', { name: /Create Buy Order/i }).click();
 
     // Search for item
-    const itemSearch = alicePage.getByPlaceholder(/Start typing/i);
+    const itemSearch = alicePage.getByPlaceholder(/Start typing to search/i);
     await itemSearch.fill('Pyerite');
 
     // Select from autocomplete dropdown (use .first() since full SDE has many Pyerite-related types)
     await alicePage.getByRole('option', { name: /Pyerite/i }).first().click();
+
+    // Search for station
+    const stationSearch = alicePage.getByPlaceholder(/Search for a station/i);
+    await stationSearch.fill('Jita');
+
+    // Select Jita station from autocomplete
+    await alicePage.getByRole('option', { name: /Jita/i }).first().click();
 
     // Fill in quantity and price
     const qtyInput = alicePage.getByLabel(/Quantity Desired/i);
@@ -135,8 +142,9 @@ test.describe('Marketplace', () => {
     // Create the order
     await alicePage.getByRole('button', { name: /Create/i }).click();
 
-    // Verify buy order appears
+    // Verify buy order appears with location
     await expect(alicePage.getByText('Pyerite').first()).toBeVisible({ timeout: 5000 });
+    await expect(alicePage.getByText('Jita').first()).toBeVisible({ timeout: 5000 });
   });
 
   test('can switch between all marketplace tabs', async ({ alicePage }) => {

--- a/frontend/packages/components/marketplace/DemandViewer.tsx
+++ b/frontend/packages/components/marketplace/DemandViewer.tsx
@@ -26,6 +26,8 @@ export type BuyOrder = {
   buyerUserId: number;
   typeId: number;
   typeName: string;
+  locationId: number;
+  locationName: string;
   quantityDesired: number;
   maxPricePerUnit: number;
   notes?: string;
@@ -200,6 +202,7 @@ export default function DemandViewer() {
                     <TableHead>
                       <TableRow>
                         <TableCell>Item</TableCell>
+                        <TableCell>Location</TableCell>
                         <TableCell align="right">Quantity</TableCell>
                         <TableCell align="right">Max Price/Unit</TableCell>
                         <TableCell align="right">Total Budget</TableCell>
@@ -211,6 +214,7 @@ export default function DemandViewer() {
                       {filteredDemand.map((order) => (
                         <TableRow key={order.id}>
                           <TableCell>{order.typeName}</TableCell>
+                          <TableCell>{order.locationName || '-'}</TableCell>
                           <TableCell align="right">{formatNumber(order.quantityDesired)}</TableCell>
                           <TableCell align="right">{formatISK(order.maxPricePerUnit)}</TableCell>
                           <TableCell align="right">

--- a/frontend/pages/api/stations/search.ts
+++ b/frontend/pages/api/stations/search.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method === "GET") {
+    const { q } = req.query;
+    const queryParam = q ? `?q=${encodeURIComponent(q as string)}` : "";
+
+    const response = await fetch(backend + `v1/stations/search${queryParam}`, {
+      method: "GET",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to search stations" });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/internal/controllers/buyOrders.go
+++ b/internal/controllers/buyOrders.go
@@ -71,6 +71,7 @@ func (c *BuyOrdersController) CreateOrder(args *web.HandlerArgs) (any, *web.Http
 
 	var req struct {
 		TypeID          int64   `json:"typeId"`
+		LocationID      int64   `json:"locationId"`
 		QuantityDesired int64   `json:"quantityDesired"`
 		MaxPricePerUnit float64 `json:"maxPricePerUnit"`
 		Notes           *string `json:"notes"`
@@ -92,6 +93,13 @@ func (c *BuyOrdersController) CreateOrder(args *web.HandlerArgs) (any, *web.Http
 		}
 	}
 
+	if req.LocationID == 0 {
+		return nil, &web.HttpError{
+			StatusCode: http.StatusBadRequest,
+			Error:      errors.New("locationId is required"),
+		}
+	}
+
 	if req.QuantityDesired <= 0 {
 		return nil, &web.HttpError{
 			StatusCode: http.StatusBadRequest,
@@ -109,6 +117,7 @@ func (c *BuyOrdersController) CreateOrder(args *web.HandlerArgs) (any, *web.Http
 	order := &models.BuyOrder{
 		BuyerUserID:     *args.User,
 		TypeID:          req.TypeID,
+		LocationID:      req.LocationID,
 		QuantityDesired: req.QuantityDesired,
 		MaxPricePerUnit: req.MaxPricePerUnit,
 		Notes:           req.Notes,
@@ -160,6 +169,7 @@ func (c *BuyOrdersController) UpdateOrder(args *web.HandlerArgs) (any, *web.Http
 	}
 
 	var req struct {
+		LocationID      int64   `json:"locationId"`
 		QuantityDesired int64   `json:"quantityDesired"`
 		MaxPricePerUnit float64 `json:"maxPricePerUnit"`
 		Notes           *string `json:"notes"`
@@ -175,6 +185,13 @@ func (c *BuyOrdersController) UpdateOrder(args *web.HandlerArgs) (any, *web.Http
 	}
 
 	// Validate
+	if req.LocationID == 0 {
+		return nil, &web.HttpError{
+			StatusCode: http.StatusBadRequest,
+			Error:      errors.New("locationId is required"),
+		}
+	}
+
 	if req.QuantityDesired <= 0 {
 		return nil, &web.HttpError{
 			StatusCode: http.StatusBadRequest,
@@ -190,6 +207,7 @@ func (c *BuyOrdersController) UpdateOrder(args *web.HandlerArgs) (any, *web.Http
 	}
 
 	// Update fields
+	order.LocationID = req.LocationID
 	order.QuantityDesired = req.QuantityDesired
 	order.MaxPricePerUnit = req.MaxPricePerUnit
 	order.Notes = req.Notes

--- a/internal/controllers/buyOrders_test.go
+++ b/internal/controllers/buyOrders_test.go
@@ -38,6 +38,7 @@ func Test_BuyOrders_CreateOrder_Success(t *testing.T) {
 
 	reqBody := map[string]interface{}{
 		"typeId":          70,
+		"locationId":      60003760,
 		"quantityDesired": 100000,
 		"maxPricePerUnit": 6,
 	}
@@ -74,6 +75,7 @@ func Test_BuyOrders_CreateOrder_InvalidQuantity(t *testing.T) {
 
 	reqBody := map[string]interface{}{
 		"typeId":          70,
+		"locationId":      60003760,
 		"quantityDesired": -100,
 		"maxPricePerUnit": 6,
 	}
@@ -90,6 +92,36 @@ func Test_BuyOrders_CreateOrder_InvalidQuantity(t *testing.T) {
 	assert.NotNil(t, httpErr)
 	assert.Equal(t, 400, httpErr.StatusCode)
 	assert.Contains(t, httpErr.Error.Error(), "quantityDesired must be positive")
+}
+
+func Test_BuyOrders_CreateOrder_MissingLocationId(t *testing.T) {
+	db, err := setupDatabase()
+	assert.NoError(t, err)
+
+	userID := int64(6011)
+	buyOrdersRepo := repositories.NewBuyOrders(db)
+	permRepo := &MockContactPermissionsRepository{}
+
+	controller := controllers.NewBuyOrders(&MockRouter{}, buyOrdersRepo, permRepo)
+
+	reqBody := map[string]interface{}{
+		"typeId":          70,
+		"quantityDesired": 100,
+		"maxPricePerUnit": 6,
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest("POST", "/v1/buy-orders", bytes.NewReader(body))
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+	}
+
+	result, httpErr := controller.CreateOrder(args)
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+	assert.Contains(t, httpErr.Error.Error(), "locationId is required")
 }
 
 func Test_BuyOrders_GetMyOrders(t *testing.T) {
@@ -117,6 +149,7 @@ func Test_BuyOrders_GetMyOrders(t *testing.T) {
 		order := &models.BuyOrder{
 			BuyerUserID:     userID,
 			TypeID:          71 + int64(i%2),
+			LocationID:      60003760,
 			QuantityDesired: int64(10000 * (i + 1)),
 			MaxPricePerUnit: float64(10 + i),
 			IsActive:        true,
@@ -164,6 +197,7 @@ func Test_BuyOrders_UpdateOrder_Success(t *testing.T) {
 	order := &models.BuyOrder{
 		BuyerUserID:     userID,
 		TypeID:          73,
+		LocationID:      60003760,
 		QuantityDesired: 50000,
 		MaxPricePerUnit: 20,
 		IsActive:        true,
@@ -174,6 +208,7 @@ func Test_BuyOrders_UpdateOrder_Success(t *testing.T) {
 
 	// Update order
 	reqBody := map[string]interface{}{
+		"locationId":      60003760,
 		"quantityDesired": 75000,
 		"maxPricePerUnit": 25,
 	}
@@ -223,6 +258,7 @@ func Test_BuyOrders_UpdateOrder_NotOwner(t *testing.T) {
 	order := &models.BuyOrder{
 		BuyerUserID:     ownerID,
 		TypeID:          74,
+		LocationID:      60003760,
 		QuantityDesired: 25000,
 		MaxPricePerUnit: 30,
 		IsActive:        true,
@@ -233,6 +269,7 @@ func Test_BuyOrders_UpdateOrder_NotOwner(t *testing.T) {
 
 	// Try to update as different user
 	reqBody := map[string]interface{}{
+		"locationId":      60003760,
 		"quantityDesired": 50000,
 		"maxPricePerUnit": 35,
 	}
@@ -275,6 +312,7 @@ func Test_BuyOrders_DeleteOrder_Success(t *testing.T) {
 	order := &models.BuyOrder{
 		BuyerUserID:     userID,
 		TypeID:          75,
+		LocationID:      60003760,
 		QuantityDesired: 15000,
 		MaxPricePerUnit: 40,
 		IsActive:        true,
@@ -357,6 +395,7 @@ func Test_BuyOrders_GetDemand(t *testing.T) {
 		order := &models.BuyOrder{
 			BuyerUserID:     buyerID,
 			TypeID:          76,
+			LocationID:      60003760,
 			QuantityDesired: int64(5000 * (i + 1)),
 			MaxPricePerUnit: float64(50 + i*10),
 			IsActive:        true,

--- a/internal/database/migrations/20260219163012_add_location_to_buy_orders.down.sql
+++ b/internal/database/migrations/20260219163012_add_location_to_buy_orders.down.sql
@@ -1,0 +1,4 @@
+-- Migration: add_location_to_buy_orders
+-- Created: Thu Feb 19 04:30:12 PM PST 2026
+
+alter table buy_orders drop column location_id;

--- a/internal/database/migrations/20260219163012_add_location_to_buy_orders.up.sql
+++ b/internal/database/migrations/20260219163012_add_location_to_buy_orders.up.sql
@@ -1,0 +1,5 @@
+-- Migration: add_location_to_buy_orders
+-- Created: Thu Feb 19 04:30:12 PM PST 2026
+
+delete from buy_orders;
+alter table buy_orders add column location_id bigint not null;

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -188,12 +188,20 @@ type BuyOrder struct {
 	BuyerUserID      int64     `json:"buyerUserId"`
 	TypeID           int64     `json:"typeId"`
 	TypeName         string    `json:"typeName"`
+	LocationID       int64     `json:"locationId"`
+	LocationName     string    `json:"locationName"`
 	QuantityDesired  int64     `json:"quantityDesired"`
 	MaxPricePerUnit  float64   `json:"maxPricePerUnit"`
 	Notes            *string   `json:"notes"`
 	IsActive         bool      `json:"isActive"`
 	CreatedAt        time.Time `json:"createdAt"`
 	UpdatedAt        time.Time `json:"updatedAt"`
+}
+
+type StationSearchResult struct {
+	StationID       int64  `json:"stationId"`
+	Name            string `json:"name"`
+	SolarSystemName string `json:"solarSystemName"`
 }
 
 // Sales Analytics Models

--- a/internal/repositories/buyOrders_test.go
+++ b/internal/repositories/buyOrders_test.go
@@ -33,6 +33,7 @@ func Test_BuyOrders_CreateAndGet(t *testing.T) {
 	order := &models.BuyOrder{
 		BuyerUserID:     5000,
 		TypeID:          60,
+		LocationID:      60003760,
 		QuantityDesired: 100000,
 		MaxPricePerUnit: 50,
 		IsActive:        true,
@@ -82,6 +83,7 @@ func Test_BuyOrders_GetByUser(t *testing.T) {
 		order := &models.BuyOrder{
 			BuyerUserID:     5010,
 			TypeID:          61 + int64(i%2),
+			LocationID:      60003760,
 			QuantityDesired: int64(10000 * (i + 1)),
 			MaxPricePerUnit: float64(50 + i),
 			IsActive:        true,
@@ -127,6 +129,7 @@ func Test_BuyOrders_Update(t *testing.T) {
 	order := &models.BuyOrder{
 		BuyerUserID:     5020,
 		TypeID:          63,
+		LocationID:      60003760,
 		QuantityDesired: 50000,
 		MaxPricePerUnit: 100,
 		IsActive:        true,
@@ -176,6 +179,7 @@ func Test_BuyOrders_Delete(t *testing.T) {
 	order := &models.BuyOrder{
 		BuyerUserID:     5030,
 		TypeID:          64,
+		LocationID:      60003760,
 		QuantityDesired: 25000,
 		MaxPricePerUnit: 150,
 		IsActive:        true,
@@ -253,6 +257,7 @@ func Test_BuyOrders_GetDemandForSeller(t *testing.T) {
 	order1 := &models.BuyOrder{
 		BuyerUserID:     5040,
 		TypeID:          65,
+		LocationID:      60003760,
 		QuantityDesired: 500000,
 		MaxPricePerUnit: 6,
 		IsActive:        true,
@@ -263,6 +268,7 @@ func Test_BuyOrders_GetDemandForSeller(t *testing.T) {
 	order2 := &models.BuyOrder{
 		BuyerUserID:     5040,
 		TypeID:          66,
+		LocationID:      60003760,
 		QuantityDesired: 250000,
 		MaxPricePerUnit: 15,
 		IsActive:        true,
@@ -274,6 +280,7 @@ func Test_BuyOrders_GetDemandForSeller(t *testing.T) {
 	order3 := &models.BuyOrder{
 		BuyerUserID:     5040,
 		TypeID:          65,
+		LocationID:      60003760,
 		QuantityDesired: 100000,
 		MaxPricePerUnit: 10,
 		IsActive:        false,
@@ -313,6 +320,7 @@ func Test_BuyOrders_Update_NotFound(t *testing.T) {
 
 	order := &models.BuyOrder{
 		ID:              999999,
+		LocationID:      60003760,
 		QuantityDesired: 100,
 		MaxPricePerUnit: 50,
 		IsActive:        true,


### PR DESCRIPTION
## Summary
- Adds `location_id` (NOT NULL) column to `buy_orders` table with migration that clears existing rows
- Station search endpoint (`/v1/stations/search`) with name resolution via station/solar system JOINs
- Station autocomplete in buy order create/edit dialog (same debounce pattern as item search)
- Location column displayed in both My Buy Orders and Demand tables

## Changes
- **Migration**: `20260219163012_add_location_to_buy_orders` — deletes existing rows, adds `location_id bigint not null`
- **Model**: `LocationID` and `LocationName` fields on `BuyOrder`, new `StationSearchResult` type
- **Repository**: All buy order queries include `location_id` + LEFT JOINs for name resolution
- **Controller**: `locationId` required in create/update requests, station search handler
- **Frontend**: Station autocomplete component, location column in tables, proxy API route
- **Tests**: All backend tests updated with `LocationID`, new test for missing `locationId` validation
- **E2E**: Buy order creation test includes station selection

## Test plan
- [x] `make test-backend` — all tests pass
- [x] `make test-frontend` — all 86 tests pass
- [ ] `make test-e2e` — E2E buy order test updated with station selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)