### PR TITLE
Speed up E2E CI by removing frontend cache export

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,10 @@
 Dockerfile
+Dockerfile.*
 build
+.git
+.github
+.vscode
+docs
+e2e
+artifacts
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,6 @@ jobs:
                   load: true
                   tags: industry-tool-frontend:latest
                   cache-from: type=gha,scope=e2e-frontend
-                  cache-to: type=gha,mode=max,scope=e2e-frontend
 
             - name: Run E2E tests
               env:


### PR DESCRIPTION
## Summary
- Remove `cache-to` from the frontend Docker image build step in CI — the GHA cache export (`mode=max`) was taking **~11 minutes** to upload all intermediate layers (including ~1.1GB `node_modules`), but only saved ~55s on `yarn install` since `COPY frontend .` invalidates the cache on every PR
- Expand `.dockerignore` to exclude `.git`, `.github`, `.vscode`, `docs`, `e2e`, `artifacts`, and `*.md` files from the Docker build context

## Expected improvement
| Metric | Before | After |
|--------|--------|-------|
| Frontend cache export | ~11 min | 0 |
| **Total E2E job** | **~15.5 min** | **~5 min** |

## Test plan
- [ ] E2E tests still pass in CI
- [ ] Observe E2E job duration drop from ~15min to ~5min

🤖 Generated with [Claude Code](https://claude.com/claude-code)