### PR TITLE
Cache station lookups to prevent ESI rate limiting

### DIFF
--- a/internal/client/esiClient.go
+++ b/internal/client/esiClient.go
@@ -242,7 +242,13 @@ func (c *EsiClient) GetPlayerOwnedStationInformation(ctx context.Context, token,
 		defer res.Body.Close()
 
 		if res.StatusCode == 403 {
-			// player does not have access to query this structure so just continue
+			// Player no longer has access — save as "Unknown Structure" so the
+			// station row exists (the Upsert preserves any real name already stored).
+			res.Body.Close()
+			stations = append(stations, models.Station{
+				ID:   id,
+				Name: "Unknown Structure",
+			})
 			continue
 		}
 

--- a/internal/database/migrations/20260220105221_add_station_last_updated.down.sql
+++ b/internal/database/migrations/20260220105221_add_station_last_updated.down.sql
@@ -1,0 +1,1 @@
+alter table stations drop column last_updated_at;

--- a/internal/database/migrations/20260220105221_add_station_last_updated.up.sql
+++ b/internal/database/migrations/20260220105221_add_station_last_updated.up.sql
@@ -1,0 +1,4 @@
+alter table stations add column last_updated_at timestamp;
+
+-- Backfill existing rows so they don't appear stale
+update stations set last_updated_at = now();

--- a/internal/repositories/stations.go
+++ b/internal/repositories/stations.go
@@ -3,8 +3,10 @@ package repositories
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 )
 
@@ -31,17 +33,30 @@ insert into
 		name,
 		solar_system_id,
 		corporation_id,
-		is_npc_station
+		is_npc_station,
+		last_updated_at
 	)
 	values
-		($1,$2,$3,$4,$5)
+		($1,$2,$3,$4,$5,now())
 on conflict
 	(station_id)
 do update set
-	name = CASE WHEN EXCLUDED.name = '' THEN stations.name ELSE EXCLUDED.name END,
-	solar_system_id = EXCLUDED.solar_system_id,
-	corporation_id = EXCLUDED.corporation_id,
-	is_npc_station = EXCLUDED.is_npc_station;
+	name = CASE
+		WHEN EXCLUDED.name IN ('', 'Unknown Structure')
+			AND stations.name NOT IN ('', 'Unknown Structure')
+			THEN stations.name
+		ELSE EXCLUDED.name
+	END,
+	solar_system_id = CASE
+		WHEN EXCLUDED.solar_system_id = 0 THEN stations.solar_system_id
+		ELSE EXCLUDED.solar_system_id
+	END,
+	corporation_id = CASE
+		WHEN EXCLUDED.corporation_id = 0 THEN stations.corporation_id
+		ELSE EXCLUDED.corporation_id
+	END,
+	is_npc_station = EXCLUDED.is_npc_station,
+	last_updated_at = now();
 	`
 
 	tx, err := r.db.BeginTx(ctx, nil)
@@ -111,4 +126,49 @@ func (r *Stations) UpdateNames(ctx context.Context, names map[int64]string) erro
 	}
 
 	return tx.Commit()
+}
+
+// FilterStaleStationIDs returns only station IDs that need refreshing from ESI.
+// Known stations (with a real name) use knownMaxAge; unknown stations use unknownMaxAge.
+// Stations not in the table at all are always returned.
+func (r *Stations) FilterStaleStationIDs(ctx context.Context, ids []int64, knownMaxAge, unknownMaxAge time.Duration) ([]int64, error) {
+	if len(ids) == 0 {
+		return []int64{}, nil
+	}
+
+	knownCutoff := time.Now().Add(-knownMaxAge)
+	unknownCutoff := time.Now().Add(-unknownMaxAge)
+
+	query := `
+		SELECT unnested_id FROM unnest($1::bigint[]) AS unnested_id
+		WHERE unnested_id NOT IN (
+			SELECT station_id FROM stations
+			WHERE station_id = ANY($1)
+			  AND last_updated_at IS NOT NULL
+			  AND last_updated_at > CASE
+				WHEN name NOT IN ('', 'Unknown Structure') THEN $2::timestamp
+				ELSE $3::timestamp
+			  END
+		)
+	`
+
+	rows, err := r.db.QueryContext(ctx, query,
+		pq.Array(ids),
+		knownCutoff,
+		unknownCutoff,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to filter stale station IDs")
+	}
+	defer rows.Close()
+
+	staleIDs := []int64{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, errors.Wrap(err, "failed to scan stale station ID")
+		}
+		staleIDs = append(staleIDs, id)
+	}
+	return staleIDs, nil
 }

--- a/internal/updaters/assets_test.go
+++ b/internal/updaters/assets_test.go
@@ -106,11 +106,21 @@ func (m *mockCorpAssetsRepo) GetPlayerOwnedStationIDs(ctx context.Context, corp,
 }
 
 type mockAssetStationRepo struct {
-	upsertErr error
+	upsertErr      error
+	filterStaleIDs []int64
+	filterStaleErr error
 }
 
 func (m *mockAssetStationRepo) Upsert(ctx context.Context, stations []models.Station) error {
 	return m.upsertErr
+}
+
+func (m *mockAssetStationRepo) FilterStaleStationIDs(ctx context.Context, ids []int64, knownMaxAge, unknownMaxAge time.Duration) ([]int64, error) {
+	if m.filterStaleIDs != nil {
+		return m.filterStaleIDs, m.filterStaleErr
+	}
+	// Default: all IDs are stale (preserves existing test behavior)
+	return ids, m.filterStaleErr
 }
 
 type mockUserTimestampRepo struct {


### PR DESCRIPTION
## Summary
- Adds `last_updated_at` column to stations table for cache TTL tracking
- Known stations (with real names) are cached for 7 days; unknown stations for 24 hours
- ESI 403 responses (no access) now save "Unknown Structure" instead of silently skipping, without overwriting existing names
- `FilterStaleStationIDs` filters out fresh cache entries before making ESI calls, drastically reducing `/universe/structures/{id}` requests

## Test plan
- [ ] Verify existing backend tests pass (`make test-backend`)
- [ ] Deploy and confirm ESI 420 rate limit errors stop appearing in logs
- [ ] Confirm known station names are preserved when a character loses access (403 → "Unknown Structure" doesn't overwrite)
- [ ] Confirm unknown stations are retried after 24 hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)