### PR TITLE
Fix contact rules not matching character-only users

### DIFF
--- a/internal/controllers/characters_test.go
+++ b/internal/controllers/characters_test.go
@@ -41,6 +41,11 @@ func (m *MockCharacterRepository) GetAll(ctx context.Context, baseUserID int64) 
 	return args.Get(0).([]*repositories.Character), args.Error(1)
 }
 
+func (m *MockCharacterRepository) UpdateCorporationID(ctx context.Context, characterID, userID, corporationID int64) error {
+	args := m.Called(ctx, characterID, userID, corporationID)
+	return args.Error(0)
+}
+
 type MockCharacterAssetUpdater struct {
 	mock.Mock
 }

--- a/internal/controllers/contactRules.go
+++ b/internal/controllers/contactRules.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	log "github.com/annymsMthd/industry-tool/internal/logging"
 	"github.com/annymsMthd/industry-tool/internal/models"
 	"github.com/annymsMthd/industry-tool/internal/repositories"
 	"github.com/annymsMthd/industry-tool/internal/web"
@@ -120,7 +121,7 @@ func (c *ContactRules) CreateRule(args *web.HandlerArgs) (any, *web.HttpError) {
 	go func() {
 		ctx := context.Background()
 		if err := c.applier.ApplyRule(ctx, rule); err != nil {
-			// Logged within ApplyRule
+			log.Error("failed to apply contact rule", "ruleID", rule.ID, "ruleType", rule.RuleType, "error", err)
 		}
 	}()
 

--- a/internal/database/migrations/20260220001437_add_corporation_id_to_characters.down.sql
+++ b/internal/database/migrations/20260220001437_add_corporation_id_to_characters.down.sql
@@ -1,0 +1,4 @@
+-- Migration: add_corporation_id_to_characters
+-- Created: Fri Feb 20 12:14:37 AM PST 2026
+
+alter table characters drop column corporation_id;

--- a/internal/database/migrations/20260220001437_add_corporation_id_to_characters.up.sql
+++ b/internal/database/migrations/20260220001437_add_corporation_id_to_characters.up.sql
@@ -1,0 +1,4 @@
+-- Migration: add_corporation_id_to_characters
+-- Created: Fri Feb 20 12:14:37 AM PST 2026
+
+alter table characters add column corporation_id bigint;

--- a/internal/repositories/character.go
+++ b/internal/repositories/character.go
@@ -98,6 +98,19 @@ where
 	return nil
 }
 
+func (r *CharacterRepository) UpdateCorporationID(ctx context.Context, characterID, userID, corporationID int64) error {
+	_, err := r.db.ExecContext(ctx, `
+update characters set
+	corporation_id = $1
+where
+	id = $2 and user_id = $3;
+	`, corporationID, characterID, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to update character corporation_id")
+	}
+	return nil
+}
+
 func (r *CharacterRepository) Add(ctx context.Context, character *Character) error {
 	_, err := r.db.ExecContext(ctx, `
 insert into


### PR DESCRIPTION
## Summary
- Contact rules (`ApplyRule`) only queried `player_corporations` to find matching users, missing users who added characters but not the corporation itself
- Added `corporation_id` column to `characters` table, populated from ESI on character add
- `GetUsersForCorporation` and `GetUsersForAlliance` now query both `player_corporations` and `characters` via UNION
- Added error logging to the `ApplyRule` goroutine which was silently swallowing errors

## Test plan
- [x] `make test-backend` passes (mock updated for new interface method)
- [ ] Create a corporation contact rule where matching users only have characters added — verify contacts are created
- [ ] Verify existing character add flow still stores `corporation_id`
- [ ] Check server logs for `ApplyRule` errors that were previously silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)