### PR TITLE
Add auto-buy for understocked stockpiles

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -109,8 +109,13 @@ var rootCmd = &cobra.Command{
 			log.Info("discord notifications disabled (no DISCORD_BOT_TOKEN)")
 		}
 
+		autoBuyConfigsRepository := repositories.NewAutoBuyConfigs(db)
+		autoBuyUpdater := updaters.NewAutoBuy(autoBuyConfigsRepository, buyOrdersRepository, marketPricesRepository)
+
 		assetUpdater.WithAutoSellUpdater(autoSellUpdater)
 		marketPricesUpdater.WithAutoSellUpdater(autoSellUpdater)
+		assetUpdater.WithAutoBuyUpdater(autoBuyUpdater)
+		marketPricesUpdater.WithAutoBuyUpdater(autoBuyUpdater)
 
 		controllers.NewStatic(router, sdeUpdater)
 		controllers.NewCharacters(router, charactersRepository, assetUpdater, esiClient, contactRulesUpdater)
@@ -129,6 +134,7 @@ var rootCmd = &cobra.Command{
 		controllers.NewItemTypes(router, itemTypesRepository)
 		controllers.NewAnalytics(router, salesAnalyticsRepository)
 		controllers.NewAutoSellContainers(router, autoSellContainersRepository, autoSellUpdater, forSaleItemsRepository)
+		controllers.NewAutoBuyConfigs(router, autoBuyConfigsRepository, autoBuyUpdater, buyOrdersRepository)
 		controllers.NewReactions(router, sdeDataRepository, marketPricesRepository, industryCostIndicesRepository)
 		controllers.NewContactRules(router, contactRulesRepository, contactRulesUpdater)
 		if discordClient != nil {

--- a/docs/features/auto-buy.md
+++ b/docs/features/auto-buy.md
@@ -1,0 +1,67 @@
+# Auto-Buy for Understocked Stockpiles
+
+## Overview
+
+Automatically creates and maintains buy orders for stockpile items that are below their desired quantity. Uses Jita market pricing (same options as auto-sell: jita_buy, jita_sell, jita_split) with a configurable percentage.
+
+## Status
+
+- **Phase**: Implementation
+- **Branch**: `feature/auto-buy`
+
+## Key Decisions
+
+1. **Container-level config with per-item override** — An `auto_buy_configs` entry targets a container (same key structure as auto-sell). Individual stockpile markers can override the pricing.
+2. **Mirrors auto-sell pattern** — Same table structure, sync triggers, and pricing logic.
+3. **Buy orders deactivate on filled deficit** — When current quantity >= desired quantity, the linked buy order is deactivated. Reactivated when deficit returns.
+4. **Same trigger points as auto-sell** — After asset refresh (`SyncForUser`) and after market price update (`SyncForAllUsers`).
+
+## Schema
+
+### `auto_buy_configs` (NEW)
+Same shape as `auto_sell_containers`, with nullable `container_id`:
+- `id`, `user_id`, `owner_type`, `owner_id`, `location_id`, `container_id` (nullable), `division_number` (nullable)
+- `price_percentage` (default 100), `price_source` (default 'jita_sell')
+- `is_active`, `created_at`, `updated_at`
+
+### `buy_orders` (MODIFIED)
+- Added `auto_buy_config_id` — links auto-generated orders to the config
+
+### `stockpile_markers` (MODIFIED)
+- Added `price_source`, `price_percentage` — nullable per-item overrides
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/auto-buy` | List user's auto-buy configs |
+| POST | `/v1/auto-buy` | Create config (triggers sync) |
+| PUT | `/v1/auto-buy/{id}` | Update config (triggers sync) |
+| DELETE | `/v1/auto-buy/{id}` | Delete config (deactivates linked orders) |
+
+## Sync Logic
+
+1. Get stockpile markers matching the config's container context
+2. Compare desired quantities with current asset quantities → compute deficits
+3. Look up Jita prices for deficit item types
+4. For each deficit: compute `maxPrice = basePrice * percentage / 100`, upsert buy order
+5. Deactivate buy orders for items no longer in deficit
+
+## File Structure
+
+### Backend
+- `internal/database/migrations/*_auto_buy*` — 3 migration pairs
+- `internal/models/models.go` — AutoBuyConfig model + extensions
+- `internal/repositories/autoBuyConfigs.go` — CRUD + deficit query
+- `internal/repositories/buyOrders.go` — Auto-buy methods added
+- `internal/repositories/stockpileMarkers.go` — Pricing columns added
+- `internal/updaters/autoBuy.go` — Sync logic
+- `internal/updaters/assets.go` — WithAutoBuyUpdater hook
+- `internal/updaters/marketPrices.go` — WithAutoBuyUpdater hook
+- `internal/controllers/autoBuyConfigs.go` — REST endpoints
+- `cmd/industry-tool/cmd/root.go` — Wiring
+
+### Frontend
+- `frontend/pages/api/auto-buy/` — API proxy routes
+- `frontend/packages/components/assets/AssetsList.tsx` — Auto-buy dialog + indicators
+- `frontend/packages/components/marketplace/BuyOrders.tsx` — Auto badge on orders

--- a/frontend/packages/components/assets/__tests__/__snapshots__/AssetsList.test.tsx.snap
+++ b/frontend/packages/components/assets/__tests__/__snapshots__/AssetsList.test.tsx.snap
@@ -256,7 +256,7 @@ exports[`AssetsList Component Multiple Structures should match snapshot with mul
             <input
               aria-invalid="false"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_1i_"
+              id="_r_1p_"
               placeholder="Search items..."
               type="text"
               value=""
@@ -1044,7 +1044,7 @@ exports[`AssetsList Component With Containers should match snapshot with contain
             <input
               aria-invalid="false"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_m_"
+              id="_r_p_"
               placeholder="Search items..."
               type="text"
               value=""
@@ -1398,7 +1398,7 @@ exports[`AssetsList Component With Corporation Hangars should match snapshot wit
             <input
               aria-invalid="false"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_t_"
+              id="_r_11_"
               placeholder="Search items..."
               type="text"
               value=""
@@ -1752,7 +1752,7 @@ exports[`AssetsList Component With Stockpile Markers should match snapshot with 
             <input
               aria-invalid="false"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_14_"
+              id="_r_19_"
               placeholder="Search items..."
               type="text"
               value=""

--- a/frontend/packages/components/marketplace/BuyOrders.tsx
+++ b/frontend/packages/components/marketplace/BuyOrders.tsx
@@ -41,6 +41,7 @@ export type BuyOrder = {
   quantityDesired: number;
   maxPricePerUnit: number;
   notes?: string;
+  autoBuyConfigId?: number;
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
@@ -321,29 +322,48 @@ export default function BuyOrders() {
                           {formatISK(order.quantityDesired * order.maxPricePerUnit)}
                         </TableCell>
                         <TableCell>
-                          <Chip
-                            label={order.isActive ? 'Active' : 'Inactive'}
-                            color={order.isActive ? 'success' : 'default'}
-                            size="small"
-                          />
+                          <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+                            <Chip
+                              label={order.isActive ? 'Active' : 'Inactive'}
+                              color={order.isActive ? 'success' : 'default'}
+                              size="small"
+                            />
+                            {order.autoBuyConfigId && (
+                              <Chip
+                                label="Auto"
+                                size="small"
+                                sx={{
+                                  fontSize: '0.7rem',
+                                  fontWeight: 600,
+                                  background: 'rgba(245, 158, 11, 0.15)',
+                                  color: '#f59e0b',
+                                  border: '1px solid rgba(245, 158, 11, 0.3)',
+                                }}
+                              />
+                            )}
+                          </Box>
                         </TableCell>
                         <TableCell>{order.notes || '-'}</TableCell>
                         <TableCell>{formatDate(order.createdAt)}</TableCell>
                         <TableCell align="right">
-                          <IconButton
-                            size="small"
-                            onClick={() => handleEdit(order)}
-                            title="Edit"
-                          >
-                            <EditIcon />
-                          </IconButton>
-                          <IconButton
-                            size="small"
-                            onClick={() => handleDelete(order.id)}
-                            title="Cancel"
-                          >
-                            <DeleteIcon />
-                          </IconButton>
+                          {!order.autoBuyConfigId && (
+                            <>
+                              <IconButton
+                                size="small"
+                                onClick={() => handleEdit(order)}
+                                title="Edit"
+                              >
+                                <EditIcon />
+                              </IconButton>
+                              <IconButton
+                                size="small"
+                                onClick={() => handleDelete(order.id)}
+                                title="Cancel"
+                              >
+                                <DeleteIcon />
+                              </IconButton>
+                            </>
+                          )}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/frontend/pages/api/auto-buy/[id].ts
+++ b/frontend/pages/api/auto-buy/[id].ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  if (!id || typeof id !== "string") {
+    return res.status(400).json({ error: "Invalid auto-buy config ID" });
+  }
+
+  if (req.method === "PUT") {
+    const response = await fetch(backend + `v1/auto-buy/${id}`, {
+      method: "PUT",
+      headers: getHeaders(session.providerAccountId),
+      body: JSON.stringify(req.body),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to update auto-buy config" });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  if (req.method === "DELETE") {
+    const response = await fetch(backend + `v1/auto-buy/${id}`, {
+      method: "DELETE",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to delete auto-buy config" });
+    }
+
+    return res.status(200).json({ success: true });
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/api/auto-buy/index.ts
+++ b/frontend/pages/api/auto-buy/index.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method === "GET") {
+    const response = await fetch(backend + "v1/auto-buy", {
+      method: "GET",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to get auto-buy configs" });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  if (req.method === "POST") {
+    const response = await fetch(backend + "v1/auto-buy", {
+      method: "POST",
+      headers: getHeaders(session.providerAccountId),
+      body: JSON.stringify(req.body),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to create auto-buy config" });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/internal/controllers/autoBuyConfigs.go
+++ b/internal/controllers/autoBuyConfigs.go
@@ -1,0 +1,222 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/pkg/errors"
+)
+
+type AutoBuyConfigsRepository interface {
+	GetByUser(ctx context.Context, userID int64) ([]*models.AutoBuyConfig, error)
+	Upsert(ctx context.Context, config *models.AutoBuyConfig) error
+	Delete(ctx context.Context, id int64, userID int64) error
+	GetByID(ctx context.Context, id int64) (*models.AutoBuyConfig, error)
+}
+
+type AutoBuyConfigsSyncer interface {
+	SyncForUser(ctx context.Context, userID int64) error
+}
+
+type BuyOrdersDeactivator interface {
+	DeactivateAutoBuyOrders(ctx context.Context, autoBuyConfigID int64) error
+}
+
+type AutoBuyConfigs struct {
+	repository       AutoBuyConfigsRepository
+	syncer           AutoBuyConfigsSyncer
+	buyOrderDeactor  BuyOrdersDeactivator
+}
+
+func NewAutoBuyConfigs(
+	router Routerer,
+	repository AutoBuyConfigsRepository,
+	syncer AutoBuyConfigsSyncer,
+	buyOrderDeactor BuyOrdersDeactivator,
+) *AutoBuyConfigs {
+	controller := &AutoBuyConfigs{
+		repository:      repository,
+		syncer:          syncer,
+		buyOrderDeactor: buyOrderDeactor,
+	}
+
+	router.RegisterRestAPIRoute("/v1/auto-buy", web.AuthAccessUser, controller.GetMyConfigs, "GET")
+	router.RegisterRestAPIRoute("/v1/auto-buy", web.AuthAccessUser, controller.CreateConfig, "POST")
+	router.RegisterRestAPIRoute("/v1/auto-buy/{id}", web.AuthAccessUser, controller.UpdateConfig, "PUT")
+	router.RegisterRestAPIRoute("/v1/auto-buy/{id}", web.AuthAccessUser, controller.DeleteConfig, "DELETE")
+
+	return controller
+}
+
+// GetMyConfigs returns all active auto-buy configs for the authenticated user
+func (c *AutoBuyConfigs) GetMyConfigs(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	items, err := c.repository.GetByUser(args.Request.Context(), *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get auto-buy configs")}
+	}
+
+	return items, nil
+}
+
+// CreateConfig creates a new auto-buy configuration
+func (c *AutoBuyConfigs) CreateConfig(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	var req struct {
+		OwnerType       string  `json:"ownerType"`
+		OwnerID         int64   `json:"ownerId"`
+		LocationID      int64   `json:"locationId"`
+		ContainerID     *int64  `json:"containerId"`
+		DivisionNumber  *int    `json:"divisionNumber"`
+		PricePercentage float64 `json:"pricePercentage"`
+		PriceSource     string  `json:"priceSource"`
+	}
+
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if req.OwnerType == "" {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("ownerType is required")}
+	}
+	if req.OwnerID == 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("ownerId is required")}
+	}
+	if req.LocationID == 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("locationId is required")}
+	}
+	if req.PricePercentage <= 0 || req.PricePercentage > 200 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("pricePercentage must be between 0 and 200")}
+	}
+
+	if req.PriceSource == "" {
+		req.PriceSource = "jita_sell"
+	}
+	if !allowedPriceSources[req.PriceSource] {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Errorf("invalid priceSource: %s", req.PriceSource)}
+	}
+
+	config := &models.AutoBuyConfig{
+		UserID:          *args.User,
+		OwnerType:       req.OwnerType,
+		OwnerID:         req.OwnerID,
+		LocationID:      req.LocationID,
+		ContainerID:     req.ContainerID,
+		DivisionNumber:  req.DivisionNumber,
+		PricePercentage: req.PricePercentage,
+		PriceSource:     req.PriceSource,
+	}
+
+	if err := c.repository.Upsert(args.Request.Context(), config); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to create auto-buy config")}
+	}
+
+	// Trigger immediate sync
+	go func() {
+		ctx := context.Background()
+		_ = c.syncer.SyncForUser(ctx, config.UserID)
+	}()
+
+	return config, nil
+}
+
+// UpdateConfig updates an existing auto-buy configuration
+func (c *AutoBuyConfigs) UpdateConfig(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	idStr, ok := args.Params["id"]
+	if !ok {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("id is required")}
+	}
+
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("invalid id")}
+	}
+
+	existing, err := c.repository.GetByID(args.Request.Context(), id)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get auto-buy config")}
+	}
+	if existing == nil {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.New("auto-buy config not found")}
+	}
+	if existing.UserID != *args.User {
+		return nil, &web.HttpError{StatusCode: 403, Error: errors.New("not authorized to update this config")}
+	}
+
+	var req struct {
+		PricePercentage float64 `json:"pricePercentage"`
+		PriceSource     string  `json:"priceSource"`
+	}
+
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if req.PricePercentage <= 0 || req.PricePercentage > 200 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("pricePercentage must be between 0 and 200")}
+	}
+
+	if req.PriceSource != "" {
+		if !allowedPriceSources[req.PriceSource] {
+			return nil, &web.HttpError{StatusCode: 400, Error: errors.Errorf("invalid priceSource: %s", req.PriceSource)}
+		}
+		existing.PriceSource = req.PriceSource
+	}
+
+	existing.PricePercentage = req.PricePercentage
+	if err := c.repository.Upsert(args.Request.Context(), existing); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to update auto-buy config")}
+	}
+
+	// Trigger immediate sync
+	go func() {
+		ctx := context.Background()
+		_ = c.syncer.SyncForUser(ctx, existing.UserID)
+	}()
+
+	return existing, nil
+}
+
+// DeleteConfig soft-deletes an auto-buy config and deactivates all associated buy orders
+func (c *AutoBuyConfigs) DeleteConfig(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	idStr, ok := args.Params["id"]
+	if !ok {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("id is required")}
+	}
+
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("invalid id")}
+	}
+
+	// Deactivate all associated buy orders first
+	if err := c.buyOrderDeactor.DeactivateAutoBuyOrders(args.Request.Context(), id); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to deactivate auto-buy orders")}
+	}
+
+	if err := c.repository.Delete(args.Request.Context(), id, *args.User); err != nil {
+		if err.Error() == "auto-buy config not found or user is not the owner" {
+			return nil, &web.HttpError{StatusCode: 404, Error: err}
+		}
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to delete auto-buy config")}
+	}
+
+	return nil, nil
+}

--- a/internal/controllers/autoBuyConfigs_test.go
+++ b/internal/controllers/autoBuyConfigs_test.go
@@ -1,0 +1,777 @@
+package controllers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/controllers"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// Mock AutoBuyConfigsRepository
+type MockAutoBuyConfigsRepository struct {
+	mock.Mock
+}
+
+func (m *MockAutoBuyConfigsRepository) GetByUser(ctx context.Context, userID int64) ([]*models.AutoBuyConfig, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.AutoBuyConfig), args.Error(1)
+}
+
+func (m *MockAutoBuyConfigsRepository) Upsert(ctx context.Context, config *models.AutoBuyConfig) error {
+	args := m.Called(ctx, config)
+	return args.Error(0)
+}
+
+func (m *MockAutoBuyConfigsRepository) Delete(ctx context.Context, id int64, userID int64) error {
+	args := m.Called(ctx, id, userID)
+	return args.Error(0)
+}
+
+func (m *MockAutoBuyConfigsRepository) GetByID(ctx context.Context, id int64) (*models.AutoBuyConfig, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AutoBuyConfig), args.Error(1)
+}
+
+// Mock AutoBuyConfigsSyncer
+type MockAutoBuyConfigsSyncer struct {
+	mock.Mock
+}
+
+func (m *MockAutoBuyConfigsSyncer) SyncForUser(ctx context.Context, userID int64) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+// Mock BuyOrdersDeactivator
+type MockBuyOrdersDeactivator struct {
+	mock.Mock
+}
+
+func (m *MockBuyOrdersDeactivator) DeactivateAutoBuyOrders(ctx context.Context, autoBuyConfigID int64) error {
+	args := m.Called(ctx, autoBuyConfigID)
+	return args.Error(0)
+}
+
+// --- GetMyConfigs Tests ---
+
+func Test_AutoBuyConfigsController_GetMyConfigs_Success(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	containerID := int64(9000)
+	expectedItems := []*models.AutoBuyConfig{
+		{
+			ID:              1,
+			UserID:          userID,
+			OwnerType:       "character",
+			OwnerID:         456,
+			LocationID:      60003760,
+			ContainerID:     &containerID,
+			PricePercentage: 90.0,
+			PriceSource:     "jita_sell",
+			IsActive:        true,
+		},
+	}
+
+	mockRepo.On("GetByUser", mock.Anything, userID).Return(expectedItems, nil)
+
+	req := httptest.NewRequest("GET", "/v1/auto-buy", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.GetMyConfigs(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	items := result.([]*models.AutoBuyConfig)
+	assert.Len(t, items, 1)
+	assert.Equal(t, 90.0, items[0].PricePercentage)
+	assert.Equal(t, int64(9000), *items[0].ContainerID)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_AutoBuyConfigsController_GetMyConfigs_Unauthorized(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	req := httptest.NewRequest("GET", "/v1/auto-buy", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    nil,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.GetMyConfigs(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 401, httpErr.StatusCode)
+}
+
+func Test_AutoBuyConfigsController_GetMyConfigs_RepositoryError(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	mockRepo.On("GetByUser", mock.Anything, userID).Return(nil, errors.New("database error"))
+
+	req := httptest.NewRequest("GET", "/v1/auto-buy", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.GetMyConfigs(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 500, httpErr.StatusCode)
+
+	mockRepo.AssertExpectations(t)
+}
+
+// --- CreateConfig Tests ---
+
+func Test_AutoBuyConfigsController_CreateConfig_Success_Defaults(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	mockRepo.On("Upsert", mock.Anything, mock.MatchedBy(func(c *models.AutoBuyConfig) bool {
+		return c.UserID == userID &&
+			c.OwnerType == "character" &&
+			c.OwnerID == 456 &&
+			c.LocationID == 60003760 &&
+			c.ContainerID == nil &&
+			c.PricePercentage == 90.0 &&
+			c.PriceSource == "jita_sell"
+	})).Return(nil)
+
+	// The sync is triggered asynchronously, so we use mock.Anything for context
+	mockSyncer.On("SyncForUser", mock.Anything, userID).Return(nil)
+
+	// No priceSource or containerId sent — should default to "jita_sell" and nil container
+	body := map[string]interface{}{
+		"ownerType":       "character",
+		"ownerId":         456,
+		"locationId":      60003760,
+		"pricePercentage": 90.0,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/auto-buy", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.CreateConfig(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_AutoBuyConfigsController_CreateConfig_Success_WithContainerID(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	mockRepo.On("Upsert", mock.Anything, mock.MatchedBy(func(c *models.AutoBuyConfig) bool {
+		return c.UserID == userID &&
+			c.OwnerType == "character" &&
+			c.OwnerID == 456 &&
+			c.LocationID == 60003760 &&
+			c.ContainerID != nil && *c.ContainerID == 9000 &&
+			c.PricePercentage == 90.0 &&
+			c.PriceSource == "jita_sell"
+	})).Return(nil)
+
+	mockSyncer.On("SyncForUser", mock.Anything, userID).Return(nil)
+
+	body := map[string]interface{}{
+		"ownerType":       "character",
+		"ownerId":         456,
+		"locationId":      60003760,
+		"containerId":     9000,
+		"pricePercentage": 90.0,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/auto-buy", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.CreateConfig(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_AutoBuyConfigsController_CreateConfig_InvalidJSON(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	req := httptest.NewRequest("POST", "/v1/auto-buy", bytes.NewReader([]byte("invalid json")))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.CreateConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_AutoBuyConfigsController_CreateConfig_MissingOwnerType(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	body := map[string]interface{}{
+		"ownerId":         456,
+		"locationId":      60003760,
+		"pricePercentage": 90.0,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/auto-buy", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.CreateConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+	assert.Contains(t, httpErr.Error.Error(), "ownerType is required")
+}
+
+func Test_AutoBuyConfigsController_CreateConfig_InvalidPercentage(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	body := map[string]interface{}{
+		"ownerType":       "character",
+		"ownerId":         456,
+		"locationId":      60003760,
+		"pricePercentage": 250.0, // Over 200
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/auto-buy", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.CreateConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+	assert.Contains(t, httpErr.Error.Error(), "pricePercentage must be between 0 and 200")
+}
+
+func Test_AutoBuyConfigsController_CreateConfig_Unauthorized(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	req := httptest.NewRequest("POST", "/v1/auto-buy", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    nil,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.CreateConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 401, httpErr.StatusCode)
+}
+
+func Test_AutoBuyConfigsController_CreateConfig_WithJitaBuy(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	mockRepo.On("Upsert", mock.Anything, mock.MatchedBy(func(c *models.AutoBuyConfig) bool {
+		return c.PriceSource == "jita_buy" && c.PricePercentage == 95.0
+	})).Return(nil)
+
+	mockSyncer.On("SyncForUser", mock.Anything, userID).Return(nil)
+
+	body := map[string]interface{}{
+		"ownerType":       "character",
+		"ownerId":         456,
+		"locationId":      60003760,
+		"pricePercentage": 95.0,
+		"priceSource":     "jita_buy",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/auto-buy", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.CreateConfig(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_AutoBuyConfigsController_CreateConfig_InvalidPriceSource(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	body := map[string]interface{}{
+		"ownerType":       "character",
+		"ownerId":         456,
+		"locationId":      60003760,
+		"pricePercentage": 90.0,
+		"priceSource":     "invalid_source",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/auto-buy", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.CreateConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+	assert.Contains(t, httpErr.Error.Error(), "invalid priceSource")
+}
+
+// --- UpdateConfig Tests ---
+
+func Test_AutoBuyConfigsController_UpdateConfig_Success(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	configID := int64(1)
+
+	existingConfig := &models.AutoBuyConfig{
+		ID:              configID,
+		UserID:          userID,
+		OwnerType:       "character",
+		OwnerID:         456,
+		LocationID:      60003760,
+		ContainerID:     nil,
+		PricePercentage: 90.0,
+		PriceSource:     "jita_sell",
+		IsActive:        true,
+	}
+
+	mockRepo.On("GetByID", mock.Anything, configID).Return(existingConfig, nil)
+	mockRepo.On("Upsert", mock.Anything, mock.MatchedBy(func(c *models.AutoBuyConfig) bool {
+		return c.ID == configID && c.PricePercentage == 85.0 && c.PriceSource == "jita_buy"
+	})).Return(nil)
+	mockSyncer.On("SyncForUser", mock.Anything, userID).Return(nil)
+
+	body := map[string]interface{}{
+		"pricePercentage": 85.0,
+		"priceSource":     "jita_buy",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/auto-buy/1", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.UpdateConfig(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_AutoBuyConfigsController_UpdateConfig_NotFound(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	mockRepo.On("GetByID", mock.Anything, int64(999)).Return(nil, nil)
+
+	body := map[string]interface{}{
+		"pricePercentage": 85.0,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/auto-buy/999", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "999"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.UpdateConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_AutoBuyConfigsController_UpdateConfig_NotOwner(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	otherUserID := int64(999)
+
+	existingConfig := &models.AutoBuyConfig{
+		ID:              1,
+		UserID:          otherUserID, // Different owner
+		OwnerType:       "character",
+		OwnerID:         456,
+		PricePercentage: 90.0,
+	}
+
+	mockRepo.On("GetByID", mock.Anything, int64(1)).Return(existingConfig, nil)
+
+	body := map[string]interface{}{
+		"pricePercentage": 85.0,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/auto-buy/1", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.UpdateConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 403, httpErr.StatusCode)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_AutoBuyConfigsController_UpdateConfig_InvalidID(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	req := httptest.NewRequest("PUT", "/v1/auto-buy/invalid", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "invalid"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.UpdateConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_AutoBuyConfigsController_UpdateConfig_InvalidPercentage(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	existingConfig := &models.AutoBuyConfig{
+		ID:              1,
+		UserID:          userID,
+		OwnerType:       "character",
+		OwnerID:         456,
+		PricePercentage: 90.0,
+	}
+
+	mockRepo.On("GetByID", mock.Anything, int64(1)).Return(existingConfig, nil)
+
+	body := map[string]interface{}{
+		"pricePercentage": 0, // Invalid: must be > 0
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/auto-buy/1", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.UpdateConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+	assert.Contains(t, httpErr.Error.Error(), "pricePercentage must be between 0 and 200")
+
+	mockRepo.AssertExpectations(t)
+}
+
+// --- DeleteConfig Tests ---
+
+func Test_AutoBuyConfigsController_DeleteConfig_Success(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	configID := int64(1)
+
+	mockDeactivator.On("DeactivateAutoBuyOrders", mock.Anything, configID).Return(nil)
+	mockRepo.On("Delete", mock.Anything, configID, userID).Return(nil)
+
+	req := httptest.NewRequest("DELETE", "/v1/auto-buy/1", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.DeleteConfig(args)
+
+	assert.Nil(t, httpErr)
+	assert.Nil(t, result)
+
+	mockRepo.AssertExpectations(t)
+	mockDeactivator.AssertExpectations(t)
+}
+
+func Test_AutoBuyConfigsController_DeleteConfig_NotFound(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	configID := int64(999)
+
+	mockDeactivator.On("DeactivateAutoBuyOrders", mock.Anything, configID).Return(nil)
+	mockRepo.On("Delete", mock.Anything, configID, userID).Return(errors.New("auto-buy config not found or user is not the owner"))
+
+	req := httptest.NewRequest("DELETE", "/v1/auto-buy/999", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "999"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.DeleteConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_AutoBuyConfigsController_DeleteConfig_InvalidID(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	req := httptest.NewRequest("DELETE", "/v1/auto-buy/invalid", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "invalid"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.DeleteConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_AutoBuyConfigsController_DeleteConfig_Unauthorized(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	req := httptest.NewRequest("DELETE", "/v1/auto-buy/1", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    nil,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.DeleteConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 401, httpErr.StatusCode)
+}
+
+func Test_AutoBuyConfigsController_DeleteConfig_DeactivationError(t *testing.T) {
+	mockRepo := new(MockAutoBuyConfigsRepository)
+	mockSyncer := new(MockAutoBuyConfigsSyncer)
+	mockDeactivator := new(MockBuyOrdersDeactivator)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	configID := int64(1)
+
+	mockDeactivator.On("DeactivateAutoBuyOrders", mock.Anything, configID).Return(errors.New("deactivation failed"))
+
+	req := httptest.NewRequest("DELETE", "/v1/auto-buy/1", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewAutoBuyConfigs(mockRouter, mockRepo, mockSyncer, mockDeactivator)
+	result, httpErr := controller.DeleteConfig(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 500, httpErr.StatusCode)
+
+	mockDeactivator.AssertExpectations(t)
+}

--- a/internal/database/migrations/20260219200824_auto_buy_configs.down.sql
+++ b/internal/database/migrations/20260219200824_auto_buy_configs.down.sql
@@ -1,0 +1,1 @@
+drop table if exists auto_buy_configs;

--- a/internal/database/migrations/20260219200824_auto_buy_configs.up.sql
+++ b/internal/database/migrations/20260219200824_auto_buy_configs.up.sql
@@ -1,0 +1,21 @@
+create table auto_buy_configs (
+	id bigserial primary key,
+	user_id bigint not null references users(id),
+	owner_type varchar(20) not null,
+	owner_id bigint not null,
+	location_id bigint not null,
+	container_id bigint,
+	division_number int,
+	price_percentage numeric(5, 2) not null default 100.00,
+	price_source varchar(20) not null default 'jita_sell',
+	is_active boolean not null default true,
+	created_at timestamp not null default now(),
+	updated_at timestamp not null default now()
+);
+
+create unique index idx_auto_buy_unique_active on auto_buy_configs(
+	user_id, owner_type, owner_id, location_id,
+	coalesce(container_id, 0), coalesce(division_number, 0)
+) where is_active = true;
+
+create index idx_auto_buy_user on auto_buy_configs(user_id);

--- a/internal/database/migrations/20260219200829_add_auto_buy_to_buy_orders.down.sql
+++ b/internal/database/migrations/20260219200829_add_auto_buy_to_buy_orders.down.sql
@@ -1,0 +1,2 @@
+drop index if exists idx_buy_orders_auto_buy_unique;
+alter table buy_orders drop column if exists auto_buy_config_id;

--- a/internal/database/migrations/20260219200829_add_auto_buy_to_buy_orders.up.sql
+++ b/internal/database/migrations/20260219200829_add_auto_buy_to_buy_orders.up.sql
@@ -1,0 +1,5 @@
+alter table buy_orders add column auto_buy_config_id bigint references auto_buy_configs(id);
+
+create unique index idx_buy_orders_auto_buy_unique on buy_orders(
+	buyer_user_id, type_id, location_id, auto_buy_config_id
+) where auto_buy_config_id is not null and is_active = true;

--- a/internal/database/migrations/20260219200835_add_pricing_to_stockpile_markers.down.sql
+++ b/internal/database/migrations/20260219200835_add_pricing_to_stockpile_markers.down.sql
@@ -1,0 +1,3 @@
+alter table stockpile_markers
+	drop column if exists price_source,
+	drop column if exists price_percentage;

--- a/internal/database/migrations/20260219200835_add_pricing_to_stockpile_markers.up.sql
+++ b/internal/database/migrations/20260219200835_add_pricing_to_stockpile_markers.up.sql
@@ -1,0 +1,3 @@
+alter table stockpile_markers
+	add column price_source varchar(20),
+	add column price_percentage numeric(5, 2);

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -69,15 +69,17 @@ type CorporationDivisions struct {
 }
 
 type StockpileMarker struct {
-	UserID          int64   `json:"userId"`
-	TypeID          int64   `json:"typeId"`
-	OwnerType       string  `json:"ownerType"`
-	OwnerID         int64   `json:"ownerId"`
-	LocationID      int64   `json:"locationId"`
-	ContainerID     *int64  `json:"containerId"`
-	DivisionNumber  *int    `json:"divisionNumber"`
-	DesiredQuantity int64   `json:"desiredQuantity"`
-	Notes           *string `json:"notes"`
+	UserID          int64    `json:"userId"`
+	TypeID          int64    `json:"typeId"`
+	OwnerType       string   `json:"ownerType"`
+	OwnerID         int64    `json:"ownerId"`
+	LocationID      int64    `json:"locationId"`
+	ContainerID     *int64   `json:"containerId"`
+	DivisionNumber  *int     `json:"divisionNumber"`
+	DesiredQuantity int64    `json:"desiredQuantity"`
+	Notes           *string  `json:"notes"`
+	PriceSource     *string  `json:"priceSource"`
+	PricePercentage *float64 `json:"pricePercentage"`
 }
 
 type MarketPrice struct {
@@ -184,18 +186,43 @@ type PurchaseTransaction struct {
 }
 
 type BuyOrder struct {
-	ID               int64     `json:"id"`
-	BuyerUserID      int64     `json:"buyerUserId"`
-	TypeID           int64     `json:"typeId"`
-	TypeName         string    `json:"typeName"`
-	LocationID       int64     `json:"locationId"`
-	LocationName     string    `json:"locationName"`
-	QuantityDesired  int64     `json:"quantityDesired"`
-	MaxPricePerUnit  float64   `json:"maxPricePerUnit"`
-	Notes            *string   `json:"notes"`
-	IsActive         bool      `json:"isActive"`
-	CreatedAt        time.Time `json:"createdAt"`
-	UpdatedAt        time.Time `json:"updatedAt"`
+	ID              int64     `json:"id"`
+	BuyerUserID     int64     `json:"buyerUserId"`
+	TypeID          int64     `json:"typeId"`
+	TypeName        string    `json:"typeName"`
+	LocationID      int64     `json:"locationId"`
+	LocationName    string    `json:"locationName"`
+	QuantityDesired int64     `json:"quantityDesired"`
+	MaxPricePerUnit float64   `json:"maxPricePerUnit"`
+	Notes           *string   `json:"notes"`
+	AutoBuyConfigID *int64    `json:"autoBuyConfigId"`
+	IsActive        bool      `json:"isActive"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+}
+
+type AutoBuyConfig struct {
+	ID              int64     `json:"id"`
+	UserID          int64     `json:"userId"`
+	OwnerType       string    `json:"ownerType"`
+	OwnerID         int64     `json:"ownerId"`
+	LocationID      int64     `json:"locationId"`
+	ContainerID     *int64    `json:"containerId"`
+	DivisionNumber  *int      `json:"divisionNumber"`
+	PricePercentage float64   `json:"pricePercentage"`
+	PriceSource     string    `json:"priceSource"`
+	IsActive        bool      `json:"isActive"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+}
+
+type StockpileDeficitItem struct {
+	TypeID          int64
+	DesiredQuantity int64
+	CurrentQuantity int64
+	Deficit         int64
+	PriceSource     *string
+	PricePercentage *float64
 }
 
 type StationSearchResult struct {

--- a/internal/repositories/autoBuyConfigs.go
+++ b/internal/repositories/autoBuyConfigs.go
@@ -1,0 +1,312 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/pkg/errors"
+)
+
+type AutoBuyConfigs struct {
+	db *sql.DB
+}
+
+func NewAutoBuyConfigs(db *sql.DB) *AutoBuyConfigs {
+	return &AutoBuyConfigs{db: db}
+}
+
+// GetByUser returns all active auto-buy configs for a user
+func (r *AutoBuyConfigs) GetByUser(ctx context.Context, userID int64) ([]*models.AutoBuyConfig, error) {
+	query := `
+		SELECT id, user_id, owner_type, owner_id, location_id, container_id,
+			division_number, price_percentage, price_source, is_active, created_at, updated_at
+		FROM auto_buy_configs
+		WHERE user_id = $1 AND is_active = true
+		ORDER BY created_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query auto-buy configs")
+	}
+	defer rows.Close()
+
+	items := []*models.AutoBuyConfig{}
+	for rows.Next() {
+		var item models.AutoBuyConfig
+		err = rows.Scan(
+			&item.ID, &item.UserID, &item.OwnerType, &item.OwnerID,
+			&item.LocationID, &item.ContainerID, &item.DivisionNumber,
+			&item.PricePercentage, &item.PriceSource, &item.IsActive, &item.CreatedAt, &item.UpdatedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan auto-buy config")
+		}
+		items = append(items, &item)
+	}
+
+	return items, nil
+}
+
+// GetAllActive returns all active auto-buy configs across all users
+func (r *AutoBuyConfigs) GetAllActive(ctx context.Context) ([]*models.AutoBuyConfig, error) {
+	query := `
+		SELECT id, user_id, owner_type, owner_id, location_id, container_id,
+			division_number, price_percentage, price_source, is_active, created_at, updated_at
+		FROM auto_buy_configs
+		WHERE is_active = true
+	`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query all active auto-buy configs")
+	}
+	defer rows.Close()
+
+	items := []*models.AutoBuyConfig{}
+	for rows.Next() {
+		var item models.AutoBuyConfig
+		err = rows.Scan(
+			&item.ID, &item.UserID, &item.OwnerType, &item.OwnerID,
+			&item.LocationID, &item.ContainerID, &item.DivisionNumber,
+			&item.PricePercentage, &item.PriceSource, &item.IsActive, &item.CreatedAt, &item.UpdatedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan auto-buy config")
+		}
+		items = append(items, &item)
+	}
+
+	return items, nil
+}
+
+// Upsert creates or updates an auto-buy config
+func (r *AutoBuyConfigs) Upsert(ctx context.Context, config *models.AutoBuyConfig) error {
+	query := `
+		INSERT INTO auto_buy_configs
+		(user_id, owner_type, owner_id, location_id, container_id, division_number, price_percentage, price_source, is_active, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, NOW())
+		ON CONFLICT (user_id, owner_type, owner_id, location_id, coalesce(container_id, 0), coalesce(division_number, 0))
+		WHERE is_active = true
+		DO UPDATE SET
+			price_percentage = EXCLUDED.price_percentage,
+			price_source = EXCLUDED.price_source,
+			updated_at = NOW()
+		RETURNING id, is_active, created_at, updated_at
+	`
+
+	err := r.db.QueryRowContext(ctx, query,
+		config.UserID,
+		config.OwnerType,
+		config.OwnerID,
+		config.LocationID,
+		config.ContainerID,
+		config.DivisionNumber,
+		config.PricePercentage,
+		config.PriceSource,
+	).Scan(&config.ID, &config.IsActive, &config.CreatedAt, &config.UpdatedAt)
+
+	if err != nil {
+		return errors.Wrap(err, "failed to upsert auto-buy config")
+	}
+
+	return nil
+}
+
+// Delete soft-deletes an auto-buy config
+func (r *AutoBuyConfigs) Delete(ctx context.Context, id int64, userID int64) error {
+	query := `
+		UPDATE auto_buy_configs
+		SET is_active = false, updated_at = NOW()
+		WHERE id = $1 AND user_id = $2 AND is_active = true
+	`
+
+	result, err := r.db.ExecContext(ctx, query, id, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete auto-buy config")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("auto-buy config not found or user is not the owner")
+	}
+
+	return nil
+}
+
+// GetByID returns a single auto-buy config by ID
+func (r *AutoBuyConfigs) GetByID(ctx context.Context, id int64) (*models.AutoBuyConfig, error) {
+	query := `
+		SELECT id, user_id, owner_type, owner_id, location_id, container_id,
+			division_number, price_percentage, price_source, is_active, created_at, updated_at
+		FROM auto_buy_configs
+		WHERE id = $1
+	`
+
+	var item models.AutoBuyConfig
+	err := r.db.QueryRowContext(ctx, query, id).Scan(
+		&item.ID, &item.UserID, &item.OwnerType, &item.OwnerID,
+		&item.LocationID, &item.ContainerID, &item.DivisionNumber,
+		&item.PricePercentage, &item.PriceSource, &item.IsActive, &item.CreatedAt, &item.UpdatedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get auto-buy config")
+	}
+
+	return &item, nil
+}
+
+// GetStockpileDeficitsForConfig returns stockpile deficits for items matching the config's container context.
+// It joins stockpile_markers with asset tables to compute current quantities and deficits.
+func (r *AutoBuyConfigs) GetStockpileDeficitsForConfig(ctx context.Context, config *models.AutoBuyConfig) ([]*models.StockpileDeficitItem, error) {
+	var query string
+
+	if config.ContainerID != nil {
+		// Items in a specific container
+		if config.OwnerType == "character" {
+			query = `
+				SELECT
+					sm.type_id,
+					sm.desired_quantity,
+					COALESCE(SUM(ca.quantity), 0) AS current_quantity,
+					sm.desired_quantity - COALESCE(SUM(ca.quantity), 0) AS deficit,
+					sm.price_source,
+					sm.price_percentage
+				FROM stockpile_markers sm
+				LEFT JOIN character_assets ca
+					ON ca.type_id = sm.type_id
+					AND ca.character_id = sm.owner_id
+					AND ca.location_id = $5
+					AND ca.location_type = 'item'
+				WHERE sm.user_id = $1
+					AND sm.owner_type = $2
+					AND sm.owner_id = $3
+					AND sm.location_id = $4
+					AND COALESCE(sm.container_id, 0) = COALESCE($5, 0)
+					AND COALESCE(sm.division_number, 0) = COALESCE($6, 0)
+				GROUP BY sm.type_id, sm.desired_quantity, sm.price_source, sm.price_percentage
+			`
+		} else {
+			query = `
+				SELECT
+					sm.type_id,
+					sm.desired_quantity,
+					COALESCE(SUM(ca.quantity), 0) AS current_quantity,
+					sm.desired_quantity - COALESCE(SUM(ca.quantity), 0) AS deficit,
+					sm.price_source,
+					sm.price_percentage
+				FROM stockpile_markers sm
+				LEFT JOIN corporation_assets ca
+					ON ca.type_id = sm.type_id
+					AND ca.corporation_id = sm.owner_id
+					AND ca.location_id = $5
+					AND ca.location_type = 'item'
+				WHERE sm.user_id = $1
+					AND sm.owner_type = $2
+					AND sm.owner_id = $3
+					AND sm.location_id = $4
+					AND COALESCE(sm.container_id, 0) = COALESCE($5, 0)
+					AND COALESCE(sm.division_number, 0) = COALESCE($6, 0)
+				GROUP BY sm.type_id, sm.desired_quantity, sm.price_source, sm.price_percentage
+			`
+		}
+	} else {
+		// Items in hangar (no container)
+		if config.OwnerType == "character" {
+			query = `
+				SELECT
+					sm.type_id,
+					sm.desired_quantity,
+					COALESCE(SUM(ca.quantity), 0) AS current_quantity,
+					sm.desired_quantity - COALESCE(SUM(ca.quantity), 0) AS deficit,
+					sm.price_source,
+					sm.price_percentage
+				FROM stockpile_markers sm
+				LEFT JOIN character_assets ca
+					ON ca.type_id = sm.type_id
+					AND ca.character_id = sm.owner_id
+					AND ca.location_id = $4
+					AND ca.location_type = 'other'
+					AND ca.location_flag = 'Hangar'
+				WHERE sm.user_id = $1
+					AND sm.owner_type = $2
+					AND sm.owner_id = $3
+					AND sm.location_id = $4
+					AND sm.container_id IS NULL
+					AND COALESCE(sm.division_number, 0) = COALESCE($5, 0)
+				GROUP BY sm.type_id, sm.desired_quantity, sm.price_source, sm.price_percentage
+			`
+		} else {
+			query = `
+				SELECT
+					sm.type_id,
+					sm.desired_quantity,
+					COALESCE(SUM(ca.quantity), 0) AS current_quantity,
+					sm.desired_quantity - COALESCE(SUM(ca.quantity), 0) AS deficit,
+					sm.price_source,
+					sm.price_percentage
+				FROM stockpile_markers sm
+				LEFT JOIN corporation_assets ca
+					ON ca.type_id = sm.type_id
+					AND ca.corporation_id = sm.owner_id
+					AND ca.location_id = $4
+					AND ca.location_type = 'other'
+				WHERE sm.user_id = $1
+					AND sm.owner_type = $2
+					AND sm.owner_id = $3
+					AND sm.location_id = $4
+					AND sm.container_id IS NULL
+					AND COALESCE(sm.division_number, 0) = COALESCE($5, 0)
+				GROUP BY sm.type_id, sm.desired_quantity, sm.price_source, sm.price_percentage
+			`
+		}
+	}
+
+	var rows *sql.Rows
+	var err error
+
+	if config.ContainerID != nil {
+		rows, err = r.db.QueryContext(ctx, query,
+			config.UserID, config.OwnerType, config.OwnerID,
+			config.LocationID, config.ContainerID, config.DivisionNumber,
+		)
+	} else {
+		rows, err = r.db.QueryContext(ctx, query,
+			config.UserID, config.OwnerType, config.OwnerID,
+			config.LocationID, config.DivisionNumber,
+		)
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query stockpile deficits for config")
+	}
+	defer rows.Close()
+
+	items := []*models.StockpileDeficitItem{}
+	for rows.Next() {
+		var item models.StockpileDeficitItem
+		err = rows.Scan(
+			&item.TypeID,
+			&item.DesiredQuantity,
+			&item.CurrentQuantity,
+			&item.Deficit,
+			&item.PriceSource,
+			&item.PricePercentage,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan stockpile deficit item")
+		}
+		items = append(items, &item)
+	}
+
+	return items, nil
+}

--- a/internal/updaters/autoBuy.go
+++ b/internal/updaters/autoBuy.go
@@ -1,0 +1,198 @@
+package updaters
+
+import (
+	"context"
+
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/pkg/errors"
+)
+
+type AutoBuyConfigsRepository interface {
+	GetByUser(ctx context.Context, userID int64) ([]*models.AutoBuyConfig, error)
+	GetAllActive(ctx context.Context) ([]*models.AutoBuyConfig, error)
+	GetStockpileDeficitsForConfig(ctx context.Context, config *models.AutoBuyConfig) ([]*models.StockpileDeficitItem, error)
+}
+
+type AutoBuyOrdersRepository interface {
+	GetActiveAutoBuyOrders(ctx context.Context, autoBuyConfigID int64) ([]*models.BuyOrder, error)
+	UpsertAutoBuy(ctx context.Context, order *models.BuyOrder) error
+	DeactivateAutoBuyOrders(ctx context.Context, autoBuyConfigID int64) error
+	DeactivateAutoBuyOrder(ctx context.Context, orderID int64) error
+}
+
+type AutoBuyMarketPricesRepository interface {
+	GetPricesForTypes(ctx context.Context, typeIDs []int64, regionID int64) (map[int64]*models.MarketPrice, error)
+}
+
+type AutoBuy struct {
+	configRepo   AutoBuyConfigsRepository
+	buyOrderRepo AutoBuyOrdersRepository
+	marketRepo   AutoBuyMarketPricesRepository
+}
+
+func NewAutoBuy(
+	configRepo AutoBuyConfigsRepository,
+	buyOrderRepo AutoBuyOrdersRepository,
+	marketRepo AutoBuyMarketPricesRepository,
+) *AutoBuy {
+	return &AutoBuy{
+		configRepo:   configRepo,
+		buyOrderRepo: buyOrderRepo,
+		marketRepo:   marketRepo,
+	}
+}
+
+// SyncForUser syncs auto-buy orders for a specific user after asset refresh
+func (u *AutoBuy) SyncForUser(ctx context.Context, userID int64) error {
+	configs, err := u.configRepo.GetByUser(ctx, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get auto-buy configs for user")
+	}
+
+	if len(configs) == 0 {
+		return nil
+	}
+
+	for _, config := range configs {
+		if err := u.syncConfig(ctx, config); err != nil {
+			log.Error("failed to sync auto-buy config",
+				"configID", config.ID,
+				"userID", config.UserID,
+				"error", err)
+		}
+	}
+
+	return nil
+}
+
+// SyncForAllUsers syncs auto-buy orders for all users after market price update
+func (u *AutoBuy) SyncForAllUsers(ctx context.Context) error {
+	configs, err := u.configRepo.GetAllActive(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get all active auto-buy configs")
+	}
+
+	if len(configs) == 0 {
+		return nil
+	}
+
+	userConfigs := make(map[int64][]*models.AutoBuyConfig)
+	for _, c := range configs {
+		userConfigs[c.UserID] = append(userConfigs[c.UserID], c)
+	}
+
+	for userID, uConfigs := range userConfigs {
+		for _, config := range uConfigs {
+			if err := u.syncConfig(ctx, config); err != nil {
+				log.Error("failed to sync auto-buy config",
+					"configID", config.ID,
+					"userID", userID,
+					"error", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (u *AutoBuy) syncConfig(ctx context.Context, config *models.AutoBuyConfig) error {
+	// Get stockpile deficits for this config's container context
+	deficits, err := u.configRepo.GetStockpileDeficitsForConfig(ctx, config)
+	if err != nil {
+		return errors.Wrap(err, "failed to get stockpile deficits")
+	}
+
+	// Collect type IDs for market price lookup
+	typeIDs := make([]int64, 0, len(deficits))
+	for _, d := range deficits {
+		if d.Deficit > 0 {
+			typeIDs = append(typeIDs, d.TypeID)
+		}
+	}
+
+	// Get Jita prices
+	prices := map[int64]*models.MarketPrice{}
+	if len(typeIDs) > 0 {
+		prices, err = u.marketRepo.GetPricesForTypes(ctx, typeIDs, JitaRegionID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get market prices")
+		}
+	}
+
+	// Get existing auto-buy orders for this config
+	existingOrders, err := u.buyOrderRepo.GetActiveAutoBuyOrders(ctx, config.ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get existing auto-buy orders")
+	}
+
+	existingByType := make(map[int64]*models.BuyOrder)
+	for _, order := range existingOrders {
+		existingByType[order.TypeID] = order
+	}
+
+	// Track which types still have a deficit
+	activeTypes := make(map[int64]bool)
+
+	for _, deficit := range deficits {
+		if deficit.Deficit <= 0 {
+			continue
+		}
+
+		// Resolve pricing: per-item override takes priority over config default
+		priceSource := config.PriceSource
+		pricePercentage := config.PricePercentage
+		if deficit.PriceSource != nil {
+			priceSource = *deficit.PriceSource
+		}
+		if deficit.PricePercentage != nil {
+			pricePercentage = *deficit.PricePercentage
+		}
+
+		price, hasPrice := prices[deficit.TypeID]
+		basePrice := (*float64)(nil)
+		if hasPrice {
+			basePrice = resolveBasePrice(price, priceSource)
+		}
+		if basePrice == nil || *basePrice <= 0 {
+			// No usable price — deactivate existing order if any
+			if existing, ok := existingByType[deficit.TypeID]; ok {
+				if err := u.buyOrderRepo.DeactivateAutoBuyOrder(ctx, existing.ID); err != nil {
+					log.Error("failed to deactivate auto-buy order with no price",
+						"typeID", deficit.TypeID, "error", err)
+				}
+			}
+			continue
+		}
+
+		activeTypes[deficit.TypeID] = true
+		computedPrice := *basePrice * pricePercentage / 100.0
+
+		order := &models.BuyOrder{
+			BuyerUserID:     config.UserID,
+			TypeID:          deficit.TypeID,
+			LocationID:      config.LocationID,
+			QuantityDesired: deficit.Deficit,
+			MaxPricePerUnit: computedPrice,
+			AutoBuyConfigID: &config.ID,
+			IsActive:        true,
+		}
+
+		if err := u.buyOrderRepo.UpsertAutoBuy(ctx, order); err != nil {
+			log.Error("failed to upsert auto-buy order",
+				"typeID", deficit.TypeID, "configID", config.ID, "error", err)
+		}
+	}
+
+	// Deactivate orders for items no longer in deficit
+	for _, order := range existingOrders {
+		if !activeTypes[order.TypeID] {
+			if err := u.buyOrderRepo.DeactivateAutoBuyOrder(ctx, order.ID); err != nil {
+				log.Error("failed to deactivate removed auto-buy order",
+					"typeID", order.TypeID, "configID", config.ID, "error", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/updaters/autoBuy_test.go
+++ b/internal/updaters/autoBuy_test.go
@@ -1,0 +1,483 @@
+package updaters_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/updaters"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Mocks ---
+
+type mockAutoBuyConfigsRepo struct {
+	byUserConfigs []*models.AutoBuyConfig
+	byUserErr     error
+	allActive     []*models.AutoBuyConfig
+	allActiveErr  error
+	deficits      []*models.StockpileDeficitItem
+	deficitsErr   error
+}
+
+func (m *mockAutoBuyConfigsRepo) GetByUser(ctx context.Context, userID int64) ([]*models.AutoBuyConfig, error) {
+	return m.byUserConfigs, m.byUserErr
+}
+
+func (m *mockAutoBuyConfigsRepo) GetAllActive(ctx context.Context) ([]*models.AutoBuyConfig, error) {
+	return m.allActive, m.allActiveErr
+}
+
+func (m *mockAutoBuyConfigsRepo) GetStockpileDeficitsForConfig(ctx context.Context, config *models.AutoBuyConfig) ([]*models.StockpileDeficitItem, error) {
+	return m.deficits, m.deficitsErr
+}
+
+type mockAutoBuyOrdersRepo struct {
+	activeOrders       []*models.BuyOrder
+	activeOrdersErr    error
+	upsertErr          error
+	deactivateAllErr   error
+	deactivateOneErr   error
+	upsertedOrders     []*models.BuyOrder
+	deactivatedIDs     []int64
+	deactivatedAllIDs  []int64
+}
+
+func (m *mockAutoBuyOrdersRepo) GetActiveAutoBuyOrders(ctx context.Context, autoBuyConfigID int64) ([]*models.BuyOrder, error) {
+	return m.activeOrders, m.activeOrdersErr
+}
+
+func (m *mockAutoBuyOrdersRepo) UpsertAutoBuy(ctx context.Context, order *models.BuyOrder) error {
+	// Make a copy to capture the state at the time of the call
+	copy := *order
+	m.upsertedOrders = append(m.upsertedOrders, &copy)
+	return m.upsertErr
+}
+
+func (m *mockAutoBuyOrdersRepo) DeactivateAutoBuyOrders(ctx context.Context, autoBuyConfigID int64) error {
+	m.deactivatedAllIDs = append(m.deactivatedAllIDs, autoBuyConfigID)
+	return m.deactivateAllErr
+}
+
+func (m *mockAutoBuyOrdersRepo) DeactivateAutoBuyOrder(ctx context.Context, orderID int64) error {
+	m.deactivatedIDs = append(m.deactivatedIDs, orderID)
+	return m.deactivateOneErr
+}
+
+// --- Helper ---
+
+func newAutoBuyUpdater(
+	configRepo *mockAutoBuyConfigsRepo,
+	buyOrderRepo *mockAutoBuyOrdersRepo,
+	marketRepo *mockAutoSellMarketRepo,
+) *updaters.AutoBuy {
+	return updaters.NewAutoBuy(configRepo, buyOrderRepo, marketRepo)
+}
+
+// --- SyncForUser Tests ---
+
+func Test_AutoBuy_SyncForUser_Success(t *testing.T) {
+	configID := int64(1)
+	buyPrice := 100.0
+
+	configRepo := &mockAutoBuyConfigsRepo{
+		byUserConfigs: []*models.AutoBuyConfig{
+			{
+				ID:              configID,
+				UserID:          42,
+				OwnerType:       "character",
+				OwnerID:         12345,
+				LocationID:      60003760,
+				PricePercentage: 110.0,
+				PriceSource:     "jita_buy",
+				IsActive:        true,
+			},
+		},
+		deficits: []*models.StockpileDeficitItem{
+			{TypeID: 34, DesiredQuantity: 1000, CurrentQuantity: 200, Deficit: 800},
+		},
+	}
+
+	buyOrderRepo := &mockAutoBuyOrdersRepo{
+		activeOrders: []*models.BuyOrder{},
+	}
+
+	marketRepo := &mockAutoSellMarketRepo{
+		prices: map[int64]*models.MarketPrice{
+			34: {TypeID: 34, RegionID: 10000002, BuyPrice: &buyPrice},
+		},
+	}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForUser(context.Background(), 42)
+
+	assert.NoError(t, err)
+	assert.Len(t, buyOrderRepo.upsertedOrders, 1)
+
+	upserted := buyOrderRepo.upsertedOrders[0]
+	assert.Equal(t, int64(42), upserted.BuyerUserID)
+	assert.Equal(t, int64(34), upserted.TypeID)
+	assert.Equal(t, int64(60003760), upserted.LocationID)
+	assert.Equal(t, int64(800), upserted.QuantityDesired)
+	assert.Equal(t, 110.0, upserted.MaxPricePerUnit) // 100 * 110 / 100
+	assert.Equal(t, &configID, upserted.AutoBuyConfigID)
+	assert.True(t, upserted.IsActive)
+	assert.Len(t, buyOrderRepo.deactivatedIDs, 0)
+}
+
+func Test_AutoBuy_SyncForUser_NoConfigs(t *testing.T) {
+	configRepo := &mockAutoBuyConfigsRepo{
+		byUserConfigs: []*models.AutoBuyConfig{},
+	}
+	buyOrderRepo := &mockAutoBuyOrdersRepo{}
+	marketRepo := &mockAutoSellMarketRepo{}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForUser(context.Background(), 42)
+
+	assert.NoError(t, err)
+	assert.Len(t, buyOrderRepo.upsertedOrders, 0)
+}
+
+func Test_AutoBuy_SyncForUser_GetConfigsError(t *testing.T) {
+	configRepo := &mockAutoBuyConfigsRepo{
+		byUserErr: fmt.Errorf("db error"),
+	}
+	buyOrderRepo := &mockAutoBuyOrdersRepo{}
+	marketRepo := &mockAutoSellMarketRepo{}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForUser(context.Background(), 42)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get auto-buy configs for user")
+}
+
+func Test_AutoBuy_SyncForUser_NoDeficit_DeactivatesExisting(t *testing.T) {
+	configID := int64(1)
+	existingOrderID := int64(99)
+
+	configRepo := &mockAutoBuyConfigsRepo{
+		byUserConfigs: []*models.AutoBuyConfig{
+			{
+				ID:              configID,
+				UserID:          42,
+				OwnerType:       "character",
+				OwnerID:         12345,
+				LocationID:      60003760,
+				PricePercentage: 110.0,
+				PriceSource:     "jita_buy",
+				IsActive:        true,
+			},
+		},
+		deficits: []*models.StockpileDeficitItem{
+			{TypeID: 34, DesiredQuantity: 1000, CurrentQuantity: 1000, Deficit: 0},
+		},
+	}
+
+	buyOrderRepo := &mockAutoBuyOrdersRepo{
+		activeOrders: []*models.BuyOrder{
+			{
+				ID:              existingOrderID,
+				TypeID:          34,
+				AutoBuyConfigID: &configID,
+				IsActive:        true,
+			},
+		},
+	}
+
+	marketRepo := &mockAutoSellMarketRepo{
+		prices: map[int64]*models.MarketPrice{},
+	}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForUser(context.Background(), 42)
+
+	assert.NoError(t, err)
+	// No upserts since deficit is 0
+	assert.Len(t, buyOrderRepo.upsertedOrders, 0)
+	// Existing order should be deactivated (not in activeTypes)
+	assert.Contains(t, buyOrderRepo.deactivatedIDs, existingOrderID)
+}
+
+func Test_AutoBuy_SyncForUser_NoPrice_DeactivatesExisting(t *testing.T) {
+	configID := int64(1)
+	existingOrderID := int64(99)
+
+	configRepo := &mockAutoBuyConfigsRepo{
+		byUserConfigs: []*models.AutoBuyConfig{
+			{
+				ID:              configID,
+				UserID:          42,
+				OwnerType:       "character",
+				OwnerID:         12345,
+				LocationID:      60003760,
+				PricePercentage: 110.0,
+				PriceSource:     "jita_buy",
+				IsActive:        true,
+			},
+		},
+		deficits: []*models.StockpileDeficitItem{
+			{TypeID: 34, DesiredQuantity: 1000, CurrentQuantity: 200, Deficit: 800},
+		},
+	}
+
+	buyOrderRepo := &mockAutoBuyOrdersRepo{
+		activeOrders: []*models.BuyOrder{
+			{
+				ID:              existingOrderID,
+				TypeID:          34,
+				AutoBuyConfigID: &configID,
+				IsActive:        true,
+			},
+		},
+	}
+
+	// No prices available
+	marketRepo := &mockAutoSellMarketRepo{
+		prices: map[int64]*models.MarketPrice{},
+	}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForUser(context.Background(), 42)
+
+	assert.NoError(t, err)
+	// No upserts since there's no price
+	assert.Len(t, buyOrderRepo.upsertedOrders, 0)
+	// Deactivated from "no price" path and from "not in activeTypes" path
+	assert.Contains(t, buyOrderRepo.deactivatedIDs, existingOrderID)
+}
+
+func Test_AutoBuy_SyncForUser_PerItemOverride(t *testing.T) {
+	configID := int64(1)
+	sellPrice := 200.0
+
+	configRepo := &mockAutoBuyConfigsRepo{
+		byUserConfigs: []*models.AutoBuyConfig{
+			{
+				ID:              configID,
+				UserID:          42,
+				OwnerType:       "character",
+				OwnerID:         12345,
+				LocationID:      60003760,
+				PricePercentage: 110.0,
+				PriceSource:     "jita_buy",
+				IsActive:        true,
+			},
+		},
+		deficits: []*models.StockpileDeficitItem{
+			{
+				TypeID:          34,
+				DesiredQuantity: 1000,
+				CurrentQuantity: 200,
+				Deficit:         800,
+				PriceSource:     stringPtr("jita_sell"),
+				PricePercentage: float64Ptr(95.0),
+			},
+		},
+	}
+
+	buyOrderRepo := &mockAutoBuyOrdersRepo{
+		activeOrders: []*models.BuyOrder{},
+	}
+
+	marketRepo := &mockAutoSellMarketRepo{
+		prices: map[int64]*models.MarketPrice{
+			34: {TypeID: 34, RegionID: 10000002, SellPrice: &sellPrice},
+		},
+	}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForUser(context.Background(), 42)
+
+	assert.NoError(t, err)
+	assert.Len(t, buyOrderRepo.upsertedOrders, 1)
+
+	upserted := buyOrderRepo.upsertedOrders[0]
+	// Per-item override: jita_sell at 95%, not config's jita_buy at 110%
+	assert.Equal(t, 190.0, upserted.MaxPricePerUnit) // 200 * 95 / 100
+	assert.True(t, upserted.IsActive)
+}
+
+func Test_AutoBuy_SyncForUser_JitaSellPricing(t *testing.T) {
+	configID := int64(1)
+	sellPrice := 55.0
+
+	configRepo := &mockAutoBuyConfigsRepo{
+		byUserConfigs: []*models.AutoBuyConfig{
+			{
+				ID:              configID,
+				UserID:          42,
+				OwnerType:       "character",
+				OwnerID:         12345,
+				LocationID:      60003760,
+				PricePercentage: 90.0,
+				PriceSource:     "jita_sell",
+				IsActive:        true,
+			},
+		},
+		deficits: []*models.StockpileDeficitItem{
+			{TypeID: 34, DesiredQuantity: 1000, CurrentQuantity: 0, Deficit: 1000},
+		},
+	}
+
+	buyOrderRepo := &mockAutoBuyOrdersRepo{
+		activeOrders: []*models.BuyOrder{},
+	}
+
+	marketRepo := &mockAutoSellMarketRepo{
+		prices: map[int64]*models.MarketPrice{
+			34: {TypeID: 34, RegionID: 10000002, SellPrice: &sellPrice},
+		},
+	}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForUser(context.Background(), 42)
+
+	assert.NoError(t, err)
+	assert.Len(t, buyOrderRepo.upsertedOrders, 1)
+
+	upserted := buyOrderRepo.upsertedOrders[0]
+	assert.Equal(t, 49.5, upserted.MaxPricePerUnit) // 55 * 90 / 100
+	assert.True(t, upserted.IsActive)
+}
+
+func Test_AutoBuy_SyncForUser_JitaSplitPricing(t *testing.T) {
+	configID := int64(1)
+	buyPrice := 50.0
+	sellPrice := 55.0
+
+	configRepo := &mockAutoBuyConfigsRepo{
+		byUserConfigs: []*models.AutoBuyConfig{
+			{
+				ID:              configID,
+				UserID:          42,
+				OwnerType:       "character",
+				OwnerID:         12345,
+				LocationID:      60003760,
+				PricePercentage: 90.0,
+				PriceSource:     "jita_split",
+				IsActive:        true,
+			},
+		},
+		deficits: []*models.StockpileDeficitItem{
+			{TypeID: 34, DesiredQuantity: 1000, CurrentQuantity: 0, Deficit: 1000},
+		},
+	}
+
+	buyOrderRepo := &mockAutoBuyOrdersRepo{
+		activeOrders: []*models.BuyOrder{},
+	}
+
+	marketRepo := &mockAutoSellMarketRepo{
+		prices: map[int64]*models.MarketPrice{
+			34: {TypeID: 34, RegionID: 10000002, BuyPrice: &buyPrice, SellPrice: &sellPrice},
+		},
+	}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForUser(context.Background(), 42)
+
+	assert.NoError(t, err)
+	assert.Len(t, buyOrderRepo.upsertedOrders, 1)
+
+	upserted := buyOrderRepo.upsertedOrders[0]
+	assert.Equal(t, 47.25, upserted.MaxPricePerUnit) // (50+55)/2 * 90 / 100 = 52.5 * 0.9
+	assert.True(t, upserted.IsActive)
+}
+
+// --- SyncForAllUsers Tests ---
+
+func Test_AutoBuy_SyncForAllUsers_Success(t *testing.T) {
+	buyPrice := 100.0
+
+	configRepo := &mockAutoBuyConfigsRepo{
+		allActive: []*models.AutoBuyConfig{
+			{
+				ID:              1,
+				UserID:          42,
+				OwnerType:       "character",
+				OwnerID:         12345,
+				LocationID:      60003760,
+				PricePercentage: 110.0,
+				PriceSource:     "jita_buy",
+				IsActive:        true,
+			},
+			{
+				ID:              2,
+				UserID:          99,
+				OwnerType:       "character",
+				OwnerID:         67890,
+				LocationID:      60003760,
+				PricePercentage: 105.0,
+				PriceSource:     "jita_buy",
+				IsActive:        true,
+			},
+		},
+		deficits: []*models.StockpileDeficitItem{
+			{TypeID: 34, DesiredQuantity: 1000, CurrentQuantity: 200, Deficit: 800},
+		},
+	}
+
+	buyOrderRepo := &mockAutoBuyOrdersRepo{
+		activeOrders: []*models.BuyOrder{},
+	}
+
+	marketRepo := &mockAutoSellMarketRepo{
+		prices: map[int64]*models.MarketPrice{
+			34: {TypeID: 34, RegionID: 10000002, BuyPrice: &buyPrice},
+		},
+	}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForAllUsers(context.Background())
+
+	assert.NoError(t, err)
+	// Should have upserted for both configs
+	assert.Len(t, buyOrderRepo.upsertedOrders, 2)
+}
+
+func Test_AutoBuy_SyncForAllUsers_NoConfigs(t *testing.T) {
+	configRepo := &mockAutoBuyConfigsRepo{
+		allActive: []*models.AutoBuyConfig{},
+	}
+	buyOrderRepo := &mockAutoBuyOrdersRepo{}
+	marketRepo := &mockAutoSellMarketRepo{}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForAllUsers(context.Background())
+
+	assert.NoError(t, err)
+}
+
+func Test_AutoBuy_SyncForAllUsers_Error(t *testing.T) {
+	configRepo := &mockAutoBuyConfigsRepo{
+		allActiveErr: fmt.Errorf("db error"),
+	}
+	buyOrderRepo := &mockAutoBuyOrdersRepo{}
+	marketRepo := &mockAutoSellMarketRepo{}
+
+	u := newAutoBuyUpdater(configRepo, buyOrderRepo, marketRepo)
+	err := u.SyncForAllUsers(context.Background())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get all active auto-buy configs")
+}
+
+// --- Constructor Test ---
+
+func Test_AutoBuy_Constructor(t *testing.T) {
+	u := updaters.NewAutoBuy(
+		&mockAutoBuyConfigsRepo{},
+		&mockAutoBuyOrdersRepo{},
+		&mockAutoSellMarketRepo{},
+	)
+	assert.NotNil(t, u)
+}
+
+// --- Helper (local to this file, not redefining shared ones) ---
+
+func stringPtr(v string) *string {
+	return &v
+}

--- a/internal/updaters/marketPrices.go
+++ b/internal/updaters/marketPrices.go
@@ -28,10 +28,15 @@ type AutoSellAllUsersSyncer interface {
 	SyncForAllUsers(ctx context.Context) error
 }
 
+type AutoBuyAllUsersSyncer interface {
+	SyncForAllUsers(ctx context.Context) error
+}
+
 type MarketPrices struct {
 	marketPricesRepo MarketPricesRepository
 	esiClient        MarketPricesEsiClient
 	autoSellSyncer   AutoSellAllUsersSyncer
+	autoBuySyncer    AutoBuyAllUsersSyncer
 }
 
 func NewMarketPrices(repo MarketPricesRepository, esiClient MarketPricesEsiClient) *MarketPrices {
@@ -135,10 +140,21 @@ func (u *MarketPrices) UpdateJitaMarket(ctx context.Context) error {
 		}
 	}
 
+	if u.autoBuySyncer != nil {
+		if err := u.autoBuySyncer.SyncForAllUsers(ctx); err != nil {
+			log.Error("failed to sync auto-buy orders after market price update", "error", err)
+		}
+	}
+
 	return nil
 }
 
 // WithAutoSellUpdater sets the optional auto-sell syncer
 func (u *MarketPrices) WithAutoSellUpdater(syncer AutoSellAllUsersSyncer) {
 	u.autoSellSyncer = syncer
+}
+
+// WithAutoBuyUpdater sets the optional auto-buy syncer
+func (u *MarketPrices) WithAutoBuyUpdater(syncer AutoBuyAllUsersSyncer) {
+	u.autoBuySyncer = syncer
 }


### PR DESCRIPTION
## Summary
- Automatically create and maintain buy orders for stockpile items that are below their desired quantity
- Container-level pricing config (price source + percentage) with per-item overrides via stockpile markers
- Syncs on asset refresh and market price updates, mirroring the existing auto-sell system
- Buy orders deactivate when deficit is filled, reactivate when it returns

## Changes
- **Migrations**: `auto_buy_configs` table, `auto_buy_config_id` on `buy_orders`, `price_source`/`price_percentage` on `stockpile_markers`
- **Backend**: New repository, updater, controller (`GET/POST/PUT/DELETE /v1/auto-buy`), hooks into asset + market price updaters
- **Frontend**: Auto-buy dialog on containers (ShoppingCart icon), "Auto" badge on auto-generated buy orders, API proxy routes
- **Tests**: 37 new backend tests (controller, repository, updater), updated frontend snapshots

## Test plan
- [x] `make test-backend` — all tests pass
- [x] `make test-frontend` — all 86 tests pass, 13 snapshots pass
- [ ] Manual: enable auto-buy on container → verify buy orders created for deficit items
- [ ] Manual: fill stockpile → verify orders deactivated
- [ ] Manual: change market prices → verify buy order max prices update

🤖 Generated with [Claude Code](https://claude.com/claude-code)