### PR TITLE
Remove CI push trigger on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,6 @@
 name: CI
 
 on:
-    push:
-        paths-ignore:
-            - "**/**/*.md"
-            - "docs/**"
-            - ".vscode/**"
-            - ".github/**"
-        branches: [main, master]
     pull_request:
         paths-ignore:
             - "**/**/*.md"


### PR DESCRIPTION
## Summary
- Remove the `push` trigger for `main`/`master` branches from CI workflow
- CI already runs on pull requests before merge, so the duplicate run on push to main wastes Actions minutes

## Test plan
- [x] Verify CI still triggers on pull requests (this PR itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)