### PR TITLE
Auto-sell respects stockpile markers

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -93,7 +93,7 @@ var rootCmd = &cobra.Command{
 		marketPricesUpdater := updaters.NewMarketPrices(marketPricesRepository, esiClient)
 		ccpPricesUpdater := updaters.NewCcpPrices(esiClient, marketPricesRepository)
 		costIndicesUpdater := updaters.NewIndustryCostIndices(esiClient, industryCostIndicesRepository)
-		autoSellUpdater := updaters.NewAutoSell(autoSellContainersRepository, forSaleItemsRepository, marketPricesRepository)
+		autoSellUpdater := updaters.NewAutoSell(autoSellContainersRepository, forSaleItemsRepository, marketPricesRepository, stockpileMarkersRepository)
 		contactRulesUpdater := updaters.NewContactRules(contactsRepository, contactRulesRepository, contactPermissionsRepository, db)
 
 		// Discord integration (optional — only enabled when DISCORD_BOT_TOKEN is set)


### PR DESCRIPTION
## Summary
- Auto-sell now subtracts stockpile marker desired quantities from container items before listing for sale
- Items at or below their stockpile target are not listed (existing listings deactivated)
- Items without a stockpile marker continue to sell at full quantity (no behavior change)
- Added `GetByContainerContext` repository method for O(1) stockpile lookup by TypeID
- 6 new unit tests covering stockpile reduces quantity, exceeds/equals quantity, no marker, mixed items, and repo error

## Test plan
- [x] All 22 auto-sell unit tests pass (16 existing + 6 new)
- [x] Full backend test suite passes
- [ ] Manual: enable auto-sell on container with stockpile markers → verify only surplus listed
- [ ] Manual: verify items without stockpile markers still list full quantity
- [ ] Manual: verify items at or below stockpile target are not listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)