### PR TITLE
Add Planetary Industry management (Phases 1-5)

### DIFF
--- a/cmd/industry-tool/cmd/settings.go
+++ b/cmd/industry-tool/cmd/settings.go
@@ -21,6 +21,7 @@ type Settings struct {
 	DiscordBotToken        string
 	DiscordClientID        string
 	DiscordClientSecret    string
+	PiUpdateIntervalSec    int
 }
 
 func GetSettings() (*Settings, error) {
@@ -71,6 +72,15 @@ func GetSettings() (*Settings, error) {
 	settings.DiscordBotToken = os.Getenv("DISCORD_BOT_TOKEN")
 	settings.DiscordClientID = os.Getenv("DISCORD_CLIENT_ID")
 	settings.DiscordClientSecret = os.Getenv("DISCORD_CLIENT_SECRET")
+
+	if s := os.Getenv("PI_UPDATE_INTERVAL_SEC"); s != "" {
+		settings.PiUpdateIntervalSec, err = strconv.Atoi(s)
+		if err != nil {
+			return nil, errors.Wrapf(err, "PI_UPDATE_INTERVAL_SEC '%s' is not a number", s)
+		}
+	} else {
+		settings.PiUpdateIntervalSec = 3600
+	}
 
 	return settings, nil
 }

--- a/docs/features/planetary-industry.md
+++ b/docs/features/planetary-industry.md
@@ -1,0 +1,319 @@
+# Planetary Industry (PI) Management
+
+## Overview
+
+Unified dashboard for managing multi-character PI chains in EVE Online. Tracks production rates, detects stalled extractors and factories, calculates profit, and provides supply chain visibility across all characters.
+
+**ESI Scope**: `esi-planets.manage_planets.v1` (already requested in character auth flow)
+
+**Key Constraint**: ESI PI data only updates when the player views the colony in-game. The `last_update` timestamp on each planet tells us when data was last refreshed by the player.
+
+---
+
+## Status
+
+### Phase 1 — Data Fetch, Storage, Display
+- [x] Database migration (pi_planets, pi_pins, pi_pin_contents, pi_routes, pi_tax_config)
+- [x] ESI client methods (GetCharacterPlanets, GetCharacterPlanetDetails)
+- [x] PI repository (piPlanets.go, piTaxConfig.go)
+- [x] PI updater with pin classification
+- [x] Dedicated PI background runner (configurable interval)
+- [x] PI controller with stall detection + production rates
+- [x] Wired in root.go and settings.go
+- [x] Frontend (overview page with planet cards, search, stats, item/planet icons, route-based input display)
+
+### Phase 2 — Profit Calculation + POCO Tax
+- [x] Tier classification (walk sde_planet_schematic_types: R0→P1→P2→P3→P4)
+- [x] Per-factory profit calculation (output value - input cost - export tax - import tax)
+- [x] Price source selector (Jita sell/buy/split)
+- [x] POCO tax integration (global + per-planet rates from pi_tax_config)
+- [x] Profit tab in frontend (per-planet summary table with expandable factory breakdown)
+- [x] Summary cards (total revenue, costs, taxes, profit per hour)
+
+### Phase 3 — Launchpad Naming + Loading Screen
+- [x] pi_launchpad_labels table
+- [x] Label CRUD endpoints (POST/DELETE /v1/pi/launchpad-labels)
+- [x] Launchpad detail endpoint (GET /v1/pi/launchpad-detail)
+- [x] Connected factory input tracking with depletion times
+- [x] Inline label editing in drawer UI
+- [x] Clickable launchpads in planet cards → detail drawer
+
+### Phase 4 — Discord Stall Alerts
+- [x] `pi_stall` notification event type
+- [x] `NotifyPiStall` in notifications updater with Discord embed (red alert, character/planet/issue fields)
+- [x] Stall detection in PI updater with state transition tracking (`last_stall_notified_at` dedup)
+- [x] `pi_stall` added to Discord settings frontend EVENT_TYPES
+
+### Phase 5 — Supply Chain Analysis
+- [x] Cross-character input/output aggregation (extractor outputs, factory inputs/outputs)
+- [x] Stockpile integration (bought supply from stockpile markers)
+- [x] Depletion time calculation for net-deficit items
+- [x] Supply Chain tab in frontend (tier filter, search, expandable producer/consumer detail)
+- [x] GET /v1/pi/supply-chain endpoint
+
+---
+
+## Key Design Decisions
+
+1. **Dedicated PI tables** — Colony structure (pins, routes, schematics) doesn't fit the asset model
+2. **Dedicated background runner** — Separate from asset refresh, configurable via `PI_UPDATE_INTERVAL_SEC` (default 3600s)
+3. **Pin category stored at write time** — Classified during ESI fetch, avoids SDE join on every read
+4. **Scope check per character** — Skip PI fetch for characters without `esi-planets.manage_planets.v1` in `esi_scopes`
+5. **Global + per-planet tax** — Two-level hierarchy matching real POCO variation
+6. **Stall dedup via `last_stall_notified_at`** — Only alert on state transition (running → stalled), not repeatedly
+
+---
+
+## Database Schema
+
+```sql
+-- Core PI colony data (one row per character+planet)
+create table pi_planets (
+    id bigserial primary key,
+    character_id bigint not null,
+    user_id bigint not null,
+    planet_id bigint not null,
+    planet_type varchar(20) not null,
+    solar_system_id bigint not null,
+    upgrade_level int not null default 0,
+    num_pins int not null default 0,
+    last_update timestamp not null,
+    last_stall_notified_at timestamp,
+    created_at timestamp not null default now(),
+    updated_at timestamp not null default now(),
+    unique(character_id, planet_id)
+);
+
+-- Individual pins on each planet
+create table pi_pins (
+    id bigserial primary key,
+    character_id bigint not null,
+    planet_id bigint not null,
+    pin_id bigint not null,
+    type_id bigint not null,
+    schematic_id int,
+    latitude double precision,
+    longitude double precision,
+    install_time timestamp,
+    expiry_time timestamp,
+    last_cycle_start timestamp,
+    extractor_cycle_time int,
+    extractor_head_radius double precision,
+    extractor_product_type_id bigint,
+    extractor_qty_per_cycle int,
+    extractor_num_heads int,
+    pin_category varchar(20) not null,
+    updated_at timestamp not null default now(),
+    unique(character_id, planet_id, pin_id)
+);
+
+-- Contents of storage/launchpad pins
+create table pi_pin_contents (
+    character_id bigint not null,
+    planet_id bigint not null,
+    pin_id bigint not null,
+    type_id bigint not null,
+    amount bigint not null,
+    primary key(character_id, planet_id, pin_id, type_id)
+);
+
+-- Routes between pins
+create table pi_routes (
+    character_id bigint not null,
+    planet_id bigint not null,
+    route_id bigint not null,
+    source_pin_id bigint not null,
+    destination_pin_id bigint not null,
+    content_type_id bigint not null,
+    quantity bigint not null,
+    primary key(character_id, planet_id, route_id)
+);
+
+-- User POCO tax configuration
+create table pi_tax_config (
+    id bigserial primary key,
+    user_id bigint not null references users(id),
+    planet_id bigint,
+    tax_rate double precision not null default 10.0,
+    unique(user_id, planet_id)
+);
+
+-- User-defined launchpad labels
+create table pi_launchpad_labels (
+    user_id bigint not null references users(id),
+    character_id bigint not null,
+    planet_id bigint not null,
+    pin_id bigint not null,
+    label varchar(100) not null,
+    primary key(user_id, character_id, planet_id, pin_id)
+);
+```
+
+---
+
+## ESI Endpoints
+
+| Method | ESI Path | Purpose |
+|--------|----------|---------|
+| GET | `/v1/characters/{id}/planets/` | Planet list (type, system, upgrade, num_pins, last_update) |
+| GET | `/v3/characters/{id}/planets/{planet_id}/` | Colony detail (pins with contents/extractor/factory details, routes) |
+
+---
+
+## Pin Classification
+
+Pins are classified during ESI fetch using a combination of ESI detail fields and known type_id sets:
+
+| Category | Detection |
+|----------|-----------|
+| extractor | `extractor_details` present |
+| factory | `factory_details` present |
+| launchpad | type_id in {2256, 2542, 2543, 2544} |
+| storage | type_id in {2257, 2535, 2536, 2541} |
+| command_center | type_id in {2524-2531} |
+
+---
+
+## Stall Detection
+
+Computed at read time in the controller (not stored):
+
+| Condition | Logic | Status |
+|-----------|-------|--------|
+| Extractor expired | `expiry_time < now()` | `"expired"` |
+| Factory idle | `last_cycle_start + (cycle_time × 2) < now()` | `"stalled"` |
+| Data stale | `planet.last_update` older than 48 hours | `"stale_data"` |
+
+Planet-level status is the worst of its pin statuses.
+
+### Discord Stall Alerts (Phase 4)
+
+After each PI data refresh, the updater runs stall detection using the same logic as the controller. Notifications are deduped using `pi_planets.last_stall_notified_at`:
+
+- **Running → Stalled**: Send `pi_stall` Discord notification, set `last_stall_notified_at = now()`
+- **Stalled → Stalled**: No notification (already notified)
+- **Stalled → Running**: Clear `last_stall_notified_at` (ready for future alerts)
+
+The Discord embed includes character name, planet type, solar system, and a summary of stalled pins (e.g., "2 extractors expired, 1 factory stalled").
+
+---
+
+## Production Rates
+
+- **Extractors**: `qty_per_cycle / cycle_time_seconds × 3600` = units/hour
+- **Factories**: From `sde_planet_schematics`: `output_quantity / cycle_time_seconds × 3600` = units/hour
+
+---
+
+## API Endpoints
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/v1/pi/planets` | User | All planets with status, extractors, factories, launchpads |
+| GET | `/v1/pi/profit?priceSource=sell` | User | Per-planet profit breakdown (sell/buy/split pricing) |
+| GET | `/v1/pi/tax` | User | Tax config (global + overrides) |
+| POST | `/v1/pi/tax` | User | Upsert tax config |
+| DELETE | `/v1/pi/tax` | User | Delete tax config entry |
+| POST | `/v1/pi/launchpad-labels` | User | Upsert launchpad label |
+| DELETE | `/v1/pi/launchpad-labels` | User | Delete launchpad label |
+| GET | `/v1/pi/launchpad-detail` | User | Launchpad detail with connected factories + depletion |
+| GET | `/v1/pi/supply-chain` | User | Cross-character supply chain aggregation with stockpile integration |
+
+---
+
+## PI Tax Formula (Phase 2)
+
+- **Export**: `base_cost_per_unit × quantity × (tax_rate / 100)`
+- **Import**: `base_cost_per_unit × quantity × (tax_rate / 100) × 0.5`
+- Base costs: R0=5, P1=400, P2=7,200, P3=60,000, P4=1,200,000 ISK
+
+---
+
+## Supply Chain Analysis (Phase 5)
+
+Aggregates production and consumption rates across all characters to show the net balance of every PI material in the user's chain.
+
+### Data Sources
+
+| Source | What it provides |
+|--------|-----------------|
+| Extractor pins | `product_type_id` at `qty_per_cycle / cycle_time * 3600` units/hour |
+| Factory outputs | Schematic output at `output_qty / cycle_time * 3600` units/hour |
+| Factory inputs (demand) | Schematic inputs at `input_qty / cycle_time * 3600` units/hour |
+| Stockpile markers | Purchased/available inventory (e.g., user buys P1 from Jita) |
+
+### Source Classification
+
+Each item is classified based on how it enters the chain:
+- **Extracted**: Produced by extractors (R0 raw resources)
+- **Produced**: Output of factories
+- **Bought**: Not produced by any planet but available in stockpile markers
+- **Extracted + Produced**: Both extractor output and factory output
+
+### Depletion Time
+
+For items with net deficit (`consumed > produced`):
+- `depletion_hours = stockpile_qty / (consumed_per_hour - produced_per_hour)`
+- Only calculated when stockpile quantity > 0 and there is a net deficit
+- Frontend color-codes: red (< 24h), yellow (< 72h), default otherwise
+
+### Expandable Detail
+
+Each row expands to show which planets produce and consume the item, with character name, solar system, planet type, and per-planet rate.
+
+---
+
+## File Structure
+
+### Backend
+
+| File | Purpose |
+|------|---------|
+| `internal/database/migrations/20260220113513_create_pi_tables.{up,down}.sql` | Schema |
+| `internal/database/migrations/20260220131419_create_pi_launchpad_labels.{up,down}.sql` | Launchpad labels schema |
+| `internal/repositories/piPlanets.go` | CRUD for pi_planets, pi_pins, pi_pin_contents, pi_routes |
+| `internal/repositories/piTaxConfig.go` | CRUD for pi_tax_config |
+| `internal/repositories/piLaunchpadLabels.go` | CRUD for pi_launchpad_labels |
+| `internal/updaters/pi.go` | Fetch ESI data, classify pins, upsert, stall detection + notification |
+| `internal/runners/pi.go` | Dedicated background runner |
+| `internal/controllers/pi.go` | HTTP handlers with stall detection + production rates + profit + launchpad detail |
+
+### Frontend
+
+| File | Phase | Purpose |
+|------|-------|---------|
+| `frontend/pages/pi.tsx` | 1 | Thin page wrapper |
+| `frontend/packages/pages/pi.tsx` | 1+2+5 | Main PI page with tabs (Overview, Profit, Supply Chain) |
+| `frontend/packages/components/pi/PlanetOverview.tsx` | 1 | Grid of planet cards with search/stats |
+| `frontend/packages/components/pi/ProfitTable.tsx` | 2 | Per-product profit table with factory breakdown |
+| `frontend/packages/components/pi/LaunchpadDetail.tsx` | 3 | Drawer with factory inputs, depletion, editable labels |
+| `frontend/pages/api/pi/planets.ts` | 1 | API route proxy |
+| `frontend/pages/api/pi/profit.ts` | 2 | API route proxy for profit endpoint |
+| `frontend/pages/api/pi/tax.ts` | 1 | API route proxy |
+| `frontend/pages/api/pi/launchpad-labels.ts` | 3 | API route proxy for label CRUD |
+| `frontend/pages/api/pi/launchpad-detail.ts` | 3 | API route proxy for launchpad detail |
+| `frontend/packages/components/pi/SupplyChain.tsx` | 5 | Supply chain analysis table with tier filter and expandable detail |
+| `frontend/pages/api/pi/supply-chain.ts` | 5 | API route proxy for supply chain endpoint |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `internal/models/models.go` | PI model structs |
+| `internal/client/esiClient.go` | GetCharacterPlanets, GetCharacterPlanetDetails |
+| `internal/repositories/character.go` | GetNames method |
+| `internal/repositories/solarSystems.go` | GetNames method |
+| `internal/repositories/sdeData.go` | GetAllSchematics, GetAllSchematicTypes |
+| `cmd/industry-tool/cmd/root.go` | Wire PI components (updater, runner, controller, stall notifier) |
+| `cmd/industry-tool/cmd/settings.go` | PiUpdateIntervalSec setting |
+| `internal/repositories/marketPrices.go` | GetAllJitaPrices (used by profit endpoint) |
+| `internal/updaters/notifications.go` | `PiStallNotifier` interface, `NotifyPiStall`, `buildPiStallEmbed` |
+| `frontend/packages/components/settings/DiscordSettings.tsx` | Added `pi_stall` event type |
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PI_UPDATE_INTERVAL_SEC` | `3600` | How often to refresh PI data from ESI |

--- a/frontend/packages/client/data/models.ts
+++ b/frontend/packages/client/data/models.ts
@@ -157,3 +157,191 @@ export type PlanResponse = {
   shopping_list: ShoppingItem[];
   summary: PlanSummary;
 };
+
+// Planetary Industry Types
+
+export type PiPinContent = {
+  typeId: number;
+  name: string;
+  amount: number;
+};
+
+export type PiExtractor = {
+  pinId: number;
+  typeId: number;
+  productTypeId: number;
+  productName: string;
+  qtyPerCycle: number;
+  cycleTimeSec: number;
+  ratePerHour: number;
+  expiryTime: string | null;
+  status: string;
+  numHeads: number;
+};
+
+export type PiFactory = {
+  pinId: number;
+  typeId: number;
+  schematicId: number;
+  schematicName: string;
+  outputTypeId: number;
+  outputName: string;
+  outputQty: number;
+  cycleTimeSec: number;
+  ratePerHour: number;
+  lastCycleStart: string | null;
+  status: string;
+  pinCategory: string;
+};
+
+export type PiLaunchpad = {
+  pinId: number;
+  typeId: number;
+  label?: string;
+  contents: PiPinContent[];
+};
+
+// Launchpad Detail Types
+
+export type LaunchpadInputRequirement = {
+  typeId: number;
+  name: string;
+  qtyPerCycle: number;
+  cyclesPerHour: number;
+  consumedPerHour: number;
+  currentStock: number;
+  depletionHours: number;
+};
+
+export type LaunchpadConnectedFactory = {
+  pinId: number;
+  schematicName: string;
+  outputName: string;
+  outputTypeId: number;
+  cycleTimeSec: number;
+  inputs: LaunchpadInputRequirement[];
+};
+
+export type LaunchpadDetailResponse = {
+  pinId: number;
+  characterId: number;
+  planetId: number;
+  label?: string;
+  contents: PiPinContent[];
+  factories: LaunchpadConnectedFactory[];
+};
+
+export type PiPlanet = {
+  planetId: number;
+  planetType: string;
+  solarSystemId: number;
+  solarSystemName: string;
+  characterId: number;
+  characterName: string;
+  upgradeLevel: number;
+  numPins: number;
+  lastUpdate: string;
+  status: string;
+  extractors: PiExtractor[];
+  factories: PiFactory[];
+  launchpads: PiLaunchpad[];
+};
+
+export type PiPlanetsResponse = {
+  planets: PiPlanet[];
+};
+
+export type PiTaxConfig = {
+  id?: number;
+  userId?: number;
+  planetId: number | null;
+  taxRate: number;
+};
+
+// PI Profit Types
+
+export type PiFactoryInput = {
+  typeId: number;
+  name: string;
+  tier: string;
+  quantity: number;
+  pricePerUnit: number;
+  costPerHour: number;
+  importTaxPerHour: number;
+  isLocal: boolean;
+};
+
+export type PiFactoryProfit = {
+  pinId: number;
+  schematicId: number;
+  schematicName: string;
+  outputTypeId: number;
+  outputName: string;
+  outputTier: string;
+  outputQty: number;
+  cycleTimeSec: number;
+  ratePerHour: number;
+  outputValuePerHour: number;
+  inputCostPerHour: number;
+  exportTaxPerHour: number;
+  importTaxPerHour: number;
+  profitPerHour: number;
+  inputs: PiFactoryInput[];
+};
+
+export type PiPlanetProfit = {
+  planetId: number;
+  planetType: string;
+  solarSystemId: number;
+  solarSystemName: string;
+  characterId: number;
+  characterName: string;
+  taxRate: number;
+  totalOutputValue: number;
+  totalInputCost: number;
+  totalExportTax: number;
+  totalImportTax: number;
+  netProfitPerHour: number;
+  factories: PiFactoryProfit[];
+};
+
+export type PiProfitResponse = {
+  planets: PiPlanetProfit[];
+  priceSource: string;
+  totalOutputValue: number;
+  totalInputCost: number;
+  totalExportTax: number;
+  totalImportTax: number;
+  totalProfit: number;
+};
+
+// PI Supply Chain Types
+
+export type SupplyChainPlanetEntry = {
+  characterId: number;
+  characterName: string;
+  planetId: number;
+  solarSystemName: string;
+  planetType: string;
+  ratePerHour: number;
+};
+
+export type SupplyChainItem = {
+  typeId: number;
+  name: string;
+  tier: number;
+  tierName: string;
+  producedPerHour: number;
+  consumedPerHour: number;
+  netPerHour: number;
+  stockpileQty: number;
+  depletionHours: number;
+  source: string;
+  producers: SupplyChainPlanetEntry[];
+  consumers: SupplyChainPlanetEntry[];
+  stockpileMarkers?: StockpileMarker[];
+};
+
+export type SupplyChainResponse = {
+  items: SupplyChainItem[];
+};

--- a/frontend/packages/components/Navbar.tsx
+++ b/frontend/packages/components/Navbar.tsx
@@ -96,6 +96,9 @@ export default function Navbar() {
           <Button color="inherit" href="/reactions">
             Reactions
           </Button>
+          <Button color="inherit" href="/pi">
+            Planets
+          </Button>
           <Button color="inherit" href="/settings">
             Settings
           </Button>

--- a/frontend/packages/components/__tests__/__snapshots__/Navbar.test.tsx.snap
+++ b/frontend/packages/components/__tests__/__snapshots__/Navbar.test.tsx.snap
@@ -90,6 +90,13 @@ exports[`Navbar Component should match snapshot when not authenticated 1`] = `
       </a>
       <a
         class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-plnrbk-MuiButtonBase-root-MuiButton-root"
+        href="/pi"
+        tabindex="0"
+      >
+        Planets
+      </a>
+      <a
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-plnrbk-MuiButtonBase-root-MuiButton-root"
         href="/settings"
         tabindex="0"
       >

--- a/frontend/packages/components/pi/LaunchpadDetail.tsx
+++ b/frontend/packages/components/pi/LaunchpadDetail.tsx
@@ -1,0 +1,461 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import {
+  LaunchpadDetailResponse,
+  PiPinContent,
+} from '@industry-tool/client/data/models';
+import { formatNumber } from '@industry-tool/utils/formatting';
+import Drawer from '@mui/material/Drawer';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import CircularProgress from '@mui/material/CircularProgress';
+import TextField from '@mui/material/TextField';
+import CloseIcon from '@mui/icons-material/Close';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
+import FactoryIcon from '@mui/icons-material/Factory';
+import InventoryIcon from '@mui/icons-material/Inventory';
+import EditIcon from '@mui/icons-material/Edit';
+
+type LaunchpadDetailProps = {
+  open: boolean;
+  onClose: () => void;
+  characterId: number;
+  planetId: number;
+  pinId: number;
+  planetName: string;
+  onLabelChange?: (characterId: number, planetId: number, pinId: number, label: string) => void;
+};
+
+function formatDepletion(hours: number): string {
+  if (hours <= 0) return 'Empty';
+  const days = Math.floor(hours / 24);
+  const h = Math.floor(hours % 24);
+  if (days > 0) return `${days}d ${h}h`;
+  const m = Math.round((hours % 1) * 60);
+  return `${h}h ${m}m`;
+}
+
+function depletionColor(hours: number): string {
+  if (hours <= 0) return '#ef4444';
+  if (hours < 24) return '#ef4444';
+  if (hours < 72) return '#f59e0b';
+  return '#10b981';
+}
+
+export default function LaunchpadDetail({
+  open,
+  onClose,
+  characterId,
+  planetId,
+  pinId,
+  planetName,
+  onLabelChange,
+}: LaunchpadDetailProps) {
+  const [data, setData] = useState<LaunchpadDetailResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [label, setLabel] = useState('');
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const [savingLabel, setSavingLabel] = useState(false);
+  const labelInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      fetchDetail();
+    } else {
+      setData(null);
+      setError(null);
+      setEditing(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, characterId, planetId, pinId]);
+
+  useEffect(() => {
+    if (data) {
+      setLabel(data.label || '');
+    }
+  }, [data]);
+
+  useEffect(() => {
+    if (editing && labelInputRef.current) {
+      labelInputRef.current.focus();
+    }
+  }, [editing]);
+
+  const fetchDetail = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({
+        characterId: String(characterId),
+        planetId: String(planetId),
+        pinId: String(pinId),
+      });
+      const response = await fetch(`/api/pi/launchpad-detail?${params}`);
+      if (response.ok) {
+        const result: LaunchpadDetailResponse = await response.json();
+        setData(result);
+      } else {
+        setError('Failed to load launchpad details');
+      }
+    } catch {
+      setError('Failed to load launchpad details');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const startEditing = useCallback(() => {
+    setEditValue(label);
+    setEditing(true);
+  }, [label]);
+
+  const cancelEditing = useCallback(() => {
+    setEditing(false);
+    setEditValue('');
+  }, []);
+
+  const saveLabel = useCallback(async () => {
+    const trimmed = editValue.trim();
+    setSavingLabel(true);
+
+    try {
+      if (trimmed === '') {
+        await fetch('/api/pi/launchpad-labels', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ characterId, planetId, pinId }),
+        });
+        setLabel('');
+        onLabelChange?.(characterId, planetId, pinId, '');
+      } else {
+        await fetch('/api/pi/launchpad-labels', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ characterId, planetId, pinId, label: trimmed }),
+        });
+        setLabel(trimmed);
+        onLabelChange?.(characterId, planetId, pinId, trimmed);
+      }
+    } catch {
+      // Silently fail, keep old label
+    } finally {
+      setSavingLabel(false);
+      setEditing(false);
+    }
+  }, [editValue, characterId, planetId, pinId, onLabelChange]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        saveLabel();
+      } else if (e.key === 'Escape') {
+        cancelEditing();
+      }
+    },
+    [saveLabel, cancelEditing]
+  );
+
+  const sortedContents = data
+    ? [...data.contents].sort((a, b) => b.amount - a.amount)
+    : [];
+
+  // Aggregate input requirements across all connected factories
+  const aggregatedInputs = useMemo(() => {
+    if (!data) return [];
+    const map = new Map<number, { typeId: number; name: string; consumedPerHour: number; currentStock: number; depletionHours: number }>();
+    for (const factory of data.factories) {
+      for (const inp of factory.inputs) {
+        const existing = map.get(inp.typeId);
+        if (existing) {
+          existing.consumedPerHour += inp.consumedPerHour;
+        } else {
+          map.set(inp.typeId, {
+            typeId: inp.typeId,
+            name: inp.name,
+            consumedPerHour: inp.consumedPerHour,
+            currentStock: inp.currentStock,
+            depletionHours: 0,
+          });
+        }
+      }
+    }
+    // Recalculate depletion from aggregated consumption
+    for (const item of map.values()) {
+      if (item.consumedPerHour > 0 && item.currentStock > 0) {
+        item.depletionHours = item.currentStock / item.consumedPerHour;
+      }
+    }
+    return Array.from(map.values()).sort((a, b) => a.depletionHours - b.depletionHours);
+  }, [data]);
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          width: 450,
+          maxWidth: '100vw',
+          bgcolor: '#0a0e1a',
+          borderLeft: '1px solid rgba(59, 130, 246, 0.15)',
+        },
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: 2.5,
+          py: 2,
+          borderBottom: '1px solid rgba(148, 163, 184, 0.1)',
+          background: 'linear-gradient(135deg, rgba(59, 130, 246, 0.05) 0%, #0a0e1a 100%)',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0, flex: 1 }}>
+          <RocketLaunchIcon sx={{ color: '#3b82f6', fontSize: 24, flexShrink: 0 }} />
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography
+              variant="body1"
+              sx={{ color: '#e2e8f0', fontWeight: 600, lineHeight: 1.3 }}
+              noWrap
+            >
+              {planetName}
+            </Typography>
+            {/* Editable label */}
+            {editing ? (
+              <TextField
+                inputRef={labelInputRef}
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onBlur={saveLabel}
+                onKeyDown={handleKeyDown}
+                disabled={savingLabel}
+                size="small"
+                placeholder="Enter label..."
+                variant="standard"
+                sx={{
+                  mt: 0.25,
+                  '& .MuiInput-root': {
+                    color: '#94a3b8',
+                    fontSize: '0.75rem',
+                    '&:before': { borderColor: 'rgba(59, 130, 246, 0.3)' },
+                    '&:after': { borderColor: '#3b82f6' },
+                  },
+                  '& .MuiInputBase-input': { py: 0.25 },
+                }}
+              />
+            ) : (
+              <Box
+                onClick={startEditing}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.5,
+                  cursor: 'pointer',
+                  '&:hover': { '& .edit-icon': { opacity: 1 } },
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: label ? '#94a3b8' : '#475569',
+                    fontStyle: label ? 'normal' : 'italic',
+                  }}
+                >
+                  {label || 'Add label...'}
+                </Typography>
+                <EditIcon
+                  className="edit-icon"
+                  sx={{
+                    fontSize: 12,
+                    color: '#475569',
+                    opacity: label ? 0 : 0.5,
+                    transition: 'opacity 0.15s',
+                  }}
+                />
+              </Box>
+            )}
+          </Box>
+        </Box>
+        <IconButton onClick={onClose} size="small" sx={{ color: '#64748b', ml: 1 }}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Box>
+
+      {/* Content */}
+      <Box sx={{ flex: 1, overflow: 'auto', px: 2.5, py: 2 }}>
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+            <CircularProgress size={36} sx={{ color: '#3b82f6' }} />
+          </Box>
+        )}
+
+        {error && !loading && (
+          <Box sx={{ textAlign: 'center', py: 8 }}>
+            <Typography variant="body2" sx={{ color: '#ef4444' }}>
+              {error}
+            </Typography>
+          </Box>
+        )}
+
+        {data && !loading && (
+          <>
+            {/* Input Requirements (aggregated across all factories) */}
+            <SectionHeader
+              icon={<FactoryIcon sx={{ fontSize: 16, color: '#3b82f6' }} />}
+              label={`Input Requirements (${aggregatedInputs.length})`}
+            />
+            {aggregatedInputs.length === 0 ? (
+              <Typography variant="caption" sx={{ color: '#475569', display: 'block', mb: 2 }}>
+                No factory inputs tracked
+              </Typography>
+            ) : (
+              <Box sx={{ mb: 3 }}>
+                {aggregatedInputs.map((input) => (
+                  <InputRow key={input.typeId} input={input} />
+                ))}
+              </Box>
+            )}
+
+            <Divider sx={{ borderColor: 'rgba(148, 163, 184, 0.08)', mb: 2 }} />
+
+            {/* Current Contents */}
+            <SectionHeader
+              icon={<InventoryIcon sx={{ fontSize: 16, color: '#3b82f6' }} />}
+              label={`Current Contents (${sortedContents.length})`}
+            />
+            {sortedContents.length === 0 ? (
+              <Typography variant="caption" sx={{ color: '#475569' }}>
+                Launchpad is empty
+              </Typography>
+            ) : (
+              <Box>
+                {sortedContents.map((item) => (
+                  <ContentRow key={item.typeId} item={item} />
+                ))}
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+    </Drawer>
+  );
+}
+
+function SectionHeader({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 1.5 }}>
+      {icon}
+      <Typography
+        variant="caption"
+        sx={{
+          color: '#64748b',
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: 0.5,
+        }}
+      >
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+type AggregatedInput = {
+  typeId: number;
+  name: string;
+  consumedPerHour: number;
+  currentStock: number;
+  depletionHours: number;
+};
+
+function InputRow({ input }: { input: AggregatedInput }) {
+  const color = depletionColor(input.depletionHours);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        py: 0.5,
+        '&:not(:last-child)': {
+          borderBottom: '1px solid rgba(148, 163, 184, 0.05)',
+        },
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0, flex: 1 }}>
+        <img
+          src={`https://images.evetech.net/types/${input.typeId}/icon?size=32`}
+          alt=""
+          width={18}
+          height={18}
+          style={{ flexShrink: 0 }}
+        />
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="caption" sx={{ color: '#cbd5e1', display: 'block' }} noWrap>
+            {input.name}
+          </Typography>
+          <Typography variant="caption" sx={{ color: '#475569', fontSize: '0.65rem' }}>
+            {formatNumber(input.consumedPerHour)}/hr
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box sx={{ textAlign: 'right', flexShrink: 0, ml: 1 }}>
+        <Typography variant="caption" sx={{ color: '#94a3b8', display: 'block' }}>
+          {formatNumber(input.currentStock)}
+        </Typography>
+        <Typography
+          variant="caption"
+          sx={{
+            color,
+            fontWeight: 600,
+            fontSize: '0.65rem',
+          }}
+        >
+          {formatDepletion(input.depletionHours)}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+function ContentRow({ item }: { item: PiPinContent }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        py: 0.5,
+        '&:not(:last-child)': {
+          borderBottom: '1px solid rgba(148, 163, 184, 0.05)',
+        },
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0 }}>
+        <img
+          src={`https://images.evetech.net/types/${item.typeId}/icon?size=32`}
+          alt=""
+          width={18}
+          height={18}
+          style={{ flexShrink: 0 }}
+        />
+        <Typography variant="caption" sx={{ color: '#cbd5e1' }} noWrap>
+          {item.name || `Type ${item.typeId}`}
+        </Typography>
+      </Box>
+      <Typography variant="caption" sx={{ color: '#94a3b8', fontWeight: 500, flexShrink: 0, ml: 1 }}>
+        {formatNumber(item.amount)}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/packages/components/pi/PlanetOverview.tsx
+++ b/frontend/packages/components/pi/PlanetOverview.tsx
@@ -1,0 +1,480 @@
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { useSession } from "next-auth/react";
+import Navbar from "@industry-tool/components/Navbar";
+import Loading from "@industry-tool/components/loading";
+import LaunchpadDetail from "@industry-tool/components/pi/LaunchpadDetail";
+import { PiPlanet, PiPlanetsResponse } from "@industry-tool/client/data/models";
+import { formatNumber } from "@industry-tool/utils/formatting";
+import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import SearchIcon from '@mui/icons-material/Search';
+import PublicIcon from '@mui/icons-material/Public';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import ErrorIcon from '@mui/icons-material/Error';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+
+const PLANET_TYPE_IDS: Record<string, number> = {
+  temperate: 11,
+  ice: 12,
+  gas: 13,
+  oceanic: 2014,
+  lava: 2015,
+  barren: 2016,
+  storm: 2017,
+  plasma: 2063,
+};
+
+const PLANET_TYPE_COLORS: Record<string, string> = {
+  temperate: '#10b981',
+  barren: '#94a3b8',
+  oceanic: '#3b82f6',
+  ice: '#67e8f9',
+  gas: '#f59e0b',
+  lava: '#ef4444',
+  storm: '#8b5cf6',
+  plasma: '#ec4899',
+};
+
+function getStatusColor(status: string): string {
+  switch (status) {
+    case 'running': return '#10b981';
+    case 'expired': return '#ef4444';
+    case 'stalled': return '#f59e0b';
+    case 'stale_data': return '#94a3b8';
+    default: return '#94a3b8';
+  }
+}
+
+function getStatusLabel(status: string): string {
+  switch (status) {
+    case 'running': return 'Running';
+    case 'expired': return 'Expired';
+    case 'stalled': return 'Stalled';
+    case 'stale_data': return 'Stale Data';
+    default: return status;
+  }
+}
+
+function getStatusIcon(status: string) {
+  switch (status) {
+    case 'running': return <CheckCircleIcon sx={{ fontSize: 14 }} />;
+    case 'expired': return <ErrorIcon sx={{ fontSize: 14 }} />;
+    case 'stalled': return <WarningAmberIcon sx={{ fontSize: 14 }} />;
+    case 'stale_data': return <AccessTimeIcon sx={{ fontSize: 14 }} />;
+    default: return null;
+  }
+}
+
+function formatTimeAgo(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays > 0) return `${diffDays}d ${diffHours % 24}h ago`;
+  if (diffHours > 0) return `${diffHours}h ago`;
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  return `${diffMins}m ago`;
+}
+
+function formatTimeUntil(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+  if (diffMs <= 0) return 'Expired';
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays > 0) return `${diffDays}d ${diffHours % 24}h`;
+  if (diffHours > 0) return `${diffHours}h ${Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60))}m`;
+  return `${Math.floor(diffMs / (1000 * 60))}m`;
+}
+
+type LaunchpadSelection = {
+  characterId: number;
+  planetId: number;
+  pinId: number;
+  planetName: string;
+};
+
+function PlanetCard({ planet, onLaunchpadClick }: { planet: PiPlanet; onLaunchpadClick: (sel: LaunchpadSelection) => void }) {
+  const typeColor = PLANET_TYPE_COLORS[planet.planetType] || '#94a3b8';
+  const statusColor = getStatusColor(planet.status);
+  const hasIssues = planet.status !== 'running';
+
+  return (
+    <Card
+      sx={{
+        background: hasIssues
+          ? `linear-gradient(135deg, rgba(239, 68, 68, 0.05) 0%, #12151f 100%)`
+          : `linear-gradient(135deg, rgba(59, 130, 246, 0.05) 0%, #12151f 100%)`,
+        border: `1px solid ${hasIssues ? 'rgba(239, 68, 68, 0.2)' : 'rgba(59, 130, 246, 0.15)'}`,
+        borderRadius: 2,
+        height: '100%',
+      }}
+    >
+      <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+        {/* Header */}
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+            <img
+              src={`https://images.evetech.net/types/${PLANET_TYPE_IDS[planet.planetType] || 11}/icon?size=64`}
+              alt={planet.planetType}
+              width={28}
+              height={28}
+              style={{ flexShrink: 0, borderRadius: '50%' }}
+            />
+            <Box sx={{ minWidth: 0 }}>
+              <Typography variant="body2" sx={{ color: '#e2e8f0', fontWeight: 600, lineHeight: 1.2 }} noWrap>
+                {planet.solarSystemName}
+              </Typography>
+              <Typography variant="caption" sx={{ color: '#64748b' }}>
+                {planet.planetType.charAt(0).toUpperCase() + planet.planetType.slice(1)} - {planet.characterName}
+              </Typography>
+            </Box>
+          </Box>
+          <Chip
+            icon={getStatusIcon(planet.status) || undefined}
+            label={getStatusLabel(planet.status)}
+            size="small"
+            sx={{
+              bgcolor: `${statusColor}20`,
+              color: statusColor,
+              border: `1px solid ${statusColor}40`,
+              fontWeight: 600,
+              fontSize: '0.7rem',
+              height: 24,
+              flexShrink: 0,
+              '& .MuiChip-icon': { color: statusColor },
+            }}
+          />
+        </Box>
+
+        {/* Extractors */}
+        {planet.extractors.length > 0 && (
+          <Box sx={{ mb: 1 }}>
+            <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+              Extractors
+            </Typography>
+            {planet.extractors.map((ext) => (
+              <Box key={ext.pinId} sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 0.25 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                  <img src={`https://images.evetech.net/types/${ext.productTypeId}/icon?size=32`} alt="" width={16} height={16} style={{ flexShrink: 0 }} />
+                  <Typography variant="caption" sx={{ color: ext.status === 'expired' ? '#ef4444' : '#cbd5e1' }} noWrap>
+                    {ext.productName || `Type ${ext.productTypeId}`}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+                    {formatNumber(Math.round(ext.ratePerHour))}/hr
+                  </Typography>
+                  {ext.expiryTime && (
+                    <Typography variant="caption" sx={{ color: ext.status === 'expired' ? '#ef4444' : '#10b981', fontWeight: 500 }}>
+                      {formatTimeUntil(ext.expiryTime)}
+                    </Typography>
+                  )}
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {/* Factories */}
+        {planet.factories.length > 0 && (
+          <Box sx={{ mb: 1 }}>
+            <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+              Factories ({planet.factories.length})
+            </Typography>
+            {/* Group by schematic */}
+            {Object.entries(
+              planet.factories.reduce<Record<string, { count: number; ratePerHour: number; status: string; outputTypeId: number }>>((acc, f) => {
+                const key = f.schematicName || `Unknown (${f.schematicId})`;
+                if (!acc[key]) acc[key] = { count: 0, ratePerHour: 0, status: 'running', outputTypeId: f.outputTypeId };
+                acc[key].count++;
+                acc[key].ratePerHour += f.ratePerHour;
+                if (f.status === 'stalled') acc[key].status = 'stalled';
+                return acc;
+              }, {})
+            ).map(([name, info]) => (
+              <Box key={name} sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 0.25 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                  {info.outputTypeId > 0 && (
+                    <img src={`https://images.evetech.net/types/${info.outputTypeId}/icon?size=32`} alt="" width={16} height={16} style={{ flexShrink: 0 }} />
+                  )}
+                  <Typography variant="caption" sx={{ color: info.status === 'stalled' ? '#f59e0b' : '#cbd5e1' }} noWrap>
+                    {info.count}x {name}
+                  </Typography>
+                </Box>
+                <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+                  {formatNumber(Math.round(info.ratePerHour))}/hr
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {/* Launchpads */}
+        {planet.launchpads.length > 0 && (
+          <Box sx={{ mb: 1 }}>
+            <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+              Storage ({planet.launchpads.length})
+            </Typography>
+            {planet.launchpads.map((lp) => (
+              <Box
+                key={lp.pinId}
+                onClick={() => onLaunchpadClick({
+                  characterId: planet.characterId,
+                  planetId: planet.planetId,
+                  pinId: lp.pinId,
+                  planetName: `${planet.solarSystemName} - ${planet.planetType.charAt(0).toUpperCase() + planet.planetType.slice(1)}`,
+                })}
+                sx={{
+                  mt: 0.5,
+                  px: 0.75,
+                  py: 0.5,
+                  borderRadius: 0.75,
+                  cursor: 'pointer',
+                  border: '1px solid transparent',
+                  '&:hover': { bgcolor: 'rgba(59, 130, 246, 0.06)', borderColor: 'rgba(59, 130, 246, 0.15)' },
+                }}
+              >
+                <Typography variant="caption" sx={{ color: lp.label ? '#94a3b8' : '#475569', fontWeight: lp.label ? 500 : 400, fontStyle: lp.label ? 'normal' : 'italic' }}>
+                  {lp.label || `Launchpad`}
+                </Typography>
+                {lp.contents.length === 0 ? (
+                  <Typography variant="caption" sx={{ color: '#475569', display: 'block', fontSize: '0.65rem' }}>
+                    Empty
+                  </Typography>
+                ) : (
+                  lp.contents.sort((a, b) => b.amount - a.amount).slice(0, 3).map((item) => (
+                    <Box key={item.typeId} sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                        <img src={`https://images.evetech.net/types/${item.typeId}/icon?size=32`} alt="" width={14} height={14} style={{ flexShrink: 0 }} />
+                        <Typography variant="caption" sx={{ color: '#cbd5e1', fontSize: '0.65rem' }} noWrap>
+                          {item.name || `Type ${item.typeId}`}
+                        </Typography>
+                      </Box>
+                      <Typography variant="caption" sx={{ color: '#94a3b8', flexShrink: 0, ml: 1, fontSize: '0.65rem' }}>
+                        {formatNumber(item.amount)}
+                      </Typography>
+                    </Box>
+                  ))
+                )}
+                {lp.contents.length > 3 && (
+                  <Typography variant="caption" sx={{ color: '#475569', fontSize: '0.6rem' }}>
+                    +{lp.contents.length - 3} more
+                  </Typography>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {/* Footer */}
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 1, pt: 1, borderTop: '1px solid rgba(148, 163, 184, 0.1)' }}>
+          <Typography variant="caption" sx={{ color: '#475569' }}>
+            CC{planet.upgradeLevel}
+          </Typography>
+          <Typography variant="caption" sx={{ color: '#475569' }}>
+            Updated {formatTimeAgo(planet.lastUpdate)}
+          </Typography>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function PlanetOverview({ embedded }: { embedded?: boolean }) {
+  const { data: session } = useSession();
+  const [planets, setPlanets] = useState<PiPlanet[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const hasFetchedRef = useRef(false);
+  const [selectedLaunchpad, setSelectedLaunchpad] = useState<LaunchpadSelection | null>(null);
+
+  useEffect(() => {
+    if (session && !hasFetchedRef.current) {
+      hasFetchedRef.current = true;
+      fetchPlanets();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session]);
+
+  const fetchPlanets = async () => {
+    if (!session) return;
+    setLoading(true);
+    try {
+      const response = await fetch('/api/pi/planets');
+      if (response.ok) {
+        const data: PiPlanetsResponse = await response.json();
+        setPlanets(data.planets || []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filteredPlanets = useMemo(() => {
+    if (!searchQuery) return planets;
+    const query = searchQuery.toLowerCase();
+    return planets.filter(
+      (p) =>
+        p.solarSystemName.toLowerCase().includes(query) ||
+        p.characterName.toLowerCase().includes(query) ||
+        p.planetType.toLowerCase().includes(query)
+    );
+  }, [planets, searchQuery]);
+
+  const stats = useMemo(() => {
+    const total = planets.length;
+    const running = planets.filter(p => p.status === 'running').length;
+    const stalled = planets.filter(p => p.status === 'stalled' || p.status === 'expired').length;
+    const stale = planets.filter(p => p.status === 'stale_data').length;
+    const totalExtractors = planets.reduce((sum, p) => sum + p.extractors.length, 0);
+    const totalFactories = planets.reduce((sum, p) => sum + p.factories.length, 0);
+    return { total, running, stalled, stale, totalExtractors, totalFactories };
+  }, [planets]);
+
+  if (loading) {
+    if (embedded) return <Loading />;
+    return (
+      <>
+        <Navbar />
+        <Loading />
+      </>
+    );
+  }
+
+  const content = (
+    <>
+        {/* Stats Row */}
+        <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+          <StatChip label="Planets" value={stats.total} color="#3b82f6" />
+          <StatChip label="Running" value={stats.running} color="#10b981" />
+          {stats.stalled > 0 && <StatChip label="Issues" value={stats.stalled} color="#ef4444" />}
+          {stats.stale > 0 && <StatChip label="Stale" value={stats.stale} color="#94a3b8" />}
+          <StatChip label="Extractors" value={stats.totalExtractors} color="#f59e0b" />
+          <StatChip label="Factories" value={stats.totalFactories} color="#8b5cf6" />
+        </Box>
+
+        {/* Search */}
+        <TextField
+          size="small"
+          placeholder="Search planets..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ color: '#64748b', fontSize: 20 }} />
+                </InputAdornment>
+              ),
+            },
+          }}
+          sx={{
+            mb: 2,
+            width: 300,
+            '& .MuiOutlinedInput-root': {
+              bgcolor: '#12151f',
+              '& fieldset': { borderColor: 'rgba(148, 163, 184, 0.15)' },
+              '&:hover fieldset': { borderColor: 'rgba(59, 130, 246, 0.3)' },
+            },
+            '& .MuiInputBase-input': { color: '#e2e8f0', fontSize: '0.875rem' },
+          }}
+        />
+
+        {/* Planet Grid */}
+        {filteredPlanets.length === 0 ? (
+          <Box sx={{ textAlign: 'center', py: 8 }}>
+            <PublicIcon sx={{ fontSize: 48, color: '#475569', mb: 1 }} />
+            <Typography variant="body1" sx={{ color: '#64748b' }}>
+              {planets.length === 0
+                ? 'No planets found. Make sure your characters have the PI scope and data has been refreshed.'
+                : 'No planets match your search.'}
+            </Typography>
+          </Box>
+        ) : (
+          <Grid container spacing={2}>
+            {filteredPlanets.map((planet) => (
+              <Grid key={`${planet.characterId}-${planet.planetId}`} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+                <PlanetCard planet={planet} onLaunchpadClick={setSelectedLaunchpad} />
+              </Grid>
+            ))}
+          </Grid>
+        )}
+    </>
+  );
+
+  const handleLabelChange = (characterId: number, planetId: number, pinId: number, label: string) => {
+    setPlanets(prev => prev.map(p => {
+      if (p.characterId !== characterId || p.planetId !== planetId) return p;
+      return {
+        ...p,
+        launchpads: p.launchpads.map(lp =>
+          lp.pinId === pinId ? { ...lp, label: label || undefined } : lp
+        ),
+      };
+    }));
+  };
+
+  const drawer = (
+    <LaunchpadDetail
+      open={selectedLaunchpad !== null}
+      onClose={() => setSelectedLaunchpad(null)}
+      characterId={selectedLaunchpad?.characterId ?? 0}
+      planetId={selectedLaunchpad?.planetId ?? 0}
+      pinId={selectedLaunchpad?.pinId ?? 0}
+      planetName={selectedLaunchpad?.planetName ?? ''}
+      onLabelChange={handleLabelChange}
+    />
+  );
+
+  if (embedded) return <>{content}{drawer}</>;
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
+        <Typography variant="h5" sx={{ color: '#e2e8f0', mb: 2, fontWeight: 600 }}>
+          Planetary Industry
+        </Typography>
+        {content}
+      </Container>
+      {drawer}
+    </>
+  );
+}
+
+function StatChip({ label, value, color }: { label: string; value: number; color: string }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+        px: 1.5,
+        py: 0.5,
+        borderRadius: 1,
+        bgcolor: `${color}10`,
+        border: `1px solid ${color}30`,
+      }}
+    >
+      <Typography variant="caption" sx={{ color: '#94a3b8', fontWeight: 500 }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ color, fontWeight: 700 }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/packages/components/pi/ProfitTable.tsx
+++ b/frontend/packages/components/pi/ProfitTable.tsx
@@ -1,0 +1,406 @@
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { useSession } from "next-auth/react";
+import Loading from "@industry-tool/components/loading";
+import { PiProfitResponse, PiFactoryProfit } from "@industry-tool/client/data/models";
+import { formatISK, formatNumber } from "@industry-tool/utils/formatting";
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import IconButton from '@mui/material/IconButton';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+
+type ProductGroup = {
+  outputTypeId: number;
+  outputName: string;
+  outputTier: string;
+  totalRatePerHour: number;
+  totalOutputValue: number;
+  totalInputCost: number;
+  totalExportTax: number;
+  totalImportTax: number;
+  totalProfit: number;
+  factories: FactoryWithPlanet[];
+};
+
+type FactoryWithPlanet = PiFactoryProfit & {
+  solarSystemName: string;
+  characterName: string;
+  planetType: string;
+};
+
+function profitColor(value: number): string {
+  if (value > 0) return '#10b981';
+  if (value < 0) return '#ef4444';
+  return '#94a3b8';
+}
+
+const TIER_ORDER: Record<string, number> = { R0: 0, P1: 1, P2: 2, P3: 3, P4: 4 };
+
+function ProductGroupRow({ group, expanded, onToggle }: {
+  group: ProductGroup;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const totalTax = group.totalExportTax + group.totalImportTax;
+
+  return (
+    <>
+      <TableRow
+        sx={{
+          cursor: 'pointer',
+          '&:hover': { bgcolor: 'rgba(59, 130, 246, 0.05)' },
+          bgcolor: expanded ? 'rgba(59, 130, 246, 0.03)' : 'transparent',
+        }}
+        onClick={onToggle}
+      >
+        <TableCell sx={{ color: '#e2e8f0', borderColor: 'rgba(148, 163, 184, 0.1)', width: 40, p: 1 }}>
+          <IconButton size="small" sx={{ color: '#64748b', p: 0.5 }}>
+            {expanded ? <KeyboardArrowDownIcon fontSize="small" /> : <KeyboardArrowRightIcon fontSize="small" />}
+          </IconButton>
+        </TableCell>
+        <TableCell sx={{ color: '#e2e8f0', borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {group.outputTypeId > 0 && (
+              <img
+                src={`https://images.evetech.net/types/${group.outputTypeId}/icon?size=32`}
+                alt="" width={20} height={20} style={{ flexShrink: 0 }}
+              />
+            )}
+            <Box>
+              <Typography variant="body2" sx={{ color: '#e2e8f0', fontWeight: 500, lineHeight: 1.2 }}>
+                {group.outputName}
+              </Typography>
+              <Typography variant="caption" sx={{ color: '#64748b' }}>
+                {group.outputTier} &middot; {group.factories.length} {group.factories.length === 1 ? 'factory' : 'factories'}
+              </Typography>
+            </Box>
+          </Box>
+        </TableCell>
+        <TableCell align="right" sx={{ color: '#94a3b8', borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+          {formatNumber(Math.round(group.totalRatePerHour))}/hr
+        </TableCell>
+        <TableCell align="right" sx={{ color: '#10b981', borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+          {formatISK(group.totalOutputValue)}
+        </TableCell>
+        <TableCell align="right" sx={{ color: '#ef4444', borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+          {formatISK(group.totalInputCost)}
+        </TableCell>
+        <TableCell align="right" sx={{ color: '#f59e0b', borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+          {formatISK(totalTax)}
+        </TableCell>
+        <TableCell align="right" sx={{ color: profitColor(group.totalProfit), fontWeight: 600, borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+          {formatISK(group.totalProfit)}
+        </TableCell>
+      </TableRow>
+      {expanded && group.factories.map((factory) => (
+        <FactoryDetailRow key={`${factory.pinId}`} factory={factory} />
+      ))}
+    </>
+  );
+}
+
+function FactoryDetailRow({ factory }: { factory: FactoryWithPlanet }) {
+  return (
+    <TableRow sx={{ bgcolor: 'rgba(15, 18, 25, 0.5)' }}>
+      <TableCell sx={{ borderColor: 'rgba(148, 163, 184, 0.05)' }} />
+      <TableCell sx={{ borderColor: 'rgba(148, 163, 184, 0.05)', pl: 6 }}>
+        <Typography variant="caption" sx={{ color: '#cbd5e1' }}>
+          {factory.solarSystemName}
+        </Typography>
+        <Typography variant="caption" sx={{ color: '#475569', ml: 0.5 }}>
+          ({factory.characterName})
+        </Typography>
+      </TableCell>
+      <TableCell align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.05)' }}>
+        <Typography variant="caption" sx={{ color: '#64748b' }}>
+          {formatNumber(Math.round(factory.ratePerHour))}/hr
+        </Typography>
+      </TableCell>
+      <TableCell align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.05)' }}>
+        <Typography variant="caption" sx={{ color: '#10b981' }}>
+          {formatISK(factory.outputValuePerHour)}
+        </Typography>
+      </TableCell>
+      <TableCell align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.05)' }}>
+        <Typography variant="caption" sx={{ color: '#ef4444' }}>
+          {formatISK(factory.inputCostPerHour)}
+        </Typography>
+      </TableCell>
+      <TableCell align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.05)' }}>
+        <Typography variant="caption" sx={{ color: '#f59e0b' }}>
+          {formatISK(factory.exportTaxPerHour + factory.importTaxPerHour)}
+        </Typography>
+      </TableCell>
+      <TableCell align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.05)' }}>
+        <Typography variant="caption" sx={{ color: profitColor(factory.profitPerHour), fontWeight: 600 }}>
+          {formatISK(factory.profitPerHour)}
+        </Typography>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function ProfitTable() {
+  const { data: session } = useSession();
+  const [profitResponse, setProfitResponse] = useState<PiProfitResponse | null>(null);
+  const [priceSource, setPriceSource] = useState<string>('sell');
+  const [loading, setLoading] = useState(true);
+  const [expandedGroups, setExpandedGroups] = useState<Set<number>>(new Set());
+  const hasFetchedRef = useRef(false);
+
+  useEffect(() => {
+    if (session && !hasFetchedRef.current) {
+      hasFetchedRef.current = true;
+      fetchProfit('sell');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session]);
+
+  const fetchProfit = async (source: string) => {
+    if (!session) return;
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/pi/profit?priceSource=${source}`);
+      if (response.ok) {
+        const data: PiProfitResponse = await response.json();
+        setProfitResponse(data);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const profitData = profitResponse?.planets || [];
+
+  const handlePriceSourceChange = (_: React.MouseEvent<HTMLElement>, newSource: string | null) => {
+    if (newSource) {
+      setPriceSource(newSource);
+      hasFetchedRef.current = false;
+      fetchProfit(newSource);
+      hasFetchedRef.current = true;
+    }
+  };
+
+  const toggleGroup = (typeId: number) => {
+    setExpandedGroups(prev => {
+      const next = new Set(prev);
+      if (next.has(typeId)) next.delete(typeId);
+      else next.add(typeId);
+      return next;
+    });
+  };
+
+  // Group all factories across planets by output type
+  const productGroups = useMemo(() => {
+    const groupMap = new Map<number, ProductGroup>();
+
+    for (const planet of profitData) {
+      for (const factory of planet.factories) {
+        let group = groupMap.get(factory.outputTypeId);
+        if (!group) {
+          group = {
+            outputTypeId: factory.outputTypeId,
+            outputName: factory.outputName,
+            outputTier: factory.outputTier,
+            totalRatePerHour: 0,
+            totalOutputValue: 0,
+            totalInputCost: 0,
+            totalExportTax: 0,
+            totalImportTax: 0,
+            totalProfit: 0,
+            factories: [],
+          };
+          groupMap.set(factory.outputTypeId, group);
+        }
+        group.totalRatePerHour += factory.ratePerHour;
+        group.totalOutputValue += factory.outputValuePerHour;
+        group.totalInputCost += factory.inputCostPerHour;
+        group.totalExportTax += factory.exportTaxPerHour;
+        group.totalImportTax += factory.importTaxPerHour;
+        group.totalProfit += factory.profitPerHour;
+        group.factories.push({
+          ...factory,
+          solarSystemName: planet.solarSystemName,
+          characterName: planet.characterName,
+          planetType: planet.planetType,
+        });
+      }
+    }
+
+    // Sort by tier then by name
+    return Array.from(groupMap.values()).sort((a, b) => {
+      const tierDiff = (TIER_ORDER[a.outputTier] ?? 99) - (TIER_ORDER[b.outputTier] ?? 99);
+      if (tierDiff !== 0) return tierDiff;
+      return a.outputName.localeCompare(b.outputName);
+    });
+  }, [profitData]);
+
+  const totals = useMemo(() => {
+    if (!profitResponse) return { output: 0, input: 0, exportTax: 0, importTax: 0, totalTax: 0, profit: 0 };
+    return {
+      output: profitResponse.totalOutputValue,
+      input: profitResponse.totalInputCost,
+      exportTax: profitResponse.totalExportTax,
+      importTax: profitResponse.totalImportTax,
+      totalTax: profitResponse.totalExportTax + profitResponse.totalImportTax,
+      profit: profitResponse.totalProfit,
+    };
+  }, [profitResponse]);
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  return (
+    <Box>
+      {/* Summary cards + controls */}
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2, flexWrap: 'wrap', gap: 2 }}>
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          <SummaryCard
+            label="Revenue / hr"
+            value={formatISK(totals.output)}
+            color="#10b981"
+            icon={<TrendingUpIcon sx={{ fontSize: 18, color: '#10b981' }} />}
+          />
+          <SummaryCard
+            label="Costs / hr"
+            value={formatISK(totals.input)}
+            color="#ef4444"
+            icon={<TrendingDownIcon sx={{ fontSize: 18, color: '#ef4444' }} />}
+          />
+          <SummaryCard
+            label="Taxes / hr"
+            value={formatISK(totals.totalTax)}
+            color="#f59e0b"
+          />
+          <SummaryCard
+            label="Profit / hr"
+            value={formatISK(totals.profit)}
+            color={profitColor(totals.profit)}
+            bold
+          />
+        </Box>
+        <ToggleButtonGroup
+          value={priceSource}
+          exclusive
+          onChange={handlePriceSourceChange}
+          size="small"
+          sx={{
+            '& .MuiToggleButton-root': {
+              color: '#64748b',
+              borderColor: 'rgba(148, 163, 184, 0.2)',
+              textTransform: 'none',
+              fontSize: '0.75rem',
+              px: 1.5,
+              py: 0.5,
+              '&.Mui-selected': {
+                color: '#3b82f6',
+                bgcolor: 'rgba(59, 130, 246, 0.1)',
+                borderColor: 'rgba(59, 130, 246, 0.3)',
+              },
+            },
+          }}
+        >
+          <ToggleButton value="sell">Sell</ToggleButton>
+          <ToggleButton value="buy">Buy</ToggleButton>
+          <ToggleButton value="split">Split</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+
+      {/* Profit table grouped by product */}
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ color: '#64748b', borderColor: 'rgba(148, 163, 184, 0.1)', bgcolor: '#0f1219', width: 40 }} />
+              <TableCell sx={{ color: '#64748b', borderColor: 'rgba(148, 163, 184, 0.1)', bgcolor: '#0f1219' }}>Product</TableCell>
+              <TableCell align="right" sx={{ color: '#64748b', borderColor: 'rgba(148, 163, 184, 0.1)', bgcolor: '#0f1219' }}>Rate</TableCell>
+              <TableCell align="right" sx={{ color: '#64748b', borderColor: 'rgba(148, 163, 184, 0.1)', bgcolor: '#0f1219' }}>Revenue/hr</TableCell>
+              <TableCell align="right" sx={{ color: '#64748b', borderColor: 'rgba(148, 163, 184, 0.1)', bgcolor: '#0f1219' }}>Costs/hr</TableCell>
+              <TableCell align="right" sx={{ color: '#64748b', borderColor: 'rgba(148, 163, 184, 0.1)', bgcolor: '#0f1219' }}>Taxes/hr</TableCell>
+              <TableCell align="right" sx={{ color: '#64748b', borderColor: 'rgba(148, 163, 184, 0.1)', bgcolor: '#0f1219' }}>Profit/hr</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {productGroups.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} align="center" sx={{ color: '#64748b', borderColor: 'rgba(148, 163, 184, 0.1)', py: 4 }}>
+                  No PI profit data available
+                </TableCell>
+              </TableRow>
+            ) : (
+              productGroups.map((group) => (
+                <ProductGroupRow
+                  key={group.outputTypeId}
+                  group={group}
+                  expanded={expandedGroups.has(group.outputTypeId)}
+                  onToggle={() => toggleGroup(group.outputTypeId)}
+                />
+              ))
+            )}
+            {productGroups.length > 0 && (
+              <TableRow sx={{ bgcolor: '#0f1219' }}>
+                <TableCell sx={{ borderColor: 'rgba(148, 163, 184, 0.1)' }} />
+                <TableCell sx={{ color: '#e2e8f0', fontWeight: 600, borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+                  Total ({productGroups.length} products)
+                </TableCell>
+                <TableCell sx={{ borderColor: 'rgba(148, 163, 184, 0.1)' }} />
+                <TableCell align="right" sx={{ color: '#10b981', fontWeight: 600, borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+                  {formatISK(totals.output)}
+                </TableCell>
+                <TableCell align="right" sx={{ color: '#ef4444', fontWeight: 600, borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+                  {formatISK(totals.input)}
+                </TableCell>
+                <TableCell align="right" sx={{ color: '#f59e0b', fontWeight: 600, borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+                  {formatISK(totals.totalTax)}
+                </TableCell>
+                <TableCell align="right" sx={{ color: profitColor(totals.profit), fontWeight: 700, borderColor: 'rgba(148, 163, 184, 0.1)' }}>
+                  {formatISK(totals.profit)}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}
+
+function SummaryCard({ label, value, color, icon, bold }: {
+  label: string;
+  value: string;
+  color: string;
+  icon?: React.ReactNode;
+  bold?: boolean;
+}) {
+  return (
+    <Card sx={{
+      background: `linear-gradient(135deg, ${color}08 0%, #12151f 100%)`,
+      border: `1px solid ${color}25`,
+      borderRadius: 2,
+      minWidth: 140,
+    }}>
+      <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
+          {icon}
+          <Typography variant="caption" sx={{ color: '#64748b' }}>{label}</Typography>
+        </Box>
+        <Typography variant="body2" sx={{ color, fontWeight: bold ? 700 : 600 }}>
+          {value}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/packages/components/pi/SupplyChain.tsx
+++ b/frontend/packages/components/pi/SupplyChain.tsx
@@ -1,0 +1,573 @@
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useSession } from "next-auth/react";
+import Loading from "@industry-tool/components/loading";
+import { SupplyChainResponse, SupplyChainItem, SupplyChainPlanetEntry, StockpileMarker } from '@industry-tool/client/data/models';
+import { formatNumber, formatQuantity } from '@industry-tool/utils/formatting';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import Popover from '@mui/material/Popover';
+import Button from '@mui/material/Button';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+
+const TIERS = ['All', 'R0', 'P1', 'P2', 'P3', 'P4'];
+const TIER_ORDER: Record<string, number> = { R0: 0, P1: 1, P2: 2, P3: 3, P4: 4 };
+
+const RESIZE_PRESETS = [
+  { label: '1 week', hours: 168 },
+  { label: '2 weeks', hours: 336 },
+  { label: '1 month', hours: 720 },
+];
+
+const SOURCE_COLORS: Record<string, { bg: string; text: string }> = {
+  extracted: { bg: 'rgba(16, 185, 129, 0.1)', text: '#10b981' },
+  produced:  { bg: 'rgba(59, 130, 246, 0.1)', text: '#3b82f6' },
+  bought:    { bg: 'rgba(245, 158, 11, 0.1)', text: '#f59e0b' },
+  mixed:     { bg: 'rgba(148, 163, 184, 0.1)', text: '#94a3b8' },
+};
+
+function formatDepletion(hours: number): string {
+  if (hours <= 0) return '\u2014';
+  const days = Math.floor(hours / 24);
+  const h = Math.floor(hours % 24);
+  if (days > 0) return `${days}d ${h}h`;
+  const m = Math.round((hours % 1) * 60);
+  return `${h}h ${m}m`;
+}
+
+function depletionColor(hours: number): string {
+  if (hours <= 0) return '#64748b';
+  if (hours < 24) return '#ef4444';
+  if (hours < 72) return '#f59e0b';
+  return '#10b981';
+}
+
+function netColor(value: number): string {
+  if (value > 0.01) return '#10b981';
+  if (value < -0.01) return '#ef4444';
+  return '#64748b';
+}
+
+function formatRate(value: number): string {
+  if (value === 0) return '\u2014';
+  return formatNumber(Math.round(value));
+}
+
+const headerCellSx = {
+  color: '#64748b',
+  borderColor: 'rgba(148, 163, 184, 0.1)',
+  bgcolor: '#0f1219',
+  fontSize: '0.7rem',
+  textTransform: 'uppercase' as const,
+  letterSpacing: 0.5,
+  fontWeight: 600,
+  py: 1,
+};
+
+function SupplyChainRow({ item, expanded, onToggle, onResize }: {
+  item: SupplyChainItem;
+  expanded: boolean;
+  onToggle: () => void;
+  onResize: (item: SupplyChainItem, newQty: number) => void;
+}) {
+  const sourceStyle = SOURCE_COLORS[item.source] || SOURCE_COLORS.mixed;
+  const hasChildren = (item.producers?.length > 0) || (item.consumers?.length > 0);
+  const isDeficit = item.netPerHour < -0.01;
+  const hasMarkers = (item.stockpileMarkers?.length ?? 0) > 0;
+  const canResize = hasMarkers && item.consumedPerHour > 0;
+
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleStockpileClick = (e: React.MouseEvent<HTMLElement>) => {
+    if (!canResize) return;
+    e.stopPropagation();
+    setAnchorEl(e.currentTarget);
+  };
+
+  const handlePresetClick = (hours: number) => {
+    const newQty = Math.ceil(item.consumedPerHour * hours);
+    onResize(item, newQty);
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <TableRow
+        sx={{
+          cursor: hasChildren ? 'pointer' : 'default',
+          '&:hover': { bgcolor: 'rgba(59, 130, 246, 0.04)' },
+          bgcolor: expanded ? 'rgba(59, 130, 246, 0.03)' : isDeficit ? 'rgba(239, 68, 68, 0.03)' : 'transparent',
+        }}
+        onClick={hasChildren ? onToggle : undefined}
+      >
+        <TableCell sx={{ color: '#e2e8f0', borderColor: 'rgba(148, 163, 184, 0.08)', width: 36, p: 0.5 }}>
+          {hasChildren && (
+            <IconButton size="small" sx={{ color: '#64748b', p: 0.25 }}>
+              {expanded ? <KeyboardArrowDownIcon fontSize="small" /> : <KeyboardArrowRightIcon fontSize="small" />}
+            </IconButton>
+          )}
+        </TableCell>
+        <TableCell sx={{ borderColor: 'rgba(148, 163, 184, 0.08)' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <img
+              src={`https://images.evetech.net/types/${item.typeId}/icon?size=32`}
+              alt="" width={24} height={24} style={{ flexShrink: 0 }}
+            />
+            <Box sx={{ minWidth: 0 }}>
+              <Typography variant="body2" sx={{ color: '#e2e8f0', fontWeight: 500, lineHeight: 1.2 }} noWrap>
+                {item.name || `Type ${item.typeId}`}
+              </Typography>
+              <Typography variant="caption" sx={{ color: '#475569', fontSize: '0.65rem' }}>
+                {item.tierName}
+              </Typography>
+            </Box>
+          </Box>
+        </TableCell>
+        <TableCell sx={{ borderColor: 'rgba(148, 163, 184, 0.08)' }}>
+          <Chip
+            label={item.source.charAt(0).toUpperCase() + item.source.slice(1)}
+            size="small"
+            sx={{
+              bgcolor: sourceStyle.bg,
+              color: sourceStyle.text,
+              fontSize: '0.65rem',
+              height: 20,
+              fontWeight: 500,
+            }}
+          />
+        </TableCell>
+        <TableCell align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.08)', color: item.producedPerHour > 0 ? '#10b981' : '#475569' }}>
+          <Typography variant="caption">{formatRate(item.producedPerHour)}</Typography>
+        </TableCell>
+        <TableCell align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.08)', color: item.consumedPerHour > 0 ? '#ef4444' : '#475569' }}>
+          <Typography variant="caption">{formatRate(item.consumedPerHour)}</Typography>
+        </TableCell>
+        <TableCell align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.08)' }}>
+          <Typography variant="caption" sx={{ color: netColor(item.netPerHour), fontWeight: 600 }}>
+            {item.netPerHour > 0.01 ? '+' : ''}{formatRate(item.netPerHour)}
+          </Typography>
+        </TableCell>
+        <TableCell
+          align="right"
+          onClick={canResize ? handleStockpileClick : undefined}
+          sx={{
+            borderColor: 'rgba(148, 163, 184, 0.08)',
+            color: '#94a3b8',
+            cursor: canResize ? 'pointer' : 'default',
+            '&:hover': canResize ? { color: '#3b82f6' } : {},
+          }}
+        >
+          <Typography variant="caption" sx={{ borderBottom: canResize ? '1px dashed currentColor' : 'none' }}>
+            {item.stockpileQty > 0 ? formatQuantity(item.stockpileQty) : '\u2014'}
+          </Typography>
+          <Popover
+            open={Boolean(anchorEl)}
+            anchorEl={anchorEl}
+            onClose={(e: React.SyntheticEvent) => { e.stopPropagation?.(); setAnchorEl(null); }}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            slotProps={{
+              paper: {
+                sx: { bgcolor: '#1a1f2e', border: '1px solid rgba(148, 163, 184, 0.15)', p: 1.5, minWidth: 200 },
+                onClick: (e: React.MouseEvent) => e.stopPropagation(),
+              },
+            }}
+          >
+            <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, fontSize: '0.6rem', mb: 1, display: 'block' }}>
+              Set stockpile for
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+              {RESIZE_PRESETS.map(preset => {
+                const qty = Math.ceil(item.consumedPerHour * preset.hours);
+                return (
+                  <Button
+                    key={preset.label}
+                    size="small"
+                    onClick={(e) => { e.stopPropagation(); handlePresetClick(preset.hours); }}
+                    sx={{
+                      justifyContent: 'space-between',
+                      textTransform: 'none',
+                      color: '#e2e8f0',
+                      fontSize: '0.75rem',
+                      py: 0.5,
+                      px: 1,
+                      '&:hover': { bgcolor: 'rgba(59, 130, 246, 0.1)' },
+                    }}
+                  >
+                    <span>{preset.label}</span>
+                    <Typography component="span" sx={{ color: '#3b82f6', fontSize: '0.75rem', fontWeight: 600, ml: 2 }}>
+                      {formatQuantity(qty)}
+                    </Typography>
+                  </Button>
+                );
+              })}
+            </Box>
+          </Popover>
+        </TableCell>
+        <TableCell align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.08)' }}>
+          <Typography variant="caption" sx={{ color: depletionColor(item.depletionHours), fontWeight: item.depletionHours > 0 && item.depletionHours < 72 ? 600 : 400 }}>
+            {formatDepletion(item.depletionHours)}
+          </Typography>
+        </TableCell>
+      </TableRow>
+      {expanded && (
+        <>
+          {item.producers?.length > 0 && (
+            <>
+              <TableRow>
+                <TableCell sx={{ borderColor: 'rgba(148, 163, 184, 0.03)', py: 0.5 }} />
+                <TableCell colSpan={7} sx={{ borderColor: 'rgba(148, 163, 184, 0.03)', py: 0.5 }}>
+                  <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, fontSize: '0.6rem' }}>
+                    Producers
+                  </Typography>
+                </TableCell>
+              </TableRow>
+              {item.producers.map((p, i) => (
+                <PlanetEntryRow key={`prod-${i}`} entry={p} type="producer" />
+              ))}
+            </>
+          )}
+          {item.consumers?.length > 0 && (
+            <>
+              <TableRow>
+                <TableCell sx={{ borderColor: 'rgba(148, 163, 184, 0.03)', py: 0.5 }} />
+                <TableCell colSpan={7} sx={{ borderColor: 'rgba(148, 163, 184, 0.03)', py: 0.5 }}>
+                  <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, fontSize: '0.6rem' }}>
+                    Consumers
+                  </Typography>
+                </TableCell>
+              </TableRow>
+              {item.consumers.map((c, i) => (
+                <PlanetEntryRow key={`cons-${i}`} entry={c} type="consumer" />
+              ))}
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
+}
+
+function PlanetEntryRow({ entry, type }: { entry: SupplyChainPlanetEntry; type: 'producer' | 'consumer' }) {
+  const rateColor = type === 'producer' ? '#10b981' : '#ef4444';
+
+  return (
+    <TableRow sx={{ bgcolor: 'rgba(15, 18, 25, 0.4)' }}>
+      <TableCell sx={{ borderColor: 'rgba(148, 163, 184, 0.03)' }} />
+      <TableCell colSpan={3} sx={{ borderColor: 'rgba(148, 163, 184, 0.03)', pl: 5 }}>
+        <Typography variant="caption" sx={{ color: '#cbd5e1' }}>
+          {entry.solarSystemName}
+        </Typography>
+        <Typography variant="caption" sx={{ color: '#475569', ml: 0.5 }}>
+          {entry.planetType} &middot; {entry.characterName}
+        </Typography>
+      </TableCell>
+      <TableCell colSpan={4} align="right" sx={{ borderColor: 'rgba(148, 163, 184, 0.03)' }}>
+        <Typography variant="caption" sx={{ color: rateColor }}>
+          {formatNumber(Math.round(entry.ratePerHour))}/hr
+        </Typography>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function SupplyChain() {
+  const { data: session } = useSession();
+  const [data, setData] = useState<SupplyChainResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [tierFilter, setTierFilter] = useState('All');
+  const [search, setSearch] = useState('');
+  const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
+  const [bulkAnchorEl, setBulkAnchorEl] = useState<HTMLElement | null>(null);
+  const hasFetchedRef = useRef(false);
+
+  useEffect(() => {
+    if (session && !hasFetchedRef.current) {
+      hasFetchedRef.current = true;
+      fetchData();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session]);
+
+  const fetchData = async () => {
+    if (!session) return;
+    setLoading(true);
+    try {
+      const response = await fetch('/api/pi/supply-chain');
+      if (response.ok) {
+        const result: SupplyChainResponse = await response.json();
+        setData(result);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const upsertMarkers = async (markers: StockpileMarker[], newQty: number) => {
+    const totalOld = markers.reduce((sum, m) => sum + m.desiredQuantity, 0);
+    const updates = markers.map((m, i) => {
+      if (markers.length === 1) return { ...m, desiredQuantity: newQty };
+      if (i === markers.length - 1) {
+        const allocated = markers.slice(0, -1).reduce((sum, mk) => {
+          return sum + Math.round(newQty * (mk.desiredQuantity / totalOld));
+        }, 0);
+        return { ...m, desiredQuantity: newQty - allocated };
+      }
+      return { ...m, desiredQuantity: Math.round(newQty * (m.desiredQuantity / totalOld)) };
+    });
+    for (const marker of updates) {
+      await fetch('/api/stockpiles/upsert', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(marker),
+      });
+    }
+  };
+
+  const handleResize = useCallback(async (item: SupplyChainItem, newQty: number) => {
+    const markers = item.stockpileMarkers;
+    if (!markers || markers.length === 0) return;
+    await upsertMarkers(markers, newQty);
+    hasFetchedRef.current = false;
+    await fetchData();
+    hasFetchedRef.current = true;
+  }, []);
+
+  const handleResizeAll = useCallback(async (hours: number) => {
+    if (!data?.items) return;
+    const resizable = data.items.filter(
+      item => (item.stockpileMarkers?.length ?? 0) > 0 && item.consumedPerHour > 0
+    );
+    if (resizable.length === 0) return;
+
+    setLoading(true);
+    for (const item of resizable) {
+      const newQty = Math.ceil(item.consumedPerHour * hours);
+      await upsertMarkers(item.stockpileMarkers!, newQty);
+    }
+    hasFetchedRef.current = false;
+    await fetchData();
+    hasFetchedRef.current = true;
+  }, [data]);
+
+  const toggleItem = (typeId: number) => {
+    setExpandedItems(prev => {
+      const next = new Set(prev);
+      if (next.has(typeId)) next.delete(typeId);
+      else next.add(typeId);
+      return next;
+    });
+  };
+
+  const filteredItems = useMemo(() => {
+    if (!data?.items) return [];
+    let items = data.items;
+
+    if (tierFilter !== 'All') {
+      items = items.filter(item => item.tierName === tierFilter);
+    }
+
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      items = items.filter(item => item.name?.toLowerCase().includes(q));
+    }
+
+    // Sort: tier ascending, then deficit first (net ascending), then name
+    return [...items].sort((a, b) => {
+      const tierDiff = (TIER_ORDER[a.tierName] ?? 99) - (TIER_ORDER[b.tierName] ?? 99);
+      if (tierDiff !== 0) return tierDiff;
+      if (a.netPerHour !== b.netPerHour) return a.netPerHour - b.netPerHour;
+      return (a.name || '').localeCompare(b.name || '');
+    });
+  }, [data, tierFilter, search]);
+
+  const summary = useMemo(() => {
+    if (!data?.items) return { total: 0, deficit: 0, surplus: 0, balanced: 0 };
+    let deficit = 0, surplus = 0, balanced = 0;
+    for (const item of data.items) {
+      if (item.netPerHour < -0.01) deficit++;
+      else if (item.netPerHour > 0.01) surplus++;
+      else balanced++;
+    }
+    return { total: data.items.length, deficit, surplus, balanced };
+  }, [data]);
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  return (
+    <Box>
+      {/* Summary chips */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2, flexWrap: 'wrap' }}>
+        <Typography variant="caption" sx={{ color: '#64748b' }}>
+          {summary.total} materials
+        </Typography>
+        {summary.deficit > 0 && (
+          <Chip
+            label={`${summary.deficit} deficit`}
+            size="small"
+            sx={{ bgcolor: 'rgba(239, 68, 68, 0.1)', color: '#ef4444', fontSize: '0.7rem', height: 22 }}
+          />
+        )}
+        {summary.surplus > 0 && (
+          <Chip
+            label={`${summary.surplus} surplus`}
+            size="small"
+            sx={{ bgcolor: 'rgba(16, 185, 129, 0.1)', color: '#10b981', fontSize: '0.7rem', height: 22 }}
+          />
+        )}
+        {summary.balanced > 0 && (
+          <Chip
+            label={`${summary.balanced} balanced`}
+            size="small"
+            sx={{ bgcolor: 'rgba(148, 163, 184, 0.1)', color: '#94a3b8', fontSize: '0.7rem', height: 22 }}
+          />
+        )}
+      </Box>
+
+      {/* Filters */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2, flexWrap: 'wrap' }}>
+        <Box sx={{ display: 'flex', gap: 0.5 }}>
+          {TIERS.map(tier => (
+            <Chip
+              key={tier}
+              label={tier}
+              size="small"
+              onClick={() => setTierFilter(tier)}
+              sx={{
+                bgcolor: tierFilter === tier ? 'rgba(59, 130, 246, 0.15)' : 'rgba(148, 163, 184, 0.06)',
+                color: tierFilter === tier ? '#3b82f6' : '#64748b',
+                border: tierFilter === tier ? '1px solid rgba(59, 130, 246, 0.3)' : '1px solid transparent',
+                fontSize: '0.7rem',
+                fontWeight: 500,
+                height: 26,
+                cursor: 'pointer',
+                '&:hover': { bgcolor: tierFilter === tier ? 'rgba(59, 130, 246, 0.2)' : 'rgba(148, 163, 184, 0.1)' },
+              }}
+            />
+          ))}
+        </Box>
+        {data?.items?.some(item => (item.stockpileMarkers?.length ?? 0) > 0 && item.consumedPerHour > 0) && (
+          <>
+            <Button
+              size="small"
+              onClick={(e) => setBulkAnchorEl(e.currentTarget)}
+              sx={{
+                textTransform: 'none',
+                color: '#94a3b8',
+                fontSize: '0.75rem',
+                border: '1px solid rgba(148, 163, 184, 0.15)',
+                px: 1.5,
+                '&:hover': { bgcolor: 'rgba(59, 130, 246, 0.08)', borderColor: 'rgba(59, 130, 246, 0.3)', color: '#3b82f6' },
+              }}
+            >
+              Set all stockpiles
+            </Button>
+            <Popover
+              open={Boolean(bulkAnchorEl)}
+              anchorEl={bulkAnchorEl}
+              onClose={() => setBulkAnchorEl(null)}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+              slotProps={{
+                paper: {
+                  sx: { bgcolor: '#1a1f2e', border: '1px solid rgba(148, 163, 184, 0.15)', p: 1.5, minWidth: 220 },
+                },
+              }}
+            >
+              <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, fontSize: '0.6rem', mb: 1, display: 'block' }}>
+                Set all stockpiles to cover
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                {RESIZE_PRESETS.map(preset => (
+                  <Button
+                    key={preset.label}
+                    size="small"
+                    onClick={() => { setBulkAnchorEl(null); handleResizeAll(preset.hours); }}
+                    sx={{
+                      justifyContent: 'flex-start',
+                      textTransform: 'none',
+                      color: '#e2e8f0',
+                      fontSize: '0.75rem',
+                      py: 0.5,
+                      px: 1,
+                      '&:hover': { bgcolor: 'rgba(59, 130, 246, 0.1)' },
+                    }}
+                  >
+                    {preset.label}
+                  </Button>
+                ))}
+              </Box>
+            </Popover>
+          </>
+        )}
+        <TextField
+          placeholder="Search..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          size="small"
+          variant="outlined"
+          sx={{
+            ml: 'auto',
+            width: 180,
+            '& .MuiOutlinedInput-root': {
+              color: '#e2e8f0',
+              fontSize: '0.8rem',
+              '& fieldset': { borderColor: 'rgba(148, 163, 184, 0.15)' },
+              '&:hover fieldset': { borderColor: 'rgba(59, 130, 246, 0.3)' },
+              '&.Mui-focused fieldset': { borderColor: '#3b82f6' },
+            },
+            '& .MuiInputBase-input': { py: 0.75 },
+          }}
+        />
+      </Box>
+
+      {/* Table */}
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ ...headerCellSx, width: 36 }} />
+              <TableCell sx={headerCellSx}>Material</TableCell>
+              <TableCell sx={headerCellSx}>Source</TableCell>
+              <TableCell align="right" sx={headerCellSx}>Produced/hr</TableCell>
+              <TableCell align="right" sx={headerCellSx}>Consumed/hr</TableCell>
+              <TableCell align="right" sx={headerCellSx}>Net/hr</TableCell>
+              <TableCell align="right" sx={headerCellSx}>Stockpile</TableCell>
+              <TableCell align="right" sx={headerCellSx}>Depletion</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filteredItems.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} align="center" sx={{ color: '#64748b', borderColor: 'rgba(148, 163, 184, 0.1)', py: 4 }}>
+                  No PI production data found
+                </TableCell>
+              </TableRow>
+            ) : (
+              filteredItems.map(item => (
+                <SupplyChainRow
+                  key={item.typeId}
+                  item={item}
+                  expanded={expandedItems.has(item.typeId)}
+                  onToggle={() => toggleItem(item.typeId)}
+                  onResize={handleResize}
+                />
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}

--- a/frontend/packages/components/settings/DiscordSettings.tsx
+++ b/frontend/packages/components/settings/DiscordSettings.tsx
@@ -65,6 +65,7 @@ type Channel = {
 
 const EVENT_TYPES = [
   { value: 'purchase_created', label: 'New Purchase' },
+  { value: 'pi_stall', label: 'PI Stall Alert' },
 ];
 
 const DISCORD_ERROR_MESSAGES: Record<string, string> = {

--- a/frontend/packages/pages/pi.tsx
+++ b/frontend/packages/pages/pi.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { useSession } from "next-auth/react";
+import Loading from "@industry-tool/components/loading";
+import Unuathorized from "@industry-tool/components/unauthorized";
+import PlanetOverview from "@industry-tool/components/pi/PlanetOverview";
+import ProfitTable from "@industry-tool/components/pi/ProfitTable";
+import SupplyChain from "@industry-tool/components/pi/SupplyChain";
+import Navbar from "@industry-tool/components/Navbar";
+import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import Box from "@mui/material/Box";
+
+export default function PlanetaryIndustry() {
+  const { status } = useSession();
+  const [tab, setTab] = useState(() => {
+    if (typeof window !== "undefined") {
+      return parseInt(localStorage.getItem("pi-tab") || "0", 10);
+    }
+    return 0;
+  });
+
+  if (status === "loading") {
+    return <Loading />;
+  }
+
+  if (status !== "authenticated") {
+    return <Unuathorized />;
+  }
+
+  const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
+    setTab(newValue);
+    localStorage.setItem("pi-tab", String(newValue));
+  };
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
+        <Typography variant="h5" sx={{ color: "#e2e8f0", mb: 2, fontWeight: 600 }}>
+          Planetary Industry
+        </Typography>
+        <Box sx={{ borderBottom: 1, borderColor: "rgba(148, 163, 184, 0.15)", mb: 2 }}>
+          <Tabs
+            value={tab}
+            onChange={handleTabChange}
+            sx={{
+              "& .MuiTab-root": { color: "#64748b", textTransform: "none", fontWeight: 500 },
+              "& .Mui-selected": { color: "#3b82f6" },
+              "& .MuiTabs-indicator": { backgroundColor: "#3b82f6" },
+            }}
+          >
+            <Tab label="Overview" />
+            <Tab label="Profit" />
+            <Tab label="Supply Chain" />
+          </Tabs>
+        </Box>
+        {tab === 0 && <PlanetOverview embedded />}
+        {tab === 1 && <ProfitTable />}
+        {tab === 2 && <SupplyChain />}
+      </Container>
+    </>
+  );
+}

--- a/frontend/pages/api/pi/launchpad-detail.ts
+++ b/frontend/pages/api/pi/launchpad-detail.ts
@@ -1,0 +1,48 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const { characterId, planetId, pinId } = req.query;
+
+  try {
+    const response = await fetch(
+      `${backend}v1/pi/launchpad-detail?characterId=${characterId}&planetId=${planetId}&pinId=${pinId}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "USER-ID": session.providerAccountId,
+          "BACKEND-KEY": backendKey,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("PI launchpad detail API error:", error);
+    return res
+      .status(500)
+      .json({ error: "Failed to fetch launchpad detail" });
+  }
+}

--- a/frontend/pages/api/pi/launchpad-labels.ts
+++ b/frontend/pages/api/pi/launchpad-labels.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const allowedMethods = ["POST", "DELETE"];
+  if (!allowedMethods.includes(req.method || "")) {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const response = await fetch(`${backend}v1/pi/launchpad-labels`, {
+      method: req.method,
+      headers: {
+        "Content-Type": "application/json",
+        "USER-ID": session.providerAccountId,
+        "BACKEND-KEY": backendKey,
+      },
+      body: JSON.stringify(req.body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const text = await response.text();
+    if (text) {
+      return res.status(200).json(JSON.parse(text));
+    }
+    return res.status(200).json(null);
+  } catch (error) {
+    console.error("PI launchpad labels API error:", error);
+    return res.status(500).json({ error: "Failed to handle launchpad labels" });
+  }
+}

--- a/frontend/pages/api/pi/planets.ts
+++ b/frontend/pages/api/pi/planets.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    const response = await fetch(`${backend}v1/pi/planets`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "USER-ID": session.providerAccountId,
+        "BACKEND-KEY": backendKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("PI planets API error:", error);
+    return res.status(500).json({ error: "Failed to fetch PI planets" });
+  }
+}

--- a/frontend/pages/api/pi/profit.ts
+++ b/frontend/pages/api/pi/profit.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    const priceSource = (req.query.priceSource as string) || "sell";
+    const response = await fetch(`${backend}v1/pi/profit?priceSource=${priceSource}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "USER-ID": session.providerAccountId,
+        "BACKEND-KEY": backendKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("PI profit API error:", error);
+    return res.status(500).json({ error: "Failed to fetch PI profit" });
+  }
+}

--- a/frontend/pages/api/pi/supply-chain.ts
+++ b/frontend/pages/api/pi/supply-chain.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    const response = await fetch(`${backend}v1/pi/supply-chain`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "USER-ID": session.providerAccountId,
+        "BACKEND-KEY": backendKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("PI supply chain API error:", error);
+    return res.status(500).json({ error: "Failed to fetch PI supply chain" });
+  }
+}

--- a/frontend/pages/api/pi/tax.ts
+++ b/frontend/pages/api/pi/tax.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const allowedMethods = ["GET", "POST", "DELETE"];
+  if (!allowedMethods.includes(req.method || "")) {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const response = await fetch(`${backend}v1/pi/tax`, {
+      method: req.method,
+      headers: {
+        "Content-Type": "application/json",
+        "USER-ID": session.providerAccountId,
+        "BACKEND-KEY": backendKey,
+      },
+      body: req.method !== "GET" ? JSON.stringify(req.body) : undefined,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const text = await response.text();
+    if (text) {
+      return res.status(200).json(JSON.parse(text));
+    }
+    return res.status(200).json(null);
+  } catch (error) {
+    console.error("PI tax API error:", error);
+    return res.status(500).json({ error: "Failed to handle PI tax config" });
+  }
+}

--- a/frontend/pages/pi.tsx
+++ b/frontend/pages/pi.tsx
@@ -1,0 +1,3 @@
+import PlanetaryIndustry from "@industry-tool/pages/pi";
+
+export default PlanetaryIndustry;

--- a/internal/controllers/pi.go
+++ b/internal/controllers/pi.go
@@ -1,0 +1,1657 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/pkg/errors"
+)
+
+type PiPlanetsRepository interface {
+	GetPlanetsForUser(ctx context.Context, userID int64) ([]*models.PiPlanet, error)
+	GetPinsForPlanets(ctx context.Context, userID int64) ([]*models.PiPin, error)
+	GetPinContentsForUser(ctx context.Context, userID int64) ([]*models.PiPinContent, error)
+	GetRoutesForUser(ctx context.Context, userID int64) ([]*models.PiRoute, error)
+}
+
+type PiTaxConfigRepository interface {
+	GetForUser(ctx context.Context, userID int64) ([]*models.PiTaxConfig, error)
+	Upsert(ctx context.Context, config *models.PiTaxConfig) error
+	Delete(ctx context.Context, userID int64, planetID *int64) error
+}
+
+type PiSchematicRepository interface {
+	GetAllSchematics(ctx context.Context) ([]*models.SdePlanetSchematic, error)
+	GetAllSchematicTypes(ctx context.Context) ([]*models.SdePlanetSchematicType, error)
+}
+
+type PiCharacterRepository interface {
+	GetNames(ctx context.Context, userID int64) (map[int64]string, error)
+}
+
+type PiSolarSystemRepository interface {
+	GetNames(ctx context.Context, ids []int64) (map[int64]string, error)
+}
+
+type PiItemTypeRepository interface {
+	GetNames(ctx context.Context, ids []int64) (map[int64]string, error)
+}
+
+type PiMarketPriceRepository interface {
+	GetAllJitaPrices(ctx context.Context) (map[int64]*models.MarketPrice, error)
+}
+
+type PiLaunchpadLabelRepository interface {
+	GetForUser(ctx context.Context, userID int64) ([]*models.PiLaunchpadLabel, error)
+	Upsert(ctx context.Context, label *models.PiLaunchpadLabel) error
+	Delete(ctx context.Context, userID, characterID, planetID, pinID int64) error
+}
+
+type PiStockpileRepository interface {
+	GetByUser(ctx context.Context, userID int64) ([]*models.StockpileMarker, error)
+}
+
+type Pi struct {
+	piRepo        PiPlanetsRepository
+	taxRepo       PiTaxConfigRepository
+	schematicRepo PiSchematicRepository
+	charRepo      PiCharacterRepository
+	systemRepo    PiSolarSystemRepository
+	itemTypeRepo  PiItemTypeRepository
+	marketRepo    PiMarketPriceRepository
+	labelRepo     PiLaunchpadLabelRepository
+	stockpileRepo PiStockpileRepository
+}
+
+func NewPi(
+	router Routerer,
+	piRepo PiPlanetsRepository,
+	taxRepo PiTaxConfigRepository,
+	schematicRepo PiSchematicRepository,
+	charRepo PiCharacterRepository,
+	systemRepo PiSolarSystemRepository,
+	itemTypeRepo PiItemTypeRepository,
+	marketRepo PiMarketPriceRepository,
+	labelRepo PiLaunchpadLabelRepository,
+	stockpileRepo PiStockpileRepository,
+) *Pi {
+	c := &Pi{
+		piRepo:        piRepo,
+		taxRepo:       taxRepo,
+		schematicRepo: schematicRepo,
+		charRepo:      charRepo,
+		systemRepo:    systemRepo,
+		itemTypeRepo:  itemTypeRepo,
+		marketRepo:    marketRepo,
+		labelRepo:     labelRepo,
+		stockpileRepo: stockpileRepo,
+	}
+
+	router.RegisterRestAPIRoute("/v1/pi/planets", web.AuthAccessUser, c.GetPlanets, "GET")
+	router.RegisterRestAPIRoute("/v1/pi/profit", web.AuthAccessUser, c.GetProfit, "GET")
+	router.RegisterRestAPIRoute("/v1/pi/tax", web.AuthAccessUser, c.GetTaxConfig, "GET")
+	router.RegisterRestAPIRoute("/v1/pi/tax", web.AuthAccessUser, c.UpsertTaxConfig, "POST")
+	router.RegisterRestAPIRoute("/v1/pi/tax", web.AuthAccessUser, c.DeleteTaxConfig, "DELETE")
+	router.RegisterRestAPIRoute("/v1/pi/launchpad-labels", web.AuthAccessUser, c.UpsertLaunchpadLabel, "POST")
+	router.RegisterRestAPIRoute("/v1/pi/launchpad-labels", web.AuthAccessUser, c.DeleteLaunchpadLabel, "DELETE")
+	router.RegisterRestAPIRoute("/v1/pi/launchpad-detail", web.AuthAccessUser, c.GetLaunchpadDetail, "GET")
+	router.RegisterRestAPIRoute("/v1/pi/supply-chain", web.AuthAccessUser, c.GetSupplyChain, "GET")
+
+	return c
+}
+
+// Stall detection thresholds
+const (
+	staleDataThreshold  = 48 * time.Hour
+	factoryIdleMultiple = 2 // factory is stalled if last_cycle_start + cycle_time*2 < now
+)
+
+// Response types
+
+type PiExtractorResponse struct {
+	PinID            int64      `json:"pinId"`
+	TypeID           int64      `json:"typeId"`
+	ProductTypeID    int64      `json:"productTypeId"`
+	ProductName      string     `json:"productName"`
+	QtyPerCycle      int        `json:"qtyPerCycle"`
+	CycleTimeSec     int        `json:"cycleTimeSec"`
+	RatePerHour      float64    `json:"ratePerHour"`
+	ExpiryTime       *time.Time `json:"expiryTime"`
+	Status           string     `json:"status"`
+	NumHeads         int        `json:"numHeads"`
+}
+
+type PiFactoryResponse struct {
+	PinID          int64      `json:"pinId"`
+	TypeID         int64      `json:"typeId"`
+	SchematicID    int        `json:"schematicId"`
+	SchematicName  string     `json:"schematicName"`
+	OutputTypeID   int64      `json:"outputTypeId"`
+	OutputName     string     `json:"outputName"`
+	OutputQty      int        `json:"outputQty"`
+	CycleTimeSec   int        `json:"cycleTimeSec"`
+	RatePerHour    float64    `json:"ratePerHour"`
+	LastCycleStart *time.Time `json:"lastCycleStart"`
+	Status         string     `json:"status"`
+	PinCategory    string     `json:"pinCategory"`
+}
+
+type PiLaunchpadResponse struct {
+	PinID    int64                   `json:"pinId"`
+	TypeID   int64                   `json:"typeId"`
+	Label    string                  `json:"label,omitempty"`
+	Contents []*PiPinContentResponse `json:"contents"`
+}
+
+type PiPinContentResponse struct {
+	TypeID int64  `json:"typeId"`
+	Name   string `json:"name"`
+	Amount int64  `json:"amount"`
+}
+
+type PiPlanetResponse struct {
+	PlanetID        int64                  `json:"planetId"`
+	PlanetType      string                 `json:"planetType"`
+	SolarSystemID   int64                  `json:"solarSystemId"`
+	SolarSystemName string                 `json:"solarSystemName"`
+	CharacterID     int64                  `json:"characterId"`
+	CharacterName   string                 `json:"characterName"`
+	UpgradeLevel    int                    `json:"upgradeLevel"`
+	NumPins         int                    `json:"numPins"`
+	LastUpdate      time.Time              `json:"lastUpdate"`
+	Status          string                 `json:"status"`
+	Extractors      []*PiExtractorResponse `json:"extractors"`
+	Factories       []*PiFactoryResponse   `json:"factories"`
+	Launchpads      []*PiLaunchpadResponse `json:"launchpads"`
+}
+
+type PiPlanetsListResponse struct {
+	Planets []*PiPlanetResponse `json:"planets"`
+}
+
+func (c *Pi) GetPlanets(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+	userID := *args.User
+
+	planets, err := c.piRepo.GetPlanetsForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI planets")}
+	}
+
+	pins, err := c.piRepo.GetPinsForPlanets(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI pins")}
+	}
+
+	contents, err := c.piRepo.GetPinContentsForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI pin contents")}
+	}
+
+	routes, err := c.piRepo.GetRoutesForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI routes")}
+	}
+
+	labels, err := c.labelRepo.GetForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get launchpad labels")}
+	}
+
+	schematics, err := c.schematicRepo.GetAllSchematics(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get schematics")}
+	}
+
+	schematicTypes, err := c.schematicRepo.GetAllSchematicTypes(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get schematic types")}
+	}
+
+	charNames, err := c.charRepo.GetNames(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get character names")}
+	}
+
+	// Collect solar system IDs for name resolution
+	systemIDs := []int64{}
+	systemIDSet := map[int64]bool{}
+	for _, p := range planets {
+		if !systemIDSet[p.SolarSystemID] {
+			systemIDs = append(systemIDs, p.SolarSystemID)
+			systemIDSet[p.SolarSystemID] = true
+		}
+	}
+
+	systemNames, err := c.systemRepo.GetNames(ctx, systemIDs)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get solar system names")}
+	}
+
+	// Build lookup maps
+	schematicMap := buildSchematicMap(schematics)
+	schematicOutputMap := buildSchematicOutputMap(schematicTypes)
+
+	// Collect all item type IDs for name resolution
+	typeIDSet := map[int64]bool{}
+	for _, pin := range pins {
+		if pin.ExtractorProductTypeID != nil {
+			typeIDSet[*pin.ExtractorProductTypeID] = true
+		}
+	}
+	for _, c := range contents {
+		typeIDSet[c.TypeID] = true
+	}
+	for _, r := range routes {
+		typeIDSet[r.ContentTypeID] = true
+	}
+	// Include factory output type IDs from schematics
+	for _, output := range schematicOutputMap {
+		typeIDSet[output.TypeID] = true
+	}
+	typeIDs := []int64{}
+	for id := range typeIDSet {
+		typeIDs = append(typeIDs, id)
+	}
+
+	typeNames, err := c.itemTypeRepo.GetNames(ctx, typeIDs)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get item type names")}
+	}
+
+	// Group pins by (characterID, planetID)
+	type planetKey struct {
+		CharacterID int64
+		PlanetID    int64
+	}
+	pinsByPlanet := map[planetKey][]*models.PiPin{}
+	for _, pin := range pins {
+		key := planetKey{pin.CharacterID, pin.PlanetID}
+		pinsByPlanet[key] = append(pinsByPlanet[key], pin)
+	}
+
+	// Group contents by (characterID, planetID, pinID)
+	type pinKey struct {
+		CharacterID int64
+		PlanetID    int64
+		PinID       int64
+	}
+	contentsByPin := map[pinKey][]*models.PiPinContent{}
+	for _, c := range contents {
+		key := pinKey{c.CharacterID, c.PlanetID, c.PinID}
+		contentsByPin[key] = append(contentsByPin[key], c)
+	}
+
+	// Build label lookup by pinKey
+	labelsByPin := map[pinKey]string{}
+	for _, l := range labels {
+		key := pinKey{l.CharacterID, l.PlanetID, l.PinID}
+		labelsByPin[key] = l.Label
+	}
+
+	// Group routes by source pin to determine required input types
+	routesBySrcPin := map[pinKey][]int64{}
+	for _, r := range routes {
+		key := pinKey{r.CharacterID, r.PlanetID, r.SourcePinID}
+		routesBySrcPin[key] = append(routesBySrcPin[key], r.ContentTypeID)
+	}
+
+	now := time.Now()
+	result := &PiPlanetsListResponse{
+		Planets: []*PiPlanetResponse{},
+	}
+
+	for _, planet := range planets {
+		key := planetKey{planet.CharacterID, planet.PlanetID}
+		planetPins := pinsByPlanet[key]
+
+		extractors := []*PiExtractorResponse{}
+		factories := []*PiFactoryResponse{}
+		launchpads := []*PiLaunchpadResponse{}
+		planetStatus := "running"
+
+		// Check for stale data
+		if now.Sub(planet.LastUpdate) > staleDataThreshold {
+			planetStatus = "stale_data"
+		}
+
+		for _, pin := range planetPins {
+			switch {
+			case pin.PinCategory == "extractor" && pin.ExtractorProductTypeID != nil:
+				ext := buildExtractorResponse(pin, now, typeNames)
+				if ext.Status == "expired" && planetStatus == "running" {
+					planetStatus = "stalled"
+				}
+				extractors = append(extractors, ext)
+
+			case pin.PinCategory == "factory" && pin.SchematicID != nil:
+				fac := buildFactoryResponse(pin, schematicMap, schematicOutputMap, now, typeNames)
+				if fac.Status == "stalled" && planetStatus == "running" {
+					planetStatus = "stalled"
+				}
+				factories = append(factories, fac)
+
+			case pin.PinCategory == "launchpad" || pin.PinCategory == "storage":
+				pk := pinKey{pin.CharacterID, pin.PlanetID, pin.PinID}
+				pinContents := contentsByPin[pk]
+				expectedTypeIDs := routesBySrcPin[pk]
+				lp := buildLaunchpadResponse(pin, pinContents, expectedTypeIDs, typeNames)
+				lp.Label = labelsByPin[pk]
+				launchpads = append(launchpads, lp)
+			}
+		}
+
+		result.Planets = append(result.Planets, &PiPlanetResponse{
+			PlanetID:        planet.PlanetID,
+			PlanetType:      planet.PlanetType,
+			SolarSystemID:   planet.SolarSystemID,
+			SolarSystemName: systemNames[planet.SolarSystemID],
+			CharacterID:     planet.CharacterID,
+			CharacterName:   charNames[planet.CharacterID],
+			UpgradeLevel:    planet.UpgradeLevel,
+			NumPins:         planet.NumPins,
+			LastUpdate:      planet.LastUpdate,
+			Status:          planetStatus,
+			Extractors:      extractors,
+			Factories:       factories,
+			Launchpads:      launchpads,
+		})
+	}
+
+	return result, nil
+}
+
+func buildExtractorResponse(pin *models.PiPin, now time.Time, typeNames map[int64]string) *PiExtractorResponse {
+	cycleTime := 0
+	if pin.ExtractorCycleTime != nil {
+		cycleTime = *pin.ExtractorCycleTime
+	}
+	qtyPerCycle := 0
+	if pin.ExtractorQtyPerCycle != nil {
+		qtyPerCycle = *pin.ExtractorQtyPerCycle
+	}
+	numHeads := 0
+	if pin.ExtractorNumHeads != nil {
+		numHeads = *pin.ExtractorNumHeads
+	}
+
+	ratePerHour := 0.0
+	if cycleTime > 0 {
+		ratePerHour = float64(qtyPerCycle) / float64(cycleTime) * 3600.0
+	}
+
+	status := "running"
+	if pin.ExpiryTime != nil && pin.ExpiryTime.Before(now) {
+		status = "expired"
+	}
+
+	return &PiExtractorResponse{
+		PinID:         pin.PinID,
+		TypeID:        pin.TypeID,
+		ProductTypeID: *pin.ExtractorProductTypeID,
+		ProductName:   typeNames[*pin.ExtractorProductTypeID],
+		QtyPerCycle:   qtyPerCycle,
+		CycleTimeSec:  cycleTime,
+		RatePerHour:   ratePerHour,
+		ExpiryTime:    pin.ExpiryTime,
+		Status:        status,
+		NumHeads:      numHeads,
+	}
+}
+
+type schematicOutput struct {
+	TypeID   int64
+	Quantity int
+}
+
+func buildSchematicMap(schematics []*models.SdePlanetSchematic) map[int]*models.SdePlanetSchematic {
+	m := map[int]*models.SdePlanetSchematic{}
+	for _, s := range schematics {
+		sid := int(s.SchematicID)
+		m[sid] = s
+	}
+	return m
+}
+
+func buildSchematicOutputMap(types []*models.SdePlanetSchematicType) map[int]*schematicOutput {
+	m := map[int]*schematicOutput{}
+	for _, t := range types {
+		if !t.IsInput {
+			sid := int(t.SchematicID)
+			m[sid] = &schematicOutput{
+				TypeID:   t.TypeID,
+				Quantity: t.Quantity,
+			}
+		}
+	}
+	return m
+}
+
+func buildFactoryResponse(pin *models.PiPin, schematicMap map[int]*models.SdePlanetSchematic, outputMap map[int]*schematicOutput, now time.Time, typeNames map[int64]string) *PiFactoryResponse {
+	schematicID := *pin.SchematicID
+	schematic := schematicMap[schematicID]
+	output := outputMap[schematicID]
+
+	resp := &PiFactoryResponse{
+		PinID:          pin.PinID,
+		TypeID:         pin.TypeID,
+		SchematicID:    schematicID,
+		LastCycleStart: pin.LastCycleStart,
+		Status:         "running",
+		PinCategory:    pin.PinCategory,
+	}
+
+	if schematic != nil {
+		resp.SchematicName = schematic.Name
+		resp.CycleTimeSec = schematic.CycleTime
+		if schematic.CycleTime > 0 && output != nil {
+			resp.RatePerHour = float64(output.Quantity) / float64(schematic.CycleTime) * 3600.0
+		}
+	}
+
+	if output != nil {
+		resp.OutputTypeID = output.TypeID
+		resp.OutputName = typeNames[output.TypeID]
+		resp.OutputQty = output.Quantity
+	}
+
+	// Stall detection: factory hasn't cycled in 2x the expected cycle time
+	if pin.LastCycleStart != nil && schematic != nil && schematic.CycleTime > 0 {
+		expectedNextCycle := pin.LastCycleStart.Add(time.Duration(schematic.CycleTime*factoryIdleMultiple) * time.Second)
+		if now.After(expectedNextCycle) {
+			resp.Status = "stalled"
+		}
+	}
+
+	return resp
+}
+
+func buildLaunchpadResponse(pin *models.PiPin, contents []*models.PiPinContent, expectedTypeIDs []int64, typeNames map[int64]string) *PiLaunchpadResponse {
+	resp := &PiLaunchpadResponse{
+		PinID:    pin.PinID,
+		TypeID:   pin.TypeID,
+		Contents: []*PiPinContentResponse{},
+	}
+
+	presentTypes := map[int64]bool{}
+	for _, c := range contents {
+		presentTypes[c.TypeID] = true
+		resp.Contents = append(resp.Contents, &PiPinContentResponse{
+			TypeID: c.TypeID,
+			Name:   typeNames[c.TypeID],
+			Amount: c.Amount,
+		})
+	}
+
+	// Add expected types from routes that have no actual contents
+	seen := map[int64]bool{}
+	for _, typeID := range expectedTypeIDs {
+		if !presentTypes[typeID] && !seen[typeID] {
+			seen[typeID] = true
+			resp.Contents = append(resp.Contents, &PiPinContentResponse{
+				TypeID: typeID,
+				Name:   typeNames[typeID],
+				Amount: 0,
+			})
+		}
+	}
+
+	return resp
+}
+
+// Tax config handlers
+
+func (c *Pi) GetTaxConfig(args *web.HandlerArgs) (any, *web.HttpError) {
+	configs, err := c.taxRepo.GetForUser(args.Request.Context(), *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI tax config")}
+	}
+	return configs, nil
+}
+
+func (c *Pi) UpsertTaxConfig(args *web.HandlerArgs) (any, *web.HttpError) {
+	d := json.NewDecoder(args.Request.Body)
+	var config models.PiTaxConfig
+	if err := d.Decode(&config); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "failed to decode json")}
+	}
+
+	config.UserID = *args.User
+
+	if err := c.taxRepo.Upsert(args.Request.Context(), &config); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to upsert PI tax config")}
+	}
+
+	return nil, nil
+}
+
+func (c *Pi) DeleteTaxConfig(args *web.HandlerArgs) (any, *web.HttpError) {
+	d := json.NewDecoder(args.Request.Body)
+	var config models.PiTaxConfig
+	if err := d.Decode(&config); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "failed to decode json")}
+	}
+
+	if err := c.taxRepo.Delete(args.Request.Context(), *args.User, config.PlanetID); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to delete PI tax config")}
+	}
+
+	return nil, nil
+}
+
+// --- Phase 3: Launchpad Labels + Detail ---
+
+func (c *Pi) UpsertLaunchpadLabel(args *web.HandlerArgs) (any, *web.HttpError) {
+	d := json.NewDecoder(args.Request.Body)
+	var label models.PiLaunchpadLabel
+	if err := d.Decode(&label); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "failed to decode json")}
+	}
+
+	label.UserID = *args.User
+
+	if err := c.labelRepo.Upsert(args.Request.Context(), &label); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to upsert launchpad label")}
+	}
+
+	return nil, nil
+}
+
+func (c *Pi) DeleteLaunchpadLabel(args *web.HandlerArgs) (any, *web.HttpError) {
+	d := json.NewDecoder(args.Request.Body)
+	var label models.PiLaunchpadLabel
+	if err := d.Decode(&label); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "failed to decode json")}
+	}
+
+	if err := c.labelRepo.Delete(args.Request.Context(), *args.User, label.CharacterID, label.PlanetID, label.PinID); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to delete launchpad label")}
+	}
+
+	return nil, nil
+}
+
+// Launchpad detail response types
+
+type LaunchpadInputRequirement struct {
+	TypeID          int64   `json:"typeId"`
+	Name            string  `json:"name"`
+	QtyPerCycle     int     `json:"qtyPerCycle"`
+	CyclesPerHour   float64 `json:"cyclesPerHour"`
+	ConsumedPerHour float64 `json:"consumedPerHour"`
+	CurrentStock    int64   `json:"currentStock"`
+	DepletionHours  float64 `json:"depletionHours"`
+}
+
+type LaunchpadConnectedFactory struct {
+	PinID         int64                        `json:"pinId"`
+	SchematicName string                       `json:"schematicName"`
+	OutputName    string                       `json:"outputName"`
+	OutputTypeID  int64                        `json:"outputTypeId"`
+	CycleTimeSec  int                          `json:"cycleTimeSec"`
+	Inputs        []*LaunchpadInputRequirement `json:"inputs"`
+}
+
+type LaunchpadDetailResponse struct {
+	PinID       int64                        `json:"pinId"`
+	CharacterID int64                        `json:"characterId"`
+	PlanetID    int64                        `json:"planetId"`
+	Label       string                       `json:"label,omitempty"`
+	Contents    []*PiPinContentResponse      `json:"contents"`
+	Factories   []*LaunchpadConnectedFactory `json:"factories"`
+}
+
+func (c *Pi) GetLaunchpadDetail(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+	userID := *args.User
+	q := args.Request.URL.Query()
+
+	characterID, err := strconv.ParseInt(q.Get("characterId"), 10, 64)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid characterId")}
+	}
+	planetID, err := strconv.ParseInt(q.Get("planetId"), 10, 64)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid planetId")}
+	}
+	pinID, err := strconv.ParseInt(q.Get("pinId"), 10, 64)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid pinId")}
+	}
+
+	// Fetch all data for this user's planets
+	pins, err := c.piRepo.GetPinsForPlanets(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI pins")}
+	}
+
+	contents, err := c.piRepo.GetPinContentsForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI pin contents")}
+	}
+
+	routes, err := c.piRepo.GetRoutesForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI routes")}
+	}
+
+	labels, err := c.labelRepo.GetForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get launchpad labels")}
+	}
+
+	schematics, err := c.schematicRepo.GetAllSchematics(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get schematics")}
+	}
+
+	schematicTypes, err := c.schematicRepo.GetAllSchematicTypes(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get schematic types")}
+	}
+
+	schematicMap := buildSchematicMap(schematics)
+	schematicOutputMap := buildSchematicOutputMap(schematicTypes)
+	schematicInputMap := buildSchematicInputMap(schematicTypes)
+
+	// Collect type IDs for name resolution
+	typeIDSet := map[int64]bool{}
+	for _, c := range contents {
+		if c.CharacterID == characterID && c.PlanetID == planetID && c.PinID == pinID {
+			typeIDSet[c.TypeID] = true
+		}
+	}
+	for _, output := range schematicOutputMap {
+		typeIDSet[output.TypeID] = true
+	}
+	for _, inputs := range schematicInputMap {
+		for _, inp := range inputs {
+			typeIDSet[inp.TypeID] = true
+		}
+	}
+	typeIDs := []int64{}
+	for id := range typeIDSet {
+		typeIDs = append(typeIDs, id)
+	}
+
+	typeNames, err := c.itemTypeRepo.GetNames(ctx, typeIDs)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get item type names")}
+	}
+
+	// Build pin lookup for this planet
+	pinsByID := map[int64]*models.PiPin{}
+	for _, pin := range pins {
+		if pin.CharacterID == characterID && pin.PlanetID == planetID {
+			pinsByID[pin.PinID] = pin
+		}
+	}
+
+	// Build contents lookup for the launchpad
+	launchpadContents := []*PiPinContentResponse{}
+	stockByType := map[int64]int64{}
+	for _, ct := range contents {
+		if ct.CharacterID == characterID && ct.PlanetID == planetID && ct.PinID == pinID {
+			stockByType[ct.TypeID] = ct.Amount
+			launchpadContents = append(launchpadContents, &PiPinContentResponse{
+				TypeID: ct.TypeID,
+				Name:   typeNames[ct.TypeID],
+				Amount: ct.Amount,
+			})
+		}
+	}
+
+	// Find routes FROM this launchpad TO factories (source = this launchpad).
+	// Track which type is routed to which factory so we only show types
+	// the launchpad actually feeds out.
+	type outboundRoute struct {
+		factoryPinID  int64
+		contentTypeID int64
+	}
+	outboundRoutes := []outboundRoute{}
+	for _, r := range routes {
+		if r.CharacterID == characterID && r.PlanetID == planetID && r.SourcePinID == pinID {
+			outboundRoutes = append(outboundRoutes, outboundRoute{
+				factoryPinID:  r.DestinationPinID,
+				contentTypeID: r.ContentTypeID,
+			})
+		}
+	}
+
+	// Group outbound routes by factory, collecting which types are routed to each
+	factoryRoutedTypes := map[int64]map[int64]bool{}
+	for _, ob := range outboundRoutes {
+		if factoryRoutedTypes[ob.factoryPinID] == nil {
+			factoryRoutedTypes[ob.factoryPinID] = map[int64]bool{}
+		}
+		factoryRoutedTypes[ob.factoryPinID][ob.contentTypeID] = true
+	}
+
+	// Build factory detail — only include inputs that are routed from this launchpad
+	factoryResps := []*LaunchpadConnectedFactory{}
+	for factoryPinID, routedTypes := range factoryRoutedTypes {
+		pin := pinsByID[factoryPinID]
+		if pin == nil || pin.PinCategory != "factory" || pin.SchematicID == nil {
+			continue
+		}
+
+		schematicID := *pin.SchematicID
+		schematic := schematicMap[schematicID]
+		output := schematicOutputMap[schematicID]
+		inputs := schematicInputMap[schematicID]
+
+		if schematic == nil || output == nil || schematic.CycleTime <= 0 {
+			continue
+		}
+
+		cyclesPerHour := 3600.0 / float64(schematic.CycleTime)
+
+		inputResps := []*LaunchpadInputRequirement{}
+		for _, inp := range inputs {
+			// Only include types that are actually routed from this launchpad
+			if !routedTypes[inp.TypeID] {
+				continue
+			}
+			consumedPerHour := float64(inp.Quantity) * cyclesPerHour
+			stock := stockByType[inp.TypeID]
+			depletionHours := 0.0
+			if consumedPerHour > 0 && stock > 0 {
+				depletionHours = float64(stock) / consumedPerHour
+			}
+
+			inputResps = append(inputResps, &LaunchpadInputRequirement{
+				TypeID:          inp.TypeID,
+				Name:            typeNames[inp.TypeID],
+				QtyPerCycle:     inp.Quantity,
+				CyclesPerHour:   cyclesPerHour,
+				ConsumedPerHour: consumedPerHour,
+				CurrentStock:    stock,
+				DepletionHours:  depletionHours,
+			})
+		}
+
+		factoryResps = append(factoryResps, &LaunchpadConnectedFactory{
+			PinID:         pin.PinID,
+			SchematicName: schematic.Name,
+			OutputName:    typeNames[output.TypeID],
+			OutputTypeID:  output.TypeID,
+			CycleTimeSec:  schematic.CycleTime,
+			Inputs:        inputResps,
+		})
+	}
+
+	// Find label for this launchpad
+	labelStr := ""
+	for _, l := range labels {
+		if l.CharacterID == characterID && l.PlanetID == planetID && l.PinID == pinID {
+			labelStr = l.Label
+			break
+		}
+	}
+
+	return &LaunchpadDetailResponse{
+		PinID:       pinID,
+		CharacterID: characterID,
+		PlanetID:    planetID,
+		Label:       labelStr,
+		Contents:    launchpadContents,
+		Factories:   factoryResps,
+	}, nil
+}
+
+// --- Phase 2: Profit Calculation ---
+
+// PI tier base costs (ISK per unit) used for POCO tax calculation
+var piTierBaseCost = map[int]float64{
+	0: 5,         // R0
+	1: 400,       // P1
+	2: 7200,      // P2
+	3: 60000,     // P3
+	4: 1200000,   // P4
+}
+
+var tierName = map[int]string{
+	0: "R0",
+	1: "P1",
+	2: "P2",
+	3: "P3",
+	4: "P4",
+}
+
+// Profit response types
+
+type PiFactoryInputResponse struct {
+	TypeID           int64   `json:"typeId"`
+	Name             string  `json:"name"`
+	Tier             string  `json:"tier"`
+	Quantity         int     `json:"quantity"`
+	PricePerUnit     float64 `json:"pricePerUnit"`
+	CostPerHour      float64 `json:"costPerHour"`
+	ImportTaxPerHour float64 `json:"importTaxPerHour"`
+	IsLocal          bool    `json:"isLocal"`
+}
+
+type PiFactoryProfitResponse struct {
+	PinID              int64                      `json:"pinId"`
+	SchematicID        int                        `json:"schematicId"`
+	SchematicName      string                     `json:"schematicName"`
+	OutputTypeID       int64                      `json:"outputTypeId"`
+	OutputName         string                     `json:"outputName"`
+	OutputTier         string                     `json:"outputTier"`
+	OutputQty          int                        `json:"outputQty"`
+	CycleTimeSec       int                        `json:"cycleTimeSec"`
+	RatePerHour        float64                    `json:"ratePerHour"`
+	OutputValuePerHour float64                    `json:"outputValuePerHour"`
+	InputCostPerHour   float64                    `json:"inputCostPerHour"`
+	ExportTaxPerHour   float64                    `json:"exportTaxPerHour"`
+	ImportTaxPerHour   float64                    `json:"importTaxPerHour"`
+	ProfitPerHour      float64                    `json:"profitPerHour"`
+	Inputs             []*PiFactoryInputResponse  `json:"inputs"`
+}
+
+type PiPlanetProfitResponse struct {
+	PlanetID           int64                       `json:"planetId"`
+	PlanetType         string                      `json:"planetType"`
+	SolarSystemID      int64                       `json:"solarSystemId"`
+	SolarSystemName    string                      `json:"solarSystemName"`
+	CharacterID        int64                       `json:"characterId"`
+	CharacterName      string                      `json:"characterName"`
+	TaxRate            float64                     `json:"taxRate"`
+	TotalOutputValue   float64                     `json:"totalOutputValue"`
+	TotalInputCost     float64                     `json:"totalInputCost"`
+	TotalExportTax     float64                     `json:"totalExportTax"`
+	TotalImportTax     float64                     `json:"totalImportTax"`
+	NetProfitPerHour   float64                     `json:"netProfitPerHour"`
+	Factories          []*PiFactoryProfitResponse  `json:"factories"`
+}
+
+type PiProfitListResponse struct {
+	Planets          []*PiPlanetProfitResponse `json:"planets"`
+	PriceSource      string                    `json:"priceSource"`
+	TotalOutputValue float64                   `json:"totalOutputValue"`
+	TotalInputCost   float64                   `json:"totalInputCost"`
+	TotalExportTax   float64                   `json:"totalExportTax"`
+	TotalImportTax   float64                   `json:"totalImportTax"`
+	TotalProfit      float64                   `json:"totalProfit"`
+}
+
+// buildTierMap classifies every PI material type into a tier (0=R0, 1=P1, ..., 4=P4)
+// by walking the schematic type graph. A type that is never the output of any schematic
+// is R0 (raw resource). Outputs inherit tier = max(input tiers) + 1.
+func buildTierMap(schematicTypes []*models.SdePlanetSchematicType) map[int64]int {
+	outputToSchematic := map[int64]int64{} // typeID -> schematicID that produces it
+	schematicInputTypeIDs := map[int64][]int64{} // schematicID -> input typeIDs
+
+	for _, st := range schematicTypes {
+		if st.IsInput {
+			schematicInputTypeIDs[st.SchematicID] = append(schematicInputTypeIDs[st.SchematicID], st.TypeID)
+		} else {
+			outputToSchematic[st.TypeID] = st.SchematicID
+		}
+	}
+
+	// Collect all type IDs that appear as inputs
+	allInputIDs := map[int64]bool{}
+	for _, inputs := range schematicInputTypeIDs {
+		for _, id := range inputs {
+			allInputIDs[id] = true
+		}
+	}
+
+	tierMap := map[int64]int{}
+
+	// R0: any type that is used as input but is never the output of a schematic
+	for typeID := range allInputIDs {
+		if _, isOutput := outputToSchematic[typeID]; !isOutput {
+			tierMap[typeID] = 0
+		}
+	}
+
+	// Iteratively classify outputs based on their inputs' tiers
+	changed := true
+	for changed {
+		changed = false
+		for outputTypeID, schematicID := range outputToSchematic {
+			if _, done := tierMap[outputTypeID]; done {
+				continue
+			}
+
+			inputs := schematicInputTypeIDs[schematicID]
+			allClassified := true
+			maxInputTier := 0
+			for _, inputID := range inputs {
+				t, ok := tierMap[inputID]
+				if !ok {
+					allClassified = false
+					break
+				}
+				if t > maxInputTier {
+					maxInputTier = t
+				}
+			}
+
+			if allClassified && len(inputs) > 0 {
+				tierMap[outputTypeID] = maxInputTier + 1
+				changed = true
+			}
+		}
+	}
+
+	return tierMap
+}
+
+// schematicInput describes one input material for a schematic
+type schematicInput struct {
+	TypeID   int64
+	Quantity int
+}
+
+// buildSchematicInputMap returns schematicID -> list of inputs
+func buildSchematicInputMap(types []*models.SdePlanetSchematicType) map[int][]*schematicInput {
+	m := map[int][]*schematicInput{}
+	for _, t := range types {
+		if t.IsInput {
+			sid := int(t.SchematicID)
+			m[sid] = append(m[sid], &schematicInput{
+				TypeID:   t.TypeID,
+				Quantity: t.Quantity,
+			})
+		}
+	}
+	return m
+}
+
+func getPrice(mp *models.MarketPrice, source string) float64 {
+	if mp == nil {
+		return 0
+	}
+	switch source {
+	case "buy":
+		if mp.BuyPrice != nil {
+			return *mp.BuyPrice
+		}
+	case "sell":
+		if mp.SellPrice != nil {
+			return *mp.SellPrice
+		}
+	case "split":
+		buy, sell := 0.0, 0.0
+		if mp.BuyPrice != nil {
+			buy = *mp.BuyPrice
+		}
+		if mp.SellPrice != nil {
+			sell = *mp.SellPrice
+		}
+		return (buy + sell) / 2
+	}
+	return 0
+}
+
+func (c *Pi) GetProfit(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+	userID := *args.User
+
+	priceSource := args.Request.URL.Query().Get("priceSource")
+	if priceSource == "" {
+		priceSource = "sell"
+	}
+
+	planets, err := c.piRepo.GetPlanetsForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI planets")}
+	}
+
+	pins, err := c.piRepo.GetPinsForPlanets(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI pins")}
+	}
+
+	schematics, err := c.schematicRepo.GetAllSchematics(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get schematics")}
+	}
+
+	schematicTypes, err := c.schematicRepo.GetAllSchematicTypes(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get schematic types")}
+	}
+
+	jitaPrices, err := c.marketRepo.GetAllJitaPrices(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get Jita prices")}
+	}
+
+	taxConfigs, err := c.taxRepo.GetForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get tax configs")}
+	}
+
+	charNames, err := c.charRepo.GetNames(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get character names")}
+	}
+
+	systemIDs := []int64{}
+	systemIDSet := map[int64]bool{}
+	for _, p := range planets {
+		if !systemIDSet[p.SolarSystemID] {
+			systemIDs = append(systemIDs, p.SolarSystemID)
+			systemIDSet[p.SolarSystemID] = true
+		}
+	}
+	systemNames, err := c.systemRepo.GetNames(ctx, systemIDs)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get system names")}
+	}
+
+	// Collect type IDs for name resolution
+	typeIDSet := map[int64]bool{}
+	for _, st := range schematicTypes {
+		typeIDSet[st.TypeID] = true
+	}
+	typeIDs := []int64{}
+	for id := range typeIDSet {
+		typeIDs = append(typeIDs, id)
+	}
+	typeNames, err := c.itemTypeRepo.GetNames(ctx, typeIDs)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get item type names")}
+	}
+
+	// Build lookup maps
+	schematicMap := buildSchematicMap(schematics)
+	schematicOutputMap := buildSchematicOutputMap(schematicTypes)
+	schematicInputMap := buildSchematicInputMap(schematicTypes)
+	tierMap := buildTierMap(schematicTypes)
+
+	// Build tax rate lookup: planetID -> rate, with global default fallback
+	globalTaxRate := 2.5
+	planetTaxRates := map[int64]float64{}
+	for _, tc := range taxConfigs {
+		if tc.PlanetID == nil {
+			globalTaxRate = tc.TaxRate
+		} else {
+			planetTaxRates[*tc.PlanetID] = tc.TaxRate
+		}
+	}
+
+	// Group pins by planet
+	type planetKey struct {
+		CharacterID int64
+		PlanetID    int64
+	}
+	pinsByPlanet := map[planetKey][]*models.PiPin{}
+	for _, pin := range pins {
+		key := planetKey{pin.CharacterID, pin.PlanetID}
+		pinsByPlanet[key] = append(pinsByPlanet[key], pin)
+	}
+
+	// Build global set of all types produced across ALL user planets.
+	// This lets us recognize cross-planet inputs (cost=0 but taxes still apply).
+	userProducedTypes := map[int64]bool{}
+	for _, pin := range pins {
+		if pin.PinCategory == "extractor" && pin.ExtractorProductTypeID != nil {
+			userProducedTypes[*pin.ExtractorProductTypeID] = true
+		}
+		if pin.PinCategory == "factory" && pin.SchematicID != nil {
+			if output := schematicOutputMap[*pin.SchematicID]; output != nil {
+				userProducedTypes[output.TypeID] = true
+			}
+		}
+	}
+
+	result := &PiProfitListResponse{
+		Planets:     []*PiPlanetProfitResponse{},
+		PriceSource: priceSource,
+	}
+
+	for _, planet := range planets {
+		taxRate := globalTaxRate
+		if rate, ok := planetTaxRates[planet.PlanetID]; ok {
+			taxRate = rate
+		}
+
+		key := planetKey{planet.CharacterID, planet.PlanetID}
+		planetPins := pinsByPlanet[key]
+
+		// First pass: collect all types produced on this planet (extractors + factories)
+		// so we know which factory inputs are locally sourced vs imported.
+		locallyProduced := map[int64]bool{}
+		// Track per-type production and consumption rates for net planet totals.
+		productionRates := map[int64]float64{} // typeID -> units/hr produced
+		consumptionRates := map[int64]float64{} // typeID -> units/hr consumed
+
+		for _, pin := range planetPins {
+			if pin.PinCategory == "extractor" && pin.ExtractorProductTypeID != nil {
+				locallyProduced[*pin.ExtractorProductTypeID] = true
+				cycleTime := 0
+				if pin.ExtractorCycleTime != nil {
+					cycleTime = *pin.ExtractorCycleTime
+				}
+				qtyPerCycle := 0
+				if pin.ExtractorQtyPerCycle != nil {
+					qtyPerCycle = *pin.ExtractorQtyPerCycle
+				}
+				if cycleTime > 0 {
+					productionRates[*pin.ExtractorProductTypeID] += float64(qtyPerCycle) / float64(cycleTime) * 3600.0
+				}
+			}
+			if pin.PinCategory == "factory" && pin.SchematicID != nil {
+				output := schematicOutputMap[*pin.SchematicID]
+				schematic := schematicMap[*pin.SchematicID]
+				if output != nil && schematic != nil && schematic.CycleTime > 0 {
+					locallyProduced[output.TypeID] = true
+					cyclesPerHour := 3600.0 / float64(schematic.CycleTime)
+					productionRates[output.TypeID] += float64(output.Quantity) * cyclesPerHour
+
+					inputs := schematicInputMap[*pin.SchematicID]
+					for _, inp := range inputs {
+						consumptionRates[inp.TypeID] += float64(inp.Quantity) * cyclesPerHour
+					}
+				}
+			}
+		}
+
+		planetResp := &PiPlanetProfitResponse{
+			PlanetID:        planet.PlanetID,
+			PlanetType:      planet.PlanetType,
+			SolarSystemID:   planet.SolarSystemID,
+			SolarSystemName: systemNames[planet.SolarSystemID],
+			CharacterID:     planet.CharacterID,
+			CharacterName:   charNames[planet.CharacterID],
+			TaxRate:         taxRate,
+			Factories:       []*PiFactoryProfitResponse{},
+		}
+
+		// Second pass: build per-factory profit (inputs sourced locally have zero cost)
+		for _, pin := range planetPins {
+			if pin.PinCategory != "factory" || pin.SchematicID == nil {
+				continue
+			}
+
+			schematicID := *pin.SchematicID
+			schematic := schematicMap[schematicID]
+			output := schematicOutputMap[schematicID]
+			inputs := schematicInputMap[schematicID]
+
+			if schematic == nil || output == nil || schematic.CycleTime <= 0 {
+				continue
+			}
+
+			cyclesPerHour := 3600.0 / float64(schematic.CycleTime)
+
+			outputPrice := getPrice(jitaPrices[output.TypeID], priceSource)
+			outputValuePerHour := float64(output.Quantity) * outputPrice * cyclesPerHour
+
+			outputTier := tierMap[output.TypeID]
+			exportTaxPerHour := piTierBaseCost[outputTier] * float64(output.Quantity) * (taxRate / 100) * cyclesPerHour
+
+			inputCostPerHour := 0.0
+			importTaxPerHour := 0.0
+			inputResps := []*PiFactoryInputResponse{}
+
+			for _, inp := range inputs {
+				inputTier := tierMap[inp.TypeID]
+				samePlanet := locallyProduced[inp.TypeID]
+				crossPlanet := !samePlanet && userProducedTypes[inp.TypeID]
+				isLocal := samePlanet || crossPlanet
+
+				costPerHour := 0.0
+				impTaxPerHour := 0.0
+				inputPrice := getPrice(jitaPrices[inp.TypeID], priceSource)
+
+				if samePlanet {
+					// Produced on same planet: no material cost, no import tax (no transfer)
+				} else if crossPlanet {
+					// Produced on another user planet: no material cost, but import tax applies (transfer)
+					impTaxPerHour = piTierBaseCost[inputTier] * float64(inp.Quantity) * (taxRate / 100) * 0.5 * cyclesPerHour
+				} else {
+					// Truly external: Jita price + import tax
+					costPerHour = float64(inp.Quantity) * inputPrice * cyclesPerHour
+					impTaxPerHour = piTierBaseCost[inputTier] * float64(inp.Quantity) * (taxRate / 100) * 0.5 * cyclesPerHour
+				}
+
+				inputCostPerHour += costPerHour
+				importTaxPerHour += impTaxPerHour
+
+				inputResps = append(inputResps, &PiFactoryInputResponse{
+					TypeID:           inp.TypeID,
+					Name:             typeNames[inp.TypeID],
+					Tier:             tierName[inputTier],
+					Quantity:         inp.Quantity,
+					PricePerUnit:     inputPrice,
+					CostPerHour:      costPerHour,
+					ImportTaxPerHour: impTaxPerHour,
+					IsLocal:          isLocal,
+				})
+			}
+
+			profitPerHour := outputValuePerHour - inputCostPerHour - exportTaxPerHour - importTaxPerHour
+
+			planetResp.Factories = append(planetResp.Factories, &PiFactoryProfitResponse{
+				PinID:              pin.PinID,
+				SchematicID:        schematicID,
+				SchematicName:      schematic.Name,
+				OutputTypeID:       output.TypeID,
+				OutputName:         typeNames[output.TypeID],
+				OutputTier:         tierName[outputTier],
+				OutputQty:          output.Quantity,
+				CycleTimeSec:       schematic.CycleTime,
+				RatePerHour:        float64(output.Quantity) * cyclesPerHour,
+				OutputValuePerHour: outputValuePerHour,
+				InputCostPerHour:   inputCostPerHour,
+				ExportTaxPerHour:   exportTaxPerHour,
+				ImportTaxPerHour:   importTaxPerHour,
+				ProfitPerHour:      profitPerHour,
+				Inputs:             inputResps,
+			})
+		}
+
+		// Planet totals: use net production/consumption to avoid double-counting intermediates.
+		// Net exported types = production > consumption → revenue
+		// Net imported types = consumption > production → cost
+		allTypeIDs := map[int64]bool{}
+		for id := range productionRates {
+			allTypeIDs[id] = true
+		}
+		for id := range consumptionRates {
+			allTypeIDs[id] = true
+		}
+
+		for typeID := range allTypeIDs {
+			produced := productionRates[typeID]
+			consumed := consumptionRates[typeID]
+			net := produced - consumed
+			t := tierMap[typeID]
+
+			if net > 0 {
+				// Net export
+				price := getPrice(jitaPrices[typeID], priceSource)
+				planetResp.TotalOutputValue += net * price
+				planetResp.TotalExportTax += net * piTierBaseCost[t] * (taxRate / 100)
+			} else if net < 0 {
+				// Net import
+				imported := -net
+				planetResp.TotalImportTax += imported * piTierBaseCost[t] * (taxRate / 100) * 0.5
+				if !userProducedTypes[typeID] {
+					// Only charge Jita price for materials not produced on any user planet
+					price := getPrice(jitaPrices[typeID], priceSource)
+					planetResp.TotalInputCost += imported * price
+				}
+			}
+		}
+		planetResp.NetProfitPerHour = planetResp.TotalOutputValue - planetResp.TotalInputCost - planetResp.TotalExportTax - planetResp.TotalImportTax
+
+		result.Planets = append(result.Planets, planetResp)
+	}
+
+	// Compute global totals across ALL planets.
+	// Only types that are net-exported across all planets count as revenue (sold at Jita).
+	// Only types that are net-imported across all planets count as costs (bought from Jita).
+	// Taxes are summed from per-factory calculations (actual POCO payments).
+	globalProduction := map[int64]float64{}
+	globalConsumption := map[int64]float64{}
+	for _, pin := range pins {
+		if pin.PinCategory == "extractor" && pin.ExtractorProductTypeID != nil {
+			cycleTime := 0
+			if pin.ExtractorCycleTime != nil {
+				cycleTime = *pin.ExtractorCycleTime
+			}
+			qtyPerCycle := 0
+			if pin.ExtractorQtyPerCycle != nil {
+				qtyPerCycle = *pin.ExtractorQtyPerCycle
+			}
+			if cycleTime > 0 {
+				globalProduction[*pin.ExtractorProductTypeID] += float64(qtyPerCycle) / float64(cycleTime) * 3600.0
+			}
+		}
+		if pin.PinCategory == "factory" && pin.SchematicID != nil {
+			output := schematicOutputMap[*pin.SchematicID]
+			schematic := schematicMap[*pin.SchematicID]
+			if output != nil && schematic != nil && schematic.CycleTime > 0 {
+				cyclesPerHour := 3600.0 / float64(schematic.CycleTime)
+				globalProduction[output.TypeID] += float64(output.Quantity) * cyclesPerHour
+				for _, inp := range schematicInputMap[*pin.SchematicID] {
+					globalConsumption[inp.TypeID] += float64(inp.Quantity) * cyclesPerHour
+				}
+			}
+		}
+	}
+
+	globalTypeIDs := map[int64]bool{}
+	for id := range globalProduction {
+		globalTypeIDs[id] = true
+	}
+	for id := range globalConsumption {
+		globalTypeIDs[id] = true
+	}
+
+	for typeID := range globalTypeIDs {
+		produced := globalProduction[typeID]
+		consumed := globalConsumption[typeID]
+		net := produced - consumed
+		t := tierMap[typeID]
+
+		if net > 0 {
+			// Truly exported to market
+			price := getPrice(jitaPrices[typeID], priceSource)
+			result.TotalOutputValue += net * price
+			result.TotalExportTax += net * piTierBaseCost[t] * (globalTaxRate / 100)
+		} else if net < 0 {
+			// Truly imported from market
+			imported := -net
+			price := getPrice(jitaPrices[typeID], priceSource)
+			result.TotalInputCost += imported * price
+			result.TotalImportTax += imported * piTierBaseCost[t] * (globalTaxRate / 100) * 0.5
+		}
+	}
+
+	// For total taxes, sum actual per-factory taxes instead of the global net estimate,
+	// since each planet has its own tax rate and inter-planet transfers incur taxes.
+	result.TotalExportTax = 0
+	result.TotalImportTax = 0
+	for _, planet := range result.Planets {
+		for _, factory := range planet.Factories {
+			result.TotalExportTax += factory.ExportTaxPerHour
+			result.TotalImportTax += factory.ImportTaxPerHour
+		}
+	}
+	result.TotalProfit = result.TotalOutputValue - result.TotalInputCost - result.TotalExportTax - result.TotalImportTax
+
+	return result, nil
+}
+
+// --- Phase 5: Supply Chain Analysis ---
+
+type SupplyChainItem struct {
+	TypeID            int64   `json:"typeId"`
+	Name              string  `json:"name"`
+	Tier              int     `json:"tier"`
+	TierName          string  `json:"tierName"`
+	ProducedPerHour   float64 `json:"producedPerHour"`
+	ConsumedPerHour   float64 `json:"consumedPerHour"`
+	NetPerHour        float64 `json:"netPerHour"`
+	StockpileQty      int64   `json:"stockpileQty"`
+	DepletionHours    float64 `json:"depletionHours"`  // 0 = no consumption or no stock
+	Source            string  `json:"source"`           // "extracted", "produced", "bought", "mixed"
+	Producers         []*SupplyChainPlanetEntry `json:"producers"`
+	Consumers         []*SupplyChainPlanetEntry `json:"consumers"`
+	StockpileMarkers  []*models.StockpileMarker `json:"stockpileMarkers,omitempty"`
+}
+
+type SupplyChainPlanetEntry struct {
+	CharacterID     int64   `json:"characterId"`
+	CharacterName   string  `json:"characterName"`
+	PlanetID        int64   `json:"planetId"`
+	SolarSystemName string  `json:"solarSystemName"`
+	PlanetType      string  `json:"planetType"`
+	RatePerHour     float64 `json:"ratePerHour"`
+}
+
+type SupplyChainResponse struct {
+	Items []*SupplyChainItem `json:"items"`
+}
+
+// rollUpByPlanet aggregates multiple pin-level entries into one entry per planet,
+// summing their rates.
+func rollUpByPlanet(entries []*SupplyChainPlanetEntry) []*SupplyChainPlanetEntry {
+	if len(entries) <= 1 {
+		return entries
+	}
+
+	type key struct {
+		characterID int64
+		planetID    int64
+	}
+	order := []key{}
+	grouped := map[key]*SupplyChainPlanetEntry{}
+	for _, e := range entries {
+		k := key{e.CharacterID, e.PlanetID}
+		if existing, ok := grouped[k]; ok {
+			existing.RatePerHour += e.RatePerHour
+		} else {
+			grouped[k] = &SupplyChainPlanetEntry{
+				CharacterID:     e.CharacterID,
+				CharacterName:   e.CharacterName,
+				PlanetID:        e.PlanetID,
+				SolarSystemName: e.SolarSystemName,
+				PlanetType:      e.PlanetType,
+				RatePerHour:     e.RatePerHour,
+			}
+			order = append(order, k)
+		}
+	}
+
+	result := make([]*SupplyChainPlanetEntry, 0, len(order))
+	for _, k := range order {
+		result = append(result, grouped[k])
+	}
+	return result
+}
+
+func (c *Pi) GetSupplyChain(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+	userID := *args.User
+
+	planets, err := c.piRepo.GetPlanetsForUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI planets")}
+	}
+
+	pins, err := c.piRepo.GetPinsForPlanets(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get PI pins")}
+	}
+
+	schematics, err := c.schematicRepo.GetAllSchematics(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get schematics")}
+	}
+
+	schematicTypes, err := c.schematicRepo.GetAllSchematicTypes(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get schematic types")}
+	}
+
+	stockpileMarkers, err := c.stockpileRepo.GetByUser(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get stockpile markers")}
+	}
+
+	charNames, err := c.charRepo.GetNames(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get character names")}
+	}
+
+	systemIDs := []int64{}
+	systemIDSet := map[int64]bool{}
+	for _, p := range planets {
+		if !systemIDSet[p.SolarSystemID] {
+			systemIDs = append(systemIDs, p.SolarSystemID)
+			systemIDSet[p.SolarSystemID] = true
+		}
+	}
+	systemNames, err := c.systemRepo.GetNames(ctx, systemIDs)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get system names")}
+	}
+
+	schematicMap := buildSchematicMap(schematics)
+	schematicOutputMap := buildSchematicOutputMap(schematicTypes)
+	schematicInputMap := buildSchematicInputMap(schematicTypes)
+	tierMap := buildTierMap(schematicTypes)
+
+	// Build planet lookup for producer/consumer entries
+	planetByKey := map[int64]*models.PiPlanet{} // characterID<<32 | planetID -> planet
+	for _, p := range planets {
+		planetByKey[p.CharacterID<<32|p.PlanetID] = p
+	}
+
+	// Aggregate production and consumption across all planets
+	type typeEntry struct {
+		producedPerHour float64
+		consumedPerHour float64
+		producers       []*SupplyChainPlanetEntry
+		consumers       []*SupplyChainPlanetEntry
+		isExtracted     bool
+		isProduced      bool
+	}
+	entries := map[int64]*typeEntry{}
+
+	getEntry := func(typeID int64) *typeEntry {
+		e := entries[typeID]
+		if e == nil {
+			e = &typeEntry{}
+			entries[typeID] = e
+		}
+		return e
+	}
+
+	makePlanetEntry := func(pin *models.PiPin, rate float64) *SupplyChainPlanetEntry {
+		planet := planetByKey[pin.CharacterID<<32|pin.PlanetID]
+		if planet == nil {
+			return &SupplyChainPlanetEntry{
+				CharacterID: pin.CharacterID,
+				PlanetID:    pin.PlanetID,
+				RatePerHour: rate,
+			}
+		}
+		return &SupplyChainPlanetEntry{
+			CharacterID:     pin.CharacterID,
+			CharacterName:   charNames[pin.CharacterID],
+			PlanetID:        pin.PlanetID,
+			SolarSystemName: systemNames[planet.SolarSystemID],
+			PlanetType:      planet.PlanetType,
+			RatePerHour:     rate,
+		}
+	}
+
+	for _, pin := range pins {
+		if pin.PinCategory == "extractor" && pin.ExtractorProductTypeID != nil {
+			cycleTime := 0
+			if pin.ExtractorCycleTime != nil {
+				cycleTime = *pin.ExtractorCycleTime
+			}
+			qtyPerCycle := 0
+			if pin.ExtractorQtyPerCycle != nil {
+				qtyPerCycle = *pin.ExtractorQtyPerCycle
+			}
+			if cycleTime > 0 {
+				rate := float64(qtyPerCycle) / float64(cycleTime) * 3600.0
+				e := getEntry(*pin.ExtractorProductTypeID)
+				e.producedPerHour += rate
+				e.isExtracted = true
+				e.producers = append(e.producers, makePlanetEntry(pin, rate))
+			}
+		}
+
+		if pin.PinCategory == "factory" && pin.SchematicID != nil {
+			output := schematicOutputMap[*pin.SchematicID]
+			schematic := schematicMap[*pin.SchematicID]
+			if output != nil && schematic != nil && schematic.CycleTime > 0 {
+				cyclesPerHour := 3600.0 / float64(schematic.CycleTime)
+				outputRate := float64(output.Quantity) * cyclesPerHour
+				e := getEntry(output.TypeID)
+				e.producedPerHour += outputRate
+				e.isProduced = true
+				e.producers = append(e.producers, makePlanetEntry(pin, outputRate))
+
+				inputs := schematicInputMap[*pin.SchematicID]
+				for _, inp := range inputs {
+					inputRate := float64(inp.Quantity) * cyclesPerHour
+					ce := getEntry(inp.TypeID)
+					ce.consumedPerHour += inputRate
+					ce.consumers = append(ce.consumers, makePlanetEntry(pin, inputRate))
+				}
+			}
+		}
+	}
+
+	// Build set of PI material type IDs from schematic data
+	piTypeIDs := map[int64]bool{}
+	for _, st := range schematicTypes {
+		piTypeIDs[st.TypeID] = true
+	}
+
+	// Aggregate stockpile quantities by typeID for PI materials
+	stockpileByType := map[int64]int64{}
+	markersByType := map[int64][]*models.StockpileMarker{}
+	for _, m := range stockpileMarkers {
+		if _, isPiType := entries[m.TypeID]; isPiType {
+			stockpileByType[m.TypeID] += m.DesiredQuantity
+			markersByType[m.TypeID] = append(markersByType[m.TypeID], m)
+		} else if piTypeIDs[m.TypeID] {
+			// Stockpile-only type not produced/consumed — add as "bought" entry
+			stockpileByType[m.TypeID] += m.DesiredQuantity
+			markersByType[m.TypeID] = append(markersByType[m.TypeID], m)
+			entries[m.TypeID] = &typeEntry{}
+		}
+	}
+
+	// Collect type IDs for name resolution
+	typeIDSet := map[int64]bool{}
+	for typeID := range entries {
+		typeIDSet[typeID] = true
+	}
+	typeIDs := []int64{}
+	for id := range typeIDSet {
+		typeIDs = append(typeIDs, id)
+	}
+	typeNames, err := c.itemTypeRepo.GetNames(ctx, typeIDs)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get item type names")}
+	}
+
+	// Build response items
+	items := []*SupplyChainItem{}
+	for typeID, e := range entries {
+		net := e.producedPerHour - e.consumedPerHour
+		stockQty := stockpileByType[typeID]
+
+		depletionHours := 0.0
+		if e.consumedPerHour > 0 && net < 0 {
+			// Net deficit — how long until stockpile runs out
+			deficit := -net
+			if stockQty > 0 {
+				depletionHours = float64(stockQty) / deficit
+			}
+		}
+
+		source := "produced"
+		if e.isExtracted && !e.isProduced {
+			source = "extracted"
+		} else if e.isExtracted && e.isProduced {
+			source = "mixed"
+		} else if !e.isExtracted && !e.isProduced && stockQty > 0 {
+			source = "bought"
+		}
+
+		tier := tierMap[typeID]
+		tn := "R0"
+		if t, ok := tierName[tier]; ok {
+			tn = t
+		}
+
+		items = append(items, &SupplyChainItem{
+			TypeID:          typeID,
+			Name:            typeNames[typeID],
+			Tier:            tier,
+			TierName:        tn,
+			ProducedPerHour: e.producedPerHour,
+			ConsumedPerHour: e.consumedPerHour,
+			NetPerHour:      net,
+			StockpileQty:    stockQty,
+			DepletionHours:  depletionHours,
+			Source:          source,
+			Producers:        rollUpByPlanet(e.producers),
+			Consumers:        rollUpByPlanet(e.consumers),
+			StockpileMarkers: markersByType[typeID],
+		})
+	}
+
+	return &SupplyChainResponse{Items: items}, nil
+}

--- a/internal/database/migrations/20260220113513_create_pi_tables.down.sql
+++ b/internal/database/migrations/20260220113513_create_pi_tables.down.sql
@@ -1,0 +1,5 @@
+drop table if exists pi_tax_config;
+drop table if exists pi_routes;
+drop table if exists pi_pin_contents;
+drop table if exists pi_pins;
+drop table if exists pi_planets;

--- a/internal/database/migrations/20260220113513_create_pi_tables.up.sql
+++ b/internal/database/migrations/20260220113513_create_pi_tables.up.sql
@@ -1,0 +1,69 @@
+create table pi_planets (
+	id bigserial primary key,
+	character_id bigint not null,
+	user_id bigint not null,
+	planet_id bigint not null,
+	planet_type varchar(20) not null,
+	solar_system_id bigint not null,
+	upgrade_level int not null default 0,
+	num_pins int not null default 0,
+	last_update timestamp not null,
+	last_stall_notified_at timestamp,
+	created_at timestamp not null default now(),
+	updated_at timestamp not null default now(),
+	unique(character_id, planet_id)
+);
+
+create index idx_pi_planets_user on pi_planets(user_id);
+
+create table pi_pins (
+	id bigserial primary key,
+	character_id bigint not null,
+	planet_id bigint not null,
+	pin_id bigint not null,
+	type_id bigint not null,
+	schematic_id int,
+	latitude double precision,
+	longitude double precision,
+	install_time timestamp,
+	expiry_time timestamp,
+	last_cycle_start timestamp,
+	extractor_cycle_time int,
+	extractor_head_radius double precision,
+	extractor_product_type_id bigint,
+	extractor_qty_per_cycle int,
+	extractor_num_heads int,
+	pin_category varchar(20) not null,
+	updated_at timestamp not null default now(),
+	unique(character_id, planet_id, pin_id)
+);
+
+create index idx_pi_pins_planet on pi_pins(character_id, planet_id);
+
+create table pi_pin_contents (
+	character_id bigint not null,
+	planet_id bigint not null,
+	pin_id bigint not null,
+	type_id bigint not null,
+	amount bigint not null,
+	primary key(character_id, planet_id, pin_id, type_id)
+);
+
+create table pi_routes (
+	character_id bigint not null,
+	planet_id bigint not null,
+	route_id bigint not null,
+	source_pin_id bigint not null,
+	destination_pin_id bigint not null,
+	content_type_id bigint not null,
+	quantity bigint not null,
+	primary key(character_id, planet_id, route_id)
+);
+
+create table pi_tax_config (
+	id bigserial primary key,
+	user_id bigint not null references users(id),
+	planet_id bigint,
+	tax_rate double precision not null default 10.0,
+	unique(user_id, planet_id)
+);

--- a/internal/database/migrations/20260220131419_create_pi_launchpad_labels.down.sql
+++ b/internal/database/migrations/20260220131419_create_pi_launchpad_labels.down.sql
@@ -1,0 +1,1 @@
+drop table if exists pi_launchpad_labels;

--- a/internal/database/migrations/20260220131419_create_pi_launchpad_labels.up.sql
+++ b/internal/database/migrations/20260220131419_create_pi_launchpad_labels.up.sql
@@ -1,0 +1,8 @@
+create table pi_launchpad_labels (
+	user_id bigint not null references users(id),
+	character_id bigint not null,
+	planet_id bigint not null,
+	pin_id bigint not null,
+	label varchar(100) not null,
+	primary key(user_id, character_id, planet_id, pin_id)
+);

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -684,3 +684,71 @@ type PlanResponse struct {
 	ShoppingList  []*ShoppingItem    `json:"shopping_list"`
 	Summary       *PlanSummary       `json:"summary"`
 }
+
+// Planetary Industry Models
+
+type PiPlanet struct {
+	ID                  int64      `json:"id"`
+	CharacterID         int64      `json:"characterId"`
+	UserID              int64      `json:"userId"`
+	PlanetID            int64      `json:"planetId"`
+	PlanetType          string     `json:"planetType"`
+	SolarSystemID       int64      `json:"solarSystemId"`
+	UpgradeLevel        int        `json:"upgradeLevel"`
+	NumPins             int        `json:"numPins"`
+	LastUpdate          time.Time  `json:"lastUpdate"`
+	LastStallNotifiedAt *time.Time `json:"lastStallNotifiedAt,omitempty"`
+}
+
+type PiPin struct {
+	ID                     int64      `json:"id"`
+	CharacterID            int64      `json:"characterId"`
+	PlanetID               int64      `json:"planetId"`
+	PinID                  int64      `json:"pinId"`
+	TypeID                 int64      `json:"typeId"`
+	SchematicID            *int       `json:"schematicId"`
+	Latitude               *float64   `json:"latitude"`
+	Longitude              *float64   `json:"longitude"`
+	InstallTime            *time.Time `json:"installTime"`
+	ExpiryTime             *time.Time `json:"expiryTime"`
+	LastCycleStart         *time.Time `json:"lastCycleStart"`
+	ExtractorCycleTime     *int       `json:"extractorCycleTime"`
+	ExtractorHeadRadius    *float64   `json:"extractorHeadRadius"`
+	ExtractorProductTypeID *int64     `json:"extractorProductTypeId"`
+	ExtractorQtyPerCycle   *int       `json:"extractorQtyPerCycle"`
+	ExtractorNumHeads      *int       `json:"extractorNumHeads"`
+	PinCategory            string     `json:"pinCategory"`
+}
+
+type PiPinContent struct {
+	CharacterID int64 `json:"characterId"`
+	PlanetID    int64 `json:"planetId"`
+	PinID       int64 `json:"pinId"`
+	TypeID      int64 `json:"typeId"`
+	Amount      int64 `json:"amount"`
+}
+
+type PiRoute struct {
+	CharacterID      int64 `json:"characterId"`
+	PlanetID         int64 `json:"planetId"`
+	RouteID          int64 `json:"routeId"`
+	SourcePinID      int64 `json:"sourcePinId"`
+	DestinationPinID int64 `json:"destinationPinId"`
+	ContentTypeID    int64 `json:"contentTypeId"`
+	Quantity         int64 `json:"quantity"`
+}
+
+type PiTaxConfig struct {
+	ID       int64   `json:"id"`
+	UserID   int64   `json:"userId"`
+	PlanetID *int64  `json:"planetId"`
+	TaxRate  float64 `json:"taxRate"`
+}
+
+type PiLaunchpadLabel struct {
+	UserID      int64  `json:"userId"`
+	CharacterID int64  `json:"characterId"`
+	PlanetID    int64  `json:"planetId"`
+	PinID       int64  `json:"pinId"`
+	Label       string `json:"label"`
+}

--- a/internal/repositories/character.go
+++ b/internal/repositories/character.go
@@ -28,6 +28,25 @@ func NewCharacterRepository(db *sql.DB) *CharacterRepository {
 	}
 }
 
+func (r *CharacterRepository) GetNames(ctx context.Context, userID int64) (map[int64]string, error) {
+	rows, err := r.db.QueryContext(ctx, `select id, name from characters where user_id = $1`, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query character names")
+	}
+	defer rows.Close()
+
+	names := map[int64]string{}
+	for rows.Next() {
+		var id int64
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			return nil, errors.Wrap(err, "failed to scan character name")
+		}
+		names[id] = name
+	}
+	return names, nil
+}
+
 func (r *CharacterRepository) GetAll(ctx context.Context, baseUserId int64) ([]*Character, error) {
 	rows, err := r.db.QueryContext(ctx, `
 select

--- a/internal/repositories/piLaunchpadLabels.go
+++ b/internal/repositories/piLaunchpadLabels.go
@@ -1,0 +1,83 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/pkg/errors"
+)
+
+type PiLaunchpadLabels struct {
+	db *sql.DB
+}
+
+func NewPiLaunchpadLabels(db *sql.DB) *PiLaunchpadLabels {
+	return &PiLaunchpadLabels{db: db}
+}
+
+func (r *PiLaunchpadLabels) GetForUser(ctx context.Context, userID int64) ([]*models.PiLaunchpadLabel, error) {
+	query := `
+		SELECT user_id, character_id, planet_id, pin_id, label
+		FROM pi_launchpad_labels
+		WHERE user_id = $1
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query pi launchpad labels")
+	}
+	defer rows.Close()
+
+	labels := []*models.PiLaunchpadLabel{}
+	for rows.Next() {
+		var label models.PiLaunchpadLabel
+		err = rows.Scan(
+			&label.UserID,
+			&label.CharacterID,
+			&label.PlanetID,
+			&label.PinID,
+			&label.Label,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan pi launchpad label")
+		}
+		labels = append(labels, &label)
+	}
+
+	return labels, nil
+}
+
+func (r *PiLaunchpadLabels) Upsert(ctx context.Context, label *models.PiLaunchpadLabel) error {
+	query := `
+		INSERT INTO pi_launchpad_labels (user_id, character_id, planet_id, pin_id, label)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (user_id, character_id, planet_id, pin_id)
+		DO UPDATE SET label = $5
+	`
+
+	_, err := r.db.ExecContext(ctx, query,
+		label.UserID,
+		label.CharacterID,
+		label.PlanetID,
+		label.PinID,
+		label.Label,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to upsert pi launchpad label")
+	}
+
+	return nil
+}
+
+func (r *PiLaunchpadLabels) Delete(ctx context.Context, userID, characterID, planetID, pinID int64) error {
+	_, err := r.db.ExecContext(ctx, `
+		DELETE FROM pi_launchpad_labels
+		WHERE user_id = $1 AND character_id = $2 AND planet_id = $3 AND pin_id = $4
+	`, userID, characterID, planetID, pinID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete pi launchpad label")
+	}
+
+	return nil
+}

--- a/internal/repositories/piPlanets.go
+++ b/internal/repositories/piPlanets.go
@@ -1,0 +1,398 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+type PiPlanets struct {
+	db *sql.DB
+}
+
+func NewPiPlanets(db *sql.DB) *PiPlanets {
+	return &PiPlanets{db: db}
+}
+
+func (r *PiPlanets) UpsertPlanets(ctx context.Context, characterID, userID int64, planets []*models.PiPlanet) error {
+	if len(planets) == 0 {
+		return nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction for pi planets upsert")
+	}
+	defer tx.Rollback()
+
+	// Delete planets that are no longer in the incoming list
+	incomingPlanetIDs := make([]int64, len(planets))
+	for i, p := range planets {
+		incomingPlanetIDs[i] = p.PlanetID
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		DELETE FROM pi_planets
+		WHERE character_id = $1
+		  AND planet_id != ALL($2::bigint[])
+	`, characterID, pq.Array(incomingPlanetIDs))
+	if err != nil {
+		return errors.Wrap(err, "failed to delete removed pi planets")
+	}
+
+	upsertQuery := `
+		INSERT INTO pi_planets
+			(character_id, user_id, planet_id, planet_type, solar_system_id,
+			 upgrade_level, num_pins, last_update, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+		ON CONFLICT (character_id, planet_id)
+		DO UPDATE SET
+			user_id = EXCLUDED.user_id,
+			planet_type = EXCLUDED.planet_type,
+			solar_system_id = EXCLUDED.solar_system_id,
+			upgrade_level = EXCLUDED.upgrade_level,
+			num_pins = EXCLUDED.num_pins,
+			last_update = EXCLUDED.last_update,
+			updated_at = now()
+	`
+
+	stmt, err := tx.PrepareContext(ctx, upsertQuery)
+	if err != nil {
+		return errors.Wrap(err, "failed to prepare pi planet upsert")
+	}
+
+	for _, planet := range planets {
+		_, err = stmt.ExecContext(ctx,
+			characterID,
+			userID,
+			planet.PlanetID,
+			planet.PlanetType,
+			planet.SolarSystemID,
+			planet.UpgradeLevel,
+			planet.NumPins,
+			planet.LastUpdate,
+		)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute pi planet upsert")
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return errors.Wrap(err, "failed to commit pi planets transaction")
+	}
+	return nil
+}
+
+func (r *PiPlanets) UpsertColony(ctx context.Context, characterID, planetID int64, pins []*models.PiPin, contents []*models.PiPinContent, routes []*models.PiRoute) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction for pi colony upsert")
+	}
+	defer tx.Rollback()
+
+	// Delete existing data for this colony (contents and routes first due to logical dependency)
+	_, err = tx.ExecContext(ctx, `DELETE FROM pi_pin_contents WHERE character_id = $1 AND planet_id = $2`, characterID, planetID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete existing pi pin contents")
+	}
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM pi_routes WHERE character_id = $1 AND planet_id = $2`, characterID, planetID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete existing pi routes")
+	}
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM pi_pins WHERE character_id = $1 AND planet_id = $2`, characterID, planetID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete existing pi pins")
+	}
+
+	// Insert new pins
+	if len(pins) > 0 {
+		pinQuery := `
+			INSERT INTO pi_pins
+				(character_id, planet_id, pin_id, type_id, schematic_id,
+				 latitude, longitude, install_time, expiry_time,
+				 last_cycle_start, extractor_cycle_time, extractor_head_radius,
+				 extractor_product_type_id, extractor_qty_per_cycle,
+				 extractor_num_heads, pin_category, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, now())
+		`
+
+		pinStmt, err := tx.PrepareContext(ctx, pinQuery)
+		if err != nil {
+			return errors.Wrap(err, "failed to prepare pi pin insert")
+		}
+
+		for _, pin := range pins {
+			_, err = pinStmt.ExecContext(ctx,
+				characterID,
+				planetID,
+				pin.PinID,
+				pin.TypeID,
+				pin.SchematicID,
+				pin.Latitude,
+				pin.Longitude,
+				pin.InstallTime,
+				pin.ExpiryTime,
+				pin.LastCycleStart,
+				pin.ExtractorCycleTime,
+				pin.ExtractorHeadRadius,
+				pin.ExtractorProductTypeID,
+				pin.ExtractorQtyPerCycle,
+				pin.ExtractorNumHeads,
+				pin.PinCategory,
+			)
+			if err != nil {
+				return errors.Wrap(err, "failed to execute pi pin insert")
+			}
+		}
+	}
+
+	// Insert new contents
+	if len(contents) > 0 {
+		contentQuery := `
+			INSERT INTO pi_pin_contents
+				(character_id, planet_id, pin_id, type_id, amount)
+			VALUES ($1, $2, $3, $4, $5)
+		`
+
+		contentStmt, err := tx.PrepareContext(ctx, contentQuery)
+		if err != nil {
+			return errors.Wrap(err, "failed to prepare pi pin content insert")
+		}
+
+		for _, content := range contents {
+			_, err = contentStmt.ExecContext(ctx,
+				characterID,
+				planetID,
+				content.PinID,
+				content.TypeID,
+				content.Amount,
+			)
+			if err != nil {
+				return errors.Wrap(err, "failed to execute pi pin content insert")
+			}
+		}
+	}
+
+	// Insert new routes
+	if len(routes) > 0 {
+		routeQuery := `
+			INSERT INTO pi_routes
+				(character_id, planet_id, route_id, source_pin_id,
+				 destination_pin_id, content_type_id, quantity)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+		`
+
+		routeStmt, err := tx.PrepareContext(ctx, routeQuery)
+		if err != nil {
+			return errors.Wrap(err, "failed to prepare pi route insert")
+		}
+
+		for _, route := range routes {
+			_, err = routeStmt.ExecContext(ctx,
+				characterID,
+				planetID,
+				route.RouteID,
+				route.SourcePinID,
+				route.DestinationPinID,
+				route.ContentTypeID,
+				route.Quantity,
+			)
+			if err != nil {
+				return errors.Wrap(err, "failed to execute pi route insert")
+			}
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return errors.Wrap(err, "failed to commit pi colony transaction")
+	}
+	return nil
+}
+
+func (r *PiPlanets) GetPlanetsForUser(ctx context.Context, userID int64) ([]*models.PiPlanet, error) {
+	query := `
+		SELECT id, character_id, user_id, planet_id, planet_type,
+		       solar_system_id, upgrade_level, num_pins, last_update,
+		       last_stall_notified_at
+		FROM pi_planets
+		WHERE user_id = $1
+		ORDER BY character_id, planet_id
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query pi planets")
+	}
+	defer rows.Close()
+
+	planets := []*models.PiPlanet{}
+	for rows.Next() {
+		var planet models.PiPlanet
+		err = rows.Scan(
+			&planet.ID,
+			&planet.CharacterID,
+			&planet.UserID,
+			&planet.PlanetID,
+			&planet.PlanetType,
+			&planet.SolarSystemID,
+			&planet.UpgradeLevel,
+			&planet.NumPins,
+			&planet.LastUpdate,
+			&planet.LastStallNotifiedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan pi planet")
+		}
+		planets = append(planets, &planet)
+	}
+
+	return planets, nil
+}
+
+func (r *PiPlanets) GetPinsForPlanets(ctx context.Context, userID int64) ([]*models.PiPin, error) {
+	query := `
+		SELECT pi_pins.id, pi_pins.character_id, pi_pins.planet_id, pi_pins.pin_id,
+		       pi_pins.type_id, pi_pins.schematic_id, pi_pins.latitude, pi_pins.longitude,
+		       pi_pins.install_time, pi_pins.expiry_time, pi_pins.last_cycle_start,
+		       pi_pins.extractor_cycle_time, pi_pins.extractor_head_radius,
+		       pi_pins.extractor_product_type_id, pi_pins.extractor_qty_per_cycle,
+		       pi_pins.extractor_num_heads, pi_pins.pin_category
+		FROM pi_pins
+		INNER JOIN pi_planets
+			ON pi_pins.character_id = pi_planets.character_id
+			AND pi_pins.planet_id = pi_planets.planet_id
+		WHERE pi_planets.user_id = $1
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query pi pins")
+	}
+	defer rows.Close()
+
+	pins := []*models.PiPin{}
+	for rows.Next() {
+		var pin models.PiPin
+		err = rows.Scan(
+			&pin.ID,
+			&pin.CharacterID,
+			&pin.PlanetID,
+			&pin.PinID,
+			&pin.TypeID,
+			&pin.SchematicID,
+			&pin.Latitude,
+			&pin.Longitude,
+			&pin.InstallTime,
+			&pin.ExpiryTime,
+			&pin.LastCycleStart,
+			&pin.ExtractorCycleTime,
+			&pin.ExtractorHeadRadius,
+			&pin.ExtractorProductTypeID,
+			&pin.ExtractorQtyPerCycle,
+			&pin.ExtractorNumHeads,
+			&pin.PinCategory,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan pi pin")
+		}
+		pins = append(pins, &pin)
+	}
+
+	return pins, nil
+}
+
+func (r *PiPlanets) GetPinContentsForUser(ctx context.Context, userID int64) ([]*models.PiPinContent, error) {
+	query := `
+		SELECT pi_pin_contents.character_id, pi_pin_contents.planet_id,
+		       pi_pin_contents.pin_id, pi_pin_contents.type_id,
+		       pi_pin_contents.amount
+		FROM pi_pin_contents
+		INNER JOIN pi_planets
+			ON pi_pin_contents.character_id = pi_planets.character_id
+			AND pi_pin_contents.planet_id = pi_planets.planet_id
+		WHERE pi_planets.user_id = $1
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query pi pin contents")
+	}
+	defer rows.Close()
+
+	contents := []*models.PiPinContent{}
+	for rows.Next() {
+		var content models.PiPinContent
+		err = rows.Scan(
+			&content.CharacterID,
+			&content.PlanetID,
+			&content.PinID,
+			&content.TypeID,
+			&content.Amount,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan pi pin content")
+		}
+		contents = append(contents, &content)
+	}
+
+	return contents, nil
+}
+
+func (r *PiPlanets) GetRoutesForUser(ctx context.Context, userID int64) ([]*models.PiRoute, error) {
+	query := `
+		SELECT pi_routes.character_id, pi_routes.planet_id, pi_routes.route_id,
+		       pi_routes.source_pin_id, pi_routes.destination_pin_id,
+		       pi_routes.content_type_id, pi_routes.quantity
+		FROM pi_routes
+		INNER JOIN pi_planets
+			ON pi_routes.character_id = pi_planets.character_id
+			AND pi_routes.planet_id = pi_planets.planet_id
+		WHERE pi_planets.user_id = $1
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query pi routes")
+	}
+	defer rows.Close()
+
+	routes := []*models.PiRoute{}
+	for rows.Next() {
+		var route models.PiRoute
+		err = rows.Scan(
+			&route.CharacterID,
+			&route.PlanetID,
+			&route.RouteID,
+			&route.SourcePinID,
+			&route.DestinationPinID,
+			&route.ContentTypeID,
+			&route.Quantity,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan pi route")
+		}
+		routes = append(routes, &route)
+	}
+
+	return routes, nil
+}
+
+func (r *PiPlanets) UpdateStallNotifiedAt(ctx context.Context, characterID, planetID int64, notifiedAt *time.Time) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE pi_planets
+		SET last_stall_notified_at = $3
+		WHERE character_id = $1 AND planet_id = $2
+	`, characterID, planetID, notifiedAt)
+	if err != nil {
+		return errors.Wrap(err, "failed to update pi planet stall notification time")
+	}
+	return nil
+}

--- a/internal/repositories/piTaxConfig.go
+++ b/internal/repositories/piTaxConfig.go
@@ -1,0 +1,91 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/pkg/errors"
+)
+
+type PiTaxConfig struct {
+	db *sql.DB
+}
+
+func NewPiTaxConfig(db *sql.DB) *PiTaxConfig {
+	return &PiTaxConfig{db: db}
+}
+
+func (r *PiTaxConfig) GetForUser(ctx context.Context, userID int64) ([]*models.PiTaxConfig, error) {
+	query := `
+		SELECT id, user_id, planet_id, tax_rate
+		FROM pi_tax_config
+		WHERE user_id = $1
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query pi tax configs")
+	}
+	defer rows.Close()
+
+	configs := []*models.PiTaxConfig{}
+	for rows.Next() {
+		var config models.PiTaxConfig
+		err = rows.Scan(
+			&config.ID,
+			&config.UserID,
+			&config.PlanetID,
+			&config.TaxRate,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan pi tax config")
+		}
+		configs = append(configs, &config)
+	}
+
+	return configs, nil
+}
+
+func (r *PiTaxConfig) Upsert(ctx context.Context, config *models.PiTaxConfig) error {
+	query := `
+		INSERT INTO pi_tax_config (user_id, planet_id, tax_rate)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (user_id, planet_id)
+		DO UPDATE SET tax_rate = $3
+	`
+
+	_, err := r.db.ExecContext(ctx, query,
+		config.UserID,
+		config.PlanetID,
+		config.TaxRate,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to upsert pi tax config")
+	}
+
+	return nil
+}
+
+func (r *PiTaxConfig) Delete(ctx context.Context, userID int64, planetID *int64) error {
+	if planetID == nil {
+		_, err := r.db.ExecContext(ctx, `
+			DELETE FROM pi_tax_config
+			WHERE user_id = $1 AND planet_id IS NULL
+		`, userID)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete global pi tax config")
+		}
+		return nil
+	}
+
+	_, err := r.db.ExecContext(ctx, `
+		DELETE FROM pi_tax_config
+		WHERE user_id = $1 AND planet_id = $2
+	`, userID, *planetID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete pi tax config")
+	}
+
+	return nil
+}

--- a/internal/repositories/sdeData.go
+++ b/internal/repositories/sdeData.go
@@ -736,6 +736,42 @@ func bulkUpsertTx[T any](ctx context.Context, tx *sql.Tx, query string, items []
 }
 
 // GetMetadataLastUpdateTime returns the last update time for SDE metadata
+func (r *SdeDataRepository) GetAllSchematics(ctx context.Context) ([]*models.SdePlanetSchematic, error) {
+	rows, err := r.db.QueryContext(ctx, `select schematic_id, name, cycle_time from sde_planet_schematics`)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query planet schematics")
+	}
+	defer rows.Close()
+
+	schematics := []*models.SdePlanetSchematic{}
+	for rows.Next() {
+		var s models.SdePlanetSchematic
+		if err := rows.Scan(&s.SchematicID, &s.Name, &s.CycleTime); err != nil {
+			return nil, errors.Wrap(err, "failed to scan planet schematic")
+		}
+		schematics = append(schematics, &s)
+	}
+	return schematics, nil
+}
+
+func (r *SdeDataRepository) GetAllSchematicTypes(ctx context.Context) ([]*models.SdePlanetSchematicType, error) {
+	rows, err := r.db.QueryContext(ctx, `select schematic_id, type_id, quantity, is_input from sde_planet_schematic_types`)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query planet schematic types")
+	}
+	defer rows.Close()
+
+	types := []*models.SdePlanetSchematicType{}
+	for rows.Next() {
+		var t models.SdePlanetSchematicType
+		if err := rows.Scan(&t.SchematicID, &t.TypeID, &t.Quantity, &t.IsInput); err != nil {
+			return nil, errors.Wrap(err, "failed to scan planet schematic type")
+		}
+		types = append(types, &t)
+	}
+	return types, nil
+}
+
 func (r *SdeDataRepository) GetMetadataLastUpdateTime(ctx context.Context) (*time.Time, error) {
 	query := `SELECT MAX(updated_at) FROM sde_metadata`
 

--- a/internal/runners/pi.go
+++ b/internal/runners/pi.go
@@ -1,0 +1,61 @@
+package runners
+
+import (
+	"context"
+	"time"
+
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+)
+
+type PiUpdater interface {
+	UpdateAllUsers(ctx context.Context) error
+}
+
+type PiRunner struct {
+	updater       PiUpdater
+	interval      time.Duration
+	tickerFactory TickerFactory
+}
+
+func NewPiRunner(updater PiUpdater, interval time.Duration) *PiRunner {
+	return &PiRunner{
+		updater:  updater,
+		interval: interval,
+		tickerFactory: func(d time.Duration) Ticker {
+			return &realTicker{time.NewTicker(d)}
+		},
+	}
+}
+
+// WithTickerFactory allows injecting a custom ticker factory for testing
+func (r *PiRunner) WithTickerFactory(factory TickerFactory) *PiRunner {
+	r.tickerFactory = factory
+	return r
+}
+
+func (r *PiRunner) Run(ctx context.Context) error {
+	ticker := r.tickerFactory(r.interval)
+	defer ticker.Stop()
+
+	// Update immediately on startup
+	log.Info("updating PI planets on startup")
+	if err := r.updater.UpdateAllUsers(ctx); err != nil {
+		log.Error("failed to update PI planets on startup", "error", err)
+	} else {
+		log.Info("PI planets updated successfully")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C():
+			log.Info("updating PI planets (scheduled)")
+			if err := r.updater.UpdateAllUsers(ctx); err != nil {
+				log.Error("failed to update PI planets", "error", err)
+			} else {
+				log.Info("PI planets updated successfully")
+			}
+		}
+	}
+}

--- a/internal/updaters/pi.go
+++ b/internal/updaters/pi.go
@@ -1,0 +1,443 @@
+package updaters
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/client"
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+
+	"github.com/pkg/errors"
+)
+
+type PiPlanetsRepository interface {
+	UpsertPlanets(ctx context.Context, characterID, userID int64, planets []*models.PiPlanet) error
+	UpsertColony(ctx context.Context, characterID, planetID int64, pins []*models.PiPin, contents []*models.PiPinContent, routes []*models.PiRoute) error
+	GetPlanetsForUser(ctx context.Context, userID int64) ([]*models.PiPlanet, error)
+	GetPinsForPlanets(ctx context.Context, userID int64) ([]*models.PiPin, error)
+	UpdateStallNotifiedAt(ctx context.Context, characterID, planetID int64, notifiedAt *time.Time) error
+}
+
+type PiEsiClient interface {
+	GetCharacterPlanets(ctx context.Context, characterID int64, token string) ([]*client.EsiPiPlanet, error)
+	GetCharacterPlanetDetails(ctx context.Context, characterID, planetID int64, token string) (*client.EsiPiColony, error)
+	RefreshAccessToken(ctx context.Context, refreshToken string) (*client.RefreshedToken, error)
+}
+
+type PiUserRepository interface {
+	GetAllIDs(ctx context.Context) ([]int64, error)
+}
+
+type PiCharacterRepository interface {
+	GetAll(ctx context.Context, baseUserID int64) ([]*repositories.Character, error)
+	UpdateTokens(ctx context.Context, id, userID int64, token, refreshToken string, expiresOn time.Time) error
+}
+
+type PiSolarSystemRepository interface {
+	GetNames(ctx context.Context, ids []int64) (map[int64]string, error)
+}
+
+type PiSchematicRepository interface {
+	GetAllSchematics(ctx context.Context) ([]*models.SdePlanetSchematic, error)
+}
+
+type PiUpdater struct {
+	userRepo      PiUserRepository
+	characterRepo PiCharacterRepository
+	piRepo        PiPlanetsRepository
+	esiClient     PiEsiClient
+	systemRepo    PiSolarSystemRepository
+	schematicRepo PiSchematicRepository
+	notifier      PiStallNotifier
+}
+
+func NewPiUpdater(
+	userRepo PiUserRepository,
+	characterRepo PiCharacterRepository,
+	piRepo PiPlanetsRepository,
+	esiClient PiEsiClient,
+	systemRepo PiSolarSystemRepository,
+	schematicRepo PiSchematicRepository,
+) *PiUpdater {
+	return &PiUpdater{
+		userRepo:      userRepo,
+		characterRepo: characterRepo,
+		piRepo:        piRepo,
+		esiClient:     esiClient,
+		systemRepo:    systemRepo,
+		schematicRepo: schematicRepo,
+	}
+}
+
+// WithStallNotifier sets an optional notifier for PI stall alerts.
+func (u *PiUpdater) WithStallNotifier(notifier PiStallNotifier) {
+	u.notifier = notifier
+}
+
+// UpdateAllUsers refreshes PI data for every user in the system.
+func (u *PiUpdater) UpdateAllUsers(ctx context.Context) error {
+	userIDs, err := u.userRepo.GetAllIDs(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get user IDs for PI update")
+	}
+
+	for _, userID := range userIDs {
+		if err := u.UpdateUserPlanets(ctx, userID); err != nil {
+			log.Error("failed to update PI planets for user", "userID", userID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// UpdateUserPlanets refreshes PI data for all characters belonging to a user.
+func (u *PiUpdater) UpdateUserPlanets(ctx context.Context, userID int64) error {
+	characters, err := u.characterRepo.GetAll(ctx, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get user characters for PI update")
+	}
+
+	charNamesByID := map[int64]string{}
+	for _, char := range characters {
+		charNamesByID[char.ID] = char.Name
+
+		if !strings.Contains(char.EsiScopes, "esi-planets.manage_planets.v1") {
+			continue
+		}
+
+		if err := u.updateCharacterPlanets(ctx, char, userID); err != nil {
+			log.Error("failed to update PI for character", "characterID", char.ID, "error", err)
+		}
+	}
+
+	// Check for stalls after all data is updated
+	if u.notifier != nil {
+		u.checkStalls(ctx, userID, charNamesByID)
+	}
+
+	return nil
+}
+
+func (u *PiUpdater) updateCharacterPlanets(ctx context.Context, char *repositories.Character, userID int64) error {
+	token, refresh, expire := char.EsiToken, char.EsiRefreshToken, char.EsiTokenExpiresOn
+
+	if time.Now().After(expire) {
+		refreshed, err := u.esiClient.RefreshAccessToken(ctx, refresh)
+		if err != nil {
+			return errors.Wrapf(err, "failed to refresh token for character %d", char.ID)
+		}
+		token = refreshed.AccessToken
+		refresh = refreshed.RefreshToken
+		expire = refreshed.Expiry
+
+		err = u.characterRepo.UpdateTokens(ctx, char.ID, char.UserID, token, refresh, expire)
+		if err != nil {
+			return errors.Wrapf(err, "failed to persist refreshed token for character %d", char.ID)
+		}
+		log.Info("refreshed ESI token for character (PI)", "characterID", char.ID)
+	}
+
+	esiPlanets, err := u.esiClient.GetCharacterPlanets(ctx, char.ID, token)
+	if err != nil {
+		return errors.Wrap(err, "failed to get character planets from ESI")
+	}
+
+	planets := []*models.PiPlanet{}
+	for _, ep := range esiPlanets {
+		lastUpdate, err := time.Parse(time.RFC3339, ep.LastUpdate)
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse last_update for planet %d", ep.PlanetID)
+		}
+
+		planets = append(planets, &models.PiPlanet{
+			CharacterID:   char.ID,
+			UserID:        userID,
+			PlanetID:      ep.PlanetID,
+			PlanetType:    ep.PlanetType,
+			SolarSystemID: ep.SolarSystemID,
+			UpgradeLevel:  ep.UpgradeLevel,
+			NumPins:       ep.NumPins,
+			LastUpdate:    lastUpdate,
+		})
+	}
+
+	err = u.piRepo.UpsertPlanets(ctx, char.ID, userID, planets)
+	if err != nil {
+		return errors.Wrap(err, "failed to upsert PI planets")
+	}
+
+	for _, ep := range esiPlanets {
+		colony, err := u.esiClient.GetCharacterPlanetDetails(ctx, char.ID, ep.PlanetID, token)
+		if err != nil {
+			log.Error("failed to get planet details from ESI", "characterID", char.ID, "planetID", ep.PlanetID, "error", err)
+			continue
+		}
+
+		pins, contents := convertColonyPins(char.ID, ep.PlanetID, colony)
+		routes := convertColonyRoutes(char.ID, ep.PlanetID, colony)
+
+		err = u.piRepo.UpsertColony(ctx, char.ID, ep.PlanetID, pins, contents, routes)
+		if err != nil {
+			log.Error("failed to upsert colony data", "characterID", char.ID, "planetID", ep.PlanetID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// classifyPin determines the category of a PI pin based on its ESI data.
+// Extractors and factories are identified by their detail fields; other types
+// are classified by well-known type_id sets from the EVE SDE.
+func classifyPin(pin *client.EsiPiPin) string {
+	if pin.ExtractorDetails != nil {
+		return "extractor"
+	}
+	if pin.FactoryDetails != nil {
+		return "factory"
+	}
+	// Factories may lack factory_details but still have a top-level schematic_id
+	if pin.SchematicID != nil {
+		return "factory"
+	}
+	switch pin.TypeID {
+	case 2256, 2542, 2543, 2544:
+		return "launchpad"
+	case 2257, 2535, 2536, 2541:
+		return "storage"
+	case 2524, 2525, 2526, 2527, 2528, 2529, 2530, 2531:
+		return "command_center"
+	case 2473, 2480, 2481:
+		return "factory"
+	default:
+		return "unknown"
+	}
+}
+
+func convertColonyPins(characterID, planetID int64, colony *client.EsiPiColony) ([]*models.PiPin, []*models.PiPinContent) {
+	pins := []*models.PiPin{}
+	contents := []*models.PiPinContent{}
+
+	for i := range colony.Pins {
+		esiPin := &colony.Pins[i]
+
+		pin := &models.PiPin{
+			CharacterID: characterID,
+			PlanetID:    planetID,
+			PinID:       esiPin.PinID,
+			TypeID:      esiPin.TypeID,
+			Latitude:    &esiPin.Latitude,
+			Longitude:   &esiPin.Longitude,
+			PinCategory: classifyPin(esiPin),
+		}
+
+		if esiPin.InstallTime != nil {
+			t, err := time.Parse(time.RFC3339, *esiPin.InstallTime)
+			if err == nil {
+				pin.InstallTime = &t
+			}
+		}
+		if esiPin.ExpiryTime != nil {
+			t, err := time.Parse(time.RFC3339, *esiPin.ExpiryTime)
+			if err == nil {
+				pin.ExpiryTime = &t
+			}
+		}
+		if esiPin.LastCycleStart != nil {
+			t, err := time.Parse(time.RFC3339, *esiPin.LastCycleStart)
+			if err == nil {
+				pin.LastCycleStart = &t
+			}
+		}
+
+		if esiPin.SchematicID != nil {
+			s := *esiPin.SchematicID
+			pin.SchematicID = &s
+		}
+		if esiPin.FactoryDetails != nil {
+			s := esiPin.FactoryDetails.SchematicID
+			pin.SchematicID = &s
+		}
+
+		if esiPin.ExtractorDetails != nil {
+			cycleTime := esiPin.ExtractorDetails.CycleTime
+			pin.ExtractorCycleTime = &cycleTime
+
+			headRadius := esiPin.ExtractorDetails.HeadRadius
+			pin.ExtractorHeadRadius = &headRadius
+
+			productTypeID := esiPin.ExtractorDetails.ProductTypeID
+			pin.ExtractorProductTypeID = &productTypeID
+
+			qtyPerCycle := esiPin.ExtractorDetails.QtyPerCycle
+			pin.ExtractorQtyPerCycle = &qtyPerCycle
+
+			numHeads := len(esiPin.ExtractorDetails.Heads)
+			pin.ExtractorNumHeads = &numHeads
+		}
+
+		pins = append(pins, pin)
+
+		for _, c := range esiPin.Contents {
+			contents = append(contents, &models.PiPinContent{
+				CharacterID: characterID,
+				PlanetID:    planetID,
+				PinID:       esiPin.PinID,
+				TypeID:      c.TypeID,
+				Amount:      int64(c.Amount),
+			})
+		}
+	}
+
+	return pins, contents
+}
+
+func convertColonyRoutes(characterID, planetID int64, colony *client.EsiPiColony) []*models.PiRoute {
+	routes := []*models.PiRoute{}
+
+	for _, r := range colony.Routes {
+		routes = append(routes, &models.PiRoute{
+			CharacterID:      characterID,
+			PlanetID:         planetID,
+			RouteID:          r.RouteID,
+			SourcePinID:      r.SourcePinID,
+			DestinationPinID: r.DestinationPinID,
+			ContentTypeID:    r.ContentTypeID,
+			Quantity:         int64(r.Quantity),
+		})
+	}
+
+	return routes
+}
+
+// Stall detection thresholds (same as controller)
+const (
+	piStaleDataThreshold  = 48 * time.Hour
+	piFactoryIdleMultiple = 2
+)
+
+// checkStalls detects newly stalled planets and sends notifications.
+// Only notifies on state transitions (running → stalled), not repeatedly.
+func (u *PiUpdater) checkStalls(ctx context.Context, userID int64, charNames map[int64]string) {
+	planets, err := u.piRepo.GetPlanetsForUser(ctx, userID)
+	if err != nil {
+		log.Error("failed to get planets for stall check", "userID", userID, "error", err)
+		return
+	}
+
+	if len(planets) == 0 {
+		return
+	}
+
+	pins, err := u.piRepo.GetPinsForPlanets(ctx, userID)
+	if err != nil {
+		log.Error("failed to get pins for stall check", "userID", userID, "error", err)
+		return
+	}
+
+	schematics, err := u.schematicRepo.GetAllSchematics(ctx)
+	if err != nil {
+		log.Error("failed to get schematics for stall check", "userID", userID, "error", err)
+		return
+	}
+	schematicMap := map[int]*models.SdePlanetSchematic{}
+	for _, s := range schematics {
+		schematicMap[int(s.SchematicID)] = s
+	}
+
+	// Group pins by planet
+	type planetKey struct {
+		characterID int64
+		planetID    int64
+	}
+	pinsByPlanet := map[planetKey][]*models.PiPin{}
+	for _, pin := range pins {
+		k := planetKey{pin.CharacterID, pin.PlanetID}
+		pinsByPlanet[k] = append(pinsByPlanet[k], pin)
+	}
+
+	// Collect solar system IDs for name resolution
+	systemIDs := []int64{}
+	for _, p := range planets {
+		systemIDs = append(systemIDs, p.SolarSystemID)
+	}
+	systemNames, err := u.systemRepo.GetNames(ctx, systemIDs)
+	if err != nil {
+		log.Error("failed to get system names for stall check", "userID", userID, "error", err)
+		systemNames = map[int64]string{}
+	}
+
+	now := time.Now()
+
+	// Collect all new stall alerts, then send as one notification
+	var newAlerts []*PiStallAlert
+	type stalledPlanet struct {
+		characterID int64
+		planetID    int64
+	}
+	var newlyStalled []stalledPlanet
+
+	for _, planet := range planets {
+		k := planetKey{planet.CharacterID, planet.PlanetID}
+		planetPins := pinsByPlanet[k]
+
+		stalledPins := []PiStalledPin{}
+
+		for _, pin := range planetPins {
+			switch pin.PinCategory {
+			case "extractor":
+				if pin.ExpiryTime != nil && pin.ExpiryTime.Before(now) {
+					stalledPins = append(stalledPins, PiStalledPin{
+						PinCategory: "extractor",
+						Reason:      "expired",
+					})
+				}
+			case "factory":
+				if pin.SchematicID != nil && pin.LastCycleStart != nil {
+					schematic := schematicMap[*pin.SchematicID]
+					if schematic != nil && schematic.CycleTime > 0 {
+						expectedNext := pin.LastCycleStart.Add(time.Duration(schematic.CycleTime*piFactoryIdleMultiple) * time.Second)
+						if now.After(expectedNext) {
+							stalledPins = append(stalledPins, PiStalledPin{
+								PinCategory: "factory",
+								Reason:      "stalled",
+							})
+						}
+					}
+				}
+			}
+		}
+
+		isStalled := len(stalledPins) > 0
+		wasNotified := planet.LastStallNotifiedAt != nil
+
+		if isStalled && !wasNotified {
+			newAlerts = append(newAlerts, &PiStallAlert{
+				CharacterName:   charNames[planet.CharacterID],
+				PlanetType:      planet.PlanetType,
+				SolarSystemName: systemNames[planet.SolarSystemID],
+				StalledPins:     stalledPins,
+			})
+			newlyStalled = append(newlyStalled, stalledPlanet{planet.CharacterID, planet.PlanetID})
+		} else if !isStalled && wasNotified {
+			// Planet recovered — clear the notification timestamp
+			if err := u.piRepo.UpdateStallNotifiedAt(ctx, planet.CharacterID, planet.PlanetID, nil); err != nil {
+				log.Error("failed to clear stall notified timestamp", "characterID", planet.CharacterID, "planetID", planet.PlanetID, "error", err)
+			}
+		}
+	}
+
+	// Send one batched notification for all newly stalled planets
+	if len(newAlerts) > 0 {
+		u.notifier.NotifyPiStalls(ctx, userID, newAlerts)
+
+		notifiedAt := now
+		for _, sp := range newlyStalled {
+			if err := u.piRepo.UpdateStallNotifiedAt(ctx, sp.characterID, sp.planetID, &notifiedAt); err != nil {
+				log.Error("failed to update stall notified timestamp", "characterID", sp.characterID, "planetID", sp.planetID, "error", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **Phase 1**: ESI data fetch, pin classification, dedicated PI background runner, planet overview with stall detection and production rates
- **Phase 2**: Per-factory profit calculation with POCO tax integration and Jita buy/sell/split pricing
- **Phase 3**: Launchpad labels with connected factory input tracking and depletion times
- **Phase 4**: Discord stall alerts with state transition dedup (`pi_stall` event type)
- **Phase 5**: Cross-character supply chain analysis with stockpile integration and bulk resize controls

## Test plan
- [ ] Verify PI data fetches from ESI for characters with `esi-planets.manage_planets.v1` scope
- [ ] Check planet overview cards show correct stall indicators and production rates
- [ ] Verify profit tab calculates correctly with tax config
- [ ] Test launchpad detail drawer shows connected factory inputs and depletion
- [ ] Confirm Discord stall alerts fire on state transition (running → stalled) and don't repeat
- [ ] Verify supply chain table aggregates production/consumption across characters
- [ ] Test stockpile resize (per-item and bulk "Set all stockpiles") updates markers correctly
- [ ] Confirm existing E2E tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)