### PR TITLE
Add auto-complete purchases via ESI contract sync

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -191,6 +191,13 @@ var rootCmd = &cobra.Command{
 			return piRunner.Run(ctx)
 		})
 
+		// Start contract sync scheduler (15 minutes)
+		contractSyncUpdater := updaters.NewContractSync(purchaseTransactionsRepository, charactersRepository, esiClient)
+		contractSyncRunner := runners.NewContractSyncRunner(contractSyncUpdater, 15*time.Minute)
+		group.Go(func() error {
+			return contractSyncRunner.Run(ctx)
+		})
+
 		log.Info("services started")
 
 		eventChan := make(chan os.Signal, 1)

--- a/docs/features/contract-sync.md
+++ b/docs/features/contract-sync.md
@@ -1,0 +1,45 @@
+# Auto-Complete Purchases via ESI Contract Sync
+
+## Overview
+
+Automatically detects when an EVE Online contract has been accepted by scanning buyer characters' contracts via ESI. Matches contracts to purchases using the `contract_key` in the contract title, then auto-completes the purchase.
+
+The manual "Complete" button remains available as a fallback.
+
+## Status
+
+- **Phase**: Implementation
+- **Branch**: `feature/contract-sync`
+
+## How It Works
+
+1. Seller marks purchase as "contract created" → app auto-generates a `contract_key` (e.g., `PT-123`)
+2. Seller copies the key into the EVE in-game contract title when creating the contract
+3. Background runner (every 15 minutes) scans buyer characters' ESI contracts
+4. Finds `finished` item_exchange contracts whose title contains a known `contract_key`
+5. Auto-completes all purchases sharing that key
+
+## Key Decisions
+
+- **Matching via title**: Uses the contract title field from ESI to match against `contract_key`. No need for the contract items sub-endpoint.
+- **Auto-generated keys**: Format `PT-{purchaseID}`. Custom keys still supported for grouping multiple purchases.
+- **Manual fallback**: Buyers can still click "Complete" manually if the seller forgot to include the key.
+- **Scope check**: Only processes characters with `esi-contracts.read_character_contracts.v1` scope.
+- **15-minute interval**: Balances responsiveness with ESI rate limits.
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `internal/client/esiClient.go` | `GetCharacterContracts` + `EsiContract` type |
+| `internal/controllers/purchases.go` | Auto-generate `contract_key` in `MarkContractCreated` |
+| `internal/repositories/purchaseTransactions.go` | `GetContractCreatedWithKeys`, `CompleteWithContractID` |
+| `internal/updaters/contractSync.go` | Matching logic + auto-completion |
+| `internal/updaters/contractSync_test.go` | Unit tests |
+| `internal/runners/contractSync.go` | Background runner |
+| `cmd/industry-tool/cmd/root.go` | Wiring |
+
+## ESI Endpoints Used
+
+- `GET /v1/characters/{character_id}/contracts/` — paginated contract list
+- Scope: `esi-contracts.read_character_contracts.v1` (already in player scopes)

--- a/internal/runners/contractSync.go
+++ b/internal/runners/contractSync.go
@@ -1,0 +1,57 @@
+package runners
+
+import (
+	"context"
+	"time"
+
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+)
+
+type ContractSyncUpdater interface {
+	SyncAll(ctx context.Context) error
+}
+
+type ContractSyncRunner struct {
+	updater       ContractSyncUpdater
+	interval      time.Duration
+	tickerFactory TickerFactory
+}
+
+func NewContractSyncRunner(updater ContractSyncUpdater, interval time.Duration) *ContractSyncRunner {
+	return &ContractSyncRunner{
+		updater:  updater,
+		interval: interval,
+		tickerFactory: func(d time.Duration) Ticker {
+			return &realTicker{time.NewTicker(d)}
+		},
+	}
+}
+
+// WithTickerFactory allows injecting a custom ticker factory for testing
+func (r *ContractSyncRunner) WithTickerFactory(factory TickerFactory) *ContractSyncRunner {
+	r.tickerFactory = factory
+	return r
+}
+
+func (r *ContractSyncRunner) Run(ctx context.Context) error {
+	ticker := r.tickerFactory(r.interval)
+	defer ticker.Stop()
+
+	// Run immediately on startup
+	log.Info("contract sync: running on startup")
+	if err := r.updater.SyncAll(ctx); err != nil {
+		log.Error("contract sync: failed on startup", "error", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C():
+			log.Info("contract sync: running (scheduled)")
+			if err := r.updater.SyncAll(ctx); err != nil {
+				log.Error("contract sync: failed", "error", err)
+			}
+		}
+	}
+}

--- a/internal/runners/contractSync_test.go
+++ b/internal/runners/contractSync_test.go
@@ -1,0 +1,166 @@
+package runners_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/runners"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockContractSyncUpdater mocks the ContractSyncUpdater interface
+type MockContractSyncUpdater struct {
+	mock.Mock
+}
+
+func (m *MockContractSyncUpdater) SyncAll(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func Test_ContractSyncRunner_SyncsOnStartup(t *testing.T) {
+	mockUpdater := new(MockContractSyncUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewContractSyncRunner(mockUpdater, 15*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	mockUpdater.On("SyncAll", mock.Anything).Return(nil).Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runner.Run(ctx)
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t)
+}
+
+func Test_ContractSyncRunner_SyncsOnStartupError(t *testing.T) {
+	mockUpdater := new(MockContractSyncUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewContractSyncRunner(mockUpdater, 15*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	mockUpdater.On("SyncAll", mock.Anything).Return(errors.New("startup error")).Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runner.Run(ctx)
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t)
+}
+
+func Test_ContractSyncRunner_SyncsPeriodically(t *testing.T) {
+	mockUpdater := new(MockContractSyncUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewContractSyncRunner(mockUpdater, 15*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	// Expect 3 calls: 1 on startup + 2 scheduled
+	mockUpdater.On("SyncAll", mock.Anything).Return(nil).Times(3)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	mockTicker.Tick()
+	time.Sleep(10 * time.Millisecond)
+	mockTicker.Tick()
+	time.Sleep(10 * time.Millisecond)
+
+	cancel()
+	err := <-done
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t)
+}
+
+func Test_ContractSyncRunner_ContinuesOnScheduledError(t *testing.T) {
+	mockUpdater := new(MockContractSyncUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewContractSyncRunner(mockUpdater, 15*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	mockUpdater.On("SyncAll", mock.Anything).Return(nil).Once()
+	mockUpdater.On("SyncAll", mock.Anything).Return(errors.New("sync error")).Times(2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	mockTicker.Tick()
+	time.Sleep(10 * time.Millisecond)
+	mockTicker.Tick()
+	time.Sleep(10 * time.Millisecond)
+
+	cancel()
+	err := <-done
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t)
+}
+
+func Test_ContractSyncRunner_StopsOnContextCancellation(t *testing.T) {
+	mockUpdater := new(MockContractSyncUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewContractSyncRunner(mockUpdater, 15*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	mockUpdater.On("SyncAll", mock.Anything).Return(nil).Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	err := <-done
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t)
+}
+
+func Test_ContractSyncRunner_Constructor(t *testing.T) {
+	mockUpdater := new(MockContractSyncUpdater)
+	interval := 15 * time.Minute
+
+	runner := runners.NewContractSyncRunner(mockUpdater, interval)
+
+	assert.NotNil(t, runner)
+}

--- a/internal/updaters/contractSync.go
+++ b/internal/updaters/contractSync.go
@@ -1,0 +1,163 @@
+package updaters
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/client"
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+
+	"github.com/pkg/errors"
+)
+
+type ContractSyncPurchaseRepository interface {
+	GetContractCreatedWithKeys(ctx context.Context) ([]*models.PurchaseTransaction, error)
+	CompleteWithContractID(ctx context.Context, purchaseID int64, eveContractID int64) error
+}
+
+type ContractSyncCharacterRepository interface {
+	GetAll(ctx context.Context, baseUserID int64) ([]*repositories.Character, error)
+	UpdateTokens(ctx context.Context, id, userID int64, token, refreshToken string, expiresOn time.Time) error
+}
+
+type ContractSyncEsiClient interface {
+	GetCharacterContracts(ctx context.Context, characterID int64, token, refresh string, expire time.Time) ([]*client.EsiContract, error)
+	RefreshAccessToken(ctx context.Context, refreshToken string) (*client.RefreshedToken, error)
+}
+
+type ContractSync struct {
+	purchaseRepo  ContractSyncPurchaseRepository
+	characterRepo ContractSyncCharacterRepository
+	esiClient     ContractSyncEsiClient
+}
+
+func NewContractSync(
+	purchaseRepo ContractSyncPurchaseRepository,
+	characterRepo ContractSyncCharacterRepository,
+	esiClient ContractSyncEsiClient,
+) *ContractSync {
+	return &ContractSync{
+		purchaseRepo:  purchaseRepo,
+		characterRepo: characterRepo,
+		esiClient:     esiClient,
+	}
+}
+
+// SyncAll checks ESI contracts for all buyers with contract_created purchases and auto-completes matches.
+func (u *ContractSync) SyncAll(ctx context.Context) error {
+	purchases, err := u.purchaseRepo.GetContractCreatedWithKeys(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get contract_created purchases")
+	}
+
+	if len(purchases) == 0 {
+		return nil
+	}
+
+	// Group purchases by buyer_user_id and build contract_key lookup
+	buyerPurchases := make(map[int64][]*models.PurchaseTransaction)
+	keyToPurchases := make(map[string][]*models.PurchaseTransaction)
+	for _, p := range purchases {
+		buyerPurchases[p.BuyerUserID] = append(buyerPurchases[p.BuyerUserID], p)
+		if p.ContractKey != nil {
+			keyToPurchases[*p.ContractKey] = append(keyToPurchases[*p.ContractKey], p)
+		}
+	}
+
+	// Collect all known contract keys for matching
+	allKeys := make([]string, 0, len(keyToPurchases))
+	for key := range keyToPurchases {
+		allKeys = append(allKeys, key)
+	}
+
+	log.Info("contract sync: checking purchases", "pendingCount", len(purchases), "buyerCount", len(buyerPurchases))
+
+	for buyerUserID := range buyerPurchases {
+		if err := u.syncBuyer(ctx, buyerUserID, allKeys, keyToPurchases); err != nil {
+			log.Error("contract sync: failed for buyer", "buyerUserID", buyerUserID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (u *ContractSync) syncBuyer(ctx context.Context, buyerUserID int64, allKeys []string, keyToPurchases map[string][]*models.PurchaseTransaction) error {
+	characters, err := u.characterRepo.GetAll(ctx, buyerUserID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get buyer characters")
+	}
+
+	for _, char := range characters {
+		if !strings.Contains(char.EsiScopes, "esi-contracts.read_character_contracts.v1") {
+			continue
+		}
+
+		if err := u.syncCharacterContracts(ctx, char, buyerUserID, allKeys, keyToPurchases); err != nil {
+			log.Error("contract sync: failed for character",
+				"characterID", char.ID, "buyerUserID", buyerUserID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (u *ContractSync) syncCharacterContracts(
+	ctx context.Context,
+	char *repositories.Character,
+	userID int64,
+	allKeys []string,
+	keyToPurchases map[string][]*models.PurchaseTransaction,
+) error {
+	token, refresh, expire := char.EsiToken, char.EsiRefreshToken, char.EsiTokenExpiresOn
+
+	if time.Now().After(expire) {
+		refreshed, err := u.esiClient.RefreshAccessToken(ctx, refresh)
+		if err != nil {
+			return errors.Wrapf(err, "failed to refresh token for character %d", char.ID)
+		}
+		token = refreshed.AccessToken
+		refresh = refreshed.RefreshToken
+		expire = refreshed.Expiry
+
+		if err := u.characterRepo.UpdateTokens(ctx, char.ID, userID, token, refresh, expire); err != nil {
+			log.Error("contract sync: failed to persist refreshed token", "characterID", char.ID, "error", err)
+		}
+	}
+
+	contracts, err := u.esiClient.GetCharacterContracts(ctx, char.ID, token, refresh, expire)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get contracts for character %d", char.ID)
+	}
+
+	for _, contract := range contracts {
+		if contract.Status != "finished" || contract.Type != "item_exchange" {
+			continue
+		}
+
+		// Check if the contract title contains any known contract_key
+		for _, key := range allKeys {
+			if strings.Contains(contract.Title, key) {
+				u.completePurchases(ctx, keyToPurchases[key], contract.ContractID)
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+func (u *ContractSync) completePurchases(ctx context.Context, purchases []*models.PurchaseTransaction, eveContractID int64) {
+	for _, purchase := range purchases {
+		if err := u.purchaseRepo.CompleteWithContractID(ctx, purchase.ID, eveContractID); err != nil {
+			log.Error("contract sync: failed to auto-complete purchase",
+				"purchaseID", purchase.ID, "eveContractID", eveContractID, "error", err)
+		} else {
+			log.Info("contract sync: auto-completed purchase",
+				"purchaseID", purchase.ID, "eveContractID", eveContractID,
+				"buyerUserID", purchase.BuyerUserID, "contractKey", *purchase.ContractKey)
+		}
+	}
+}

--- a/internal/updaters/contractSync_test.go
+++ b/internal/updaters/contractSync_test.go
@@ -1,0 +1,365 @@
+package updaters_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/client"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/updaters"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Mocks ---
+
+type mockContractSyncPurchaseRepo struct {
+	contractCreated    []*models.PurchaseTransaction
+	contractCreatedErr error
+	completedCalls     []completeCall
+	completeErr        error
+}
+
+type completeCall struct {
+	PurchaseID    int64
+	EveContractID int64
+}
+
+func (m *mockContractSyncPurchaseRepo) GetContractCreatedWithKeys(ctx context.Context) ([]*models.PurchaseTransaction, error) {
+	return m.contractCreated, m.contractCreatedErr
+}
+
+func (m *mockContractSyncPurchaseRepo) CompleteWithContractID(ctx context.Context, purchaseID int64, eveContractID int64) error {
+	m.completedCalls = append(m.completedCalls, completeCall{PurchaseID: purchaseID, EveContractID: eveContractID})
+	return m.completeErr
+}
+
+type mockContractSyncCharRepo struct {
+	charactersByUser map[int64][]*repositories.Character
+	getErr           error
+	tokenUpdateErr   error
+}
+
+func (m *mockContractSyncCharRepo) GetAll(ctx context.Context, baseUserID int64) ([]*repositories.Character, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	return m.charactersByUser[baseUserID], nil
+}
+
+func (m *mockContractSyncCharRepo) UpdateTokens(ctx context.Context, id, userID int64, token, refreshToken string, expiresOn time.Time) error {
+	return m.tokenUpdateErr
+}
+
+type mockContractSyncEsiClient struct {
+	contractsByChar map[int64][]*client.EsiContract
+	contractsErr    error
+	refreshedToken  *client.RefreshedToken
+	refreshErr      error
+}
+
+func (m *mockContractSyncEsiClient) GetCharacterContracts(ctx context.Context, characterID int64, token, refresh string, expire time.Time) ([]*client.EsiContract, error) {
+	if m.contractsErr != nil {
+		return nil, m.contractsErr
+	}
+	return m.contractsByChar[characterID], nil
+}
+
+func (m *mockContractSyncEsiClient) RefreshAccessToken(ctx context.Context, refreshToken string) (*client.RefreshedToken, error) {
+	if m.refreshErr != nil {
+		return nil, m.refreshErr
+	}
+	return m.refreshedToken, nil
+}
+
+// --- Helpers ---
+
+func strPtr(s string) *string { return &s }
+
+// --- Tests ---
+
+func Test_ContractSync_AutoCompletesMatchingContract(t *testing.T) {
+	key := "PT-42"
+	purchaseRepo := &mockContractSyncPurchaseRepo{
+		contractCreated: []*models.PurchaseTransaction{
+			{ID: 42, BuyerUserID: 100, ContractKey: &key},
+		},
+	}
+
+	charRepo := &mockContractSyncCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 2001, UserID: 100, EsiToken: "tok", EsiRefreshToken: "ref",
+					EsiTokenExpiresOn: time.Now().Add(1 * time.Hour),
+					EsiScopes:         "esi-contracts.read_character_contracts.v1"},
+			},
+		},
+	}
+
+	esiClient := &mockContractSyncEsiClient{
+		contractsByChar: map[int64][]*client.EsiContract{
+			2001: {
+				{ContractID: 99999, Type: "item_exchange", Status: "finished", Title: "Items for PT-42"},
+			},
+		},
+	}
+
+	syncer := updaters.NewContractSync(purchaseRepo, charRepo, esiClient)
+	err := syncer.SyncAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, purchaseRepo.completedCalls, 1)
+	assert.Equal(t, int64(42), purchaseRepo.completedCalls[0].PurchaseID)
+	assert.Equal(t, int64(99999), purchaseRepo.completedCalls[0].EveContractID)
+}
+
+func Test_ContractSync_NoActionWhenNoPurchases(t *testing.T) {
+	purchaseRepo := &mockContractSyncPurchaseRepo{
+		contractCreated: []*models.PurchaseTransaction{},
+	}
+
+	charRepo := &mockContractSyncCharRepo{}
+	esiClient := &mockContractSyncEsiClient{}
+
+	syncer := updaters.NewContractSync(purchaseRepo, charRepo, esiClient)
+	err := syncer.SyncAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, purchaseRepo.completedCalls, 0)
+}
+
+func Test_ContractSync_SkipsCharacterWithoutScope(t *testing.T) {
+	key := "PT-10"
+	purchaseRepo := &mockContractSyncPurchaseRepo{
+		contractCreated: []*models.PurchaseTransaction{
+			{ID: 10, BuyerUserID: 100, ContractKey: &key},
+		},
+	}
+
+	charRepo := &mockContractSyncCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 2001, UserID: 100, EsiToken: "tok", EsiRefreshToken: "ref",
+					EsiTokenExpiresOn: time.Now().Add(1 * time.Hour),
+					EsiScopes:         "esi-assets.read_assets.v1"},
+			},
+		},
+	}
+
+	esiClient := &mockContractSyncEsiClient{
+		contractsByChar: map[int64][]*client.EsiContract{
+			2001: {
+				{ContractID: 99999, Type: "item_exchange", Status: "finished", Title: "PT-10 delivery"},
+			},
+		},
+	}
+
+	syncer := updaters.NewContractSync(purchaseRepo, charRepo, esiClient)
+	err := syncer.SyncAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, purchaseRepo.completedCalls, 0)
+}
+
+func Test_ContractSync_NoMatchWhenTitleDoesNotContainKey(t *testing.T) {
+	key := "PT-42"
+	purchaseRepo := &mockContractSyncPurchaseRepo{
+		contractCreated: []*models.PurchaseTransaction{
+			{ID: 42, BuyerUserID: 100, ContractKey: &key},
+		},
+	}
+
+	charRepo := &mockContractSyncCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 2001, UserID: 100, EsiToken: "tok", EsiRefreshToken: "ref",
+					EsiTokenExpiresOn: time.Now().Add(1 * time.Hour),
+					EsiScopes:         "esi-contracts.read_character_contracts.v1"},
+			},
+		},
+	}
+
+	esiClient := &mockContractSyncEsiClient{
+		contractsByChar: map[int64][]*client.EsiContract{
+			2001: {
+				{ContractID: 88888, Type: "item_exchange", Status: "finished", Title: "Random contract"},
+			},
+		},
+	}
+
+	syncer := updaters.NewContractSync(purchaseRepo, charRepo, esiClient)
+	err := syncer.SyncAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, purchaseRepo.completedCalls, 0)
+}
+
+func Test_ContractSync_MultiplePurchasesSameKeyAllCompleted(t *testing.T) {
+	key := "BATCH-1"
+	purchaseRepo := &mockContractSyncPurchaseRepo{
+		contractCreated: []*models.PurchaseTransaction{
+			{ID: 10, BuyerUserID: 100, ContractKey: &key},
+			{ID: 11, BuyerUserID: 100, ContractKey: &key},
+			{ID: 12, BuyerUserID: 100, ContractKey: &key},
+		},
+	}
+
+	charRepo := &mockContractSyncCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 2001, UserID: 100, EsiToken: "tok", EsiRefreshToken: "ref",
+					EsiTokenExpiresOn: time.Now().Add(1 * time.Hour),
+					EsiScopes:         "esi-contracts.read_character_contracts.v1"},
+			},
+		},
+	}
+
+	esiClient := &mockContractSyncEsiClient{
+		contractsByChar: map[int64][]*client.EsiContract{
+			2001: {
+				{ContractID: 55555, Type: "item_exchange", Status: "finished", Title: "Corp delivery BATCH-1"},
+			},
+		},
+	}
+
+	syncer := updaters.NewContractSync(purchaseRepo, charRepo, esiClient)
+	err := syncer.SyncAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, purchaseRepo.completedCalls, 3)
+	assert.Equal(t, int64(10), purchaseRepo.completedCalls[0].PurchaseID)
+	assert.Equal(t, int64(11), purchaseRepo.completedCalls[1].PurchaseID)
+	assert.Equal(t, int64(12), purchaseRepo.completedCalls[2].PurchaseID)
+	for _, call := range purchaseRepo.completedCalls {
+		assert.Equal(t, int64(55555), call.EveContractID)
+	}
+}
+
+func Test_ContractSync_IgnoresNonFinishedContracts(t *testing.T) {
+	key := "PT-1"
+	purchaseRepo := &mockContractSyncPurchaseRepo{
+		contractCreated: []*models.PurchaseTransaction{
+			{ID: 1, BuyerUserID: 100, ContractKey: &key},
+		},
+	}
+
+	charRepo := &mockContractSyncCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 2001, UserID: 100, EsiToken: "tok", EsiRefreshToken: "ref",
+					EsiTokenExpiresOn: time.Now().Add(1 * time.Hour),
+					EsiScopes:         "esi-contracts.read_character_contracts.v1"},
+			},
+		},
+	}
+
+	esiClient := &mockContractSyncEsiClient{
+		contractsByChar: map[int64][]*client.EsiContract{
+			2001: {
+				{ContractID: 111, Type: "item_exchange", Status: "outstanding", Title: "PT-1"},
+				{ContractID: 222, Type: "courier", Status: "finished", Title: "PT-1"},
+				{ContractID: 333, Type: "item_exchange", Status: "cancelled", Title: "PT-1"},
+			},
+		},
+	}
+
+	syncer := updaters.NewContractSync(purchaseRepo, charRepo, esiClient)
+	err := syncer.SyncAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, purchaseRepo.completedCalls, 0)
+}
+
+func Test_ContractSync_ESIErrorLogsAndContinues(t *testing.T) {
+	key1 := "PT-1"
+	key2 := "PT-2"
+	purchaseRepo := &mockContractSyncPurchaseRepo{
+		contractCreated: []*models.PurchaseTransaction{
+			{ID: 1, BuyerUserID: 100, ContractKey: &key1},
+			{ID: 2, BuyerUserID: 200, ContractKey: &key2},
+		},
+	}
+
+	charRepo := &mockContractSyncCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 2001, UserID: 100, EsiToken: "tok", EsiRefreshToken: "ref",
+					EsiTokenExpiresOn: time.Now().Add(1 * time.Hour),
+					EsiScopes:         "esi-contracts.read_character_contracts.v1"},
+			},
+			200: {
+				{ID: 3001, UserID: 200, EsiToken: "tok2", EsiRefreshToken: "ref2",
+					EsiTokenExpiresOn: time.Now().Add(1 * time.Hour),
+					EsiScopes:         "esi-contracts.read_character_contracts.v1"},
+			},
+		},
+	}
+
+	// ESI returns error for all characters
+	esiClient := &mockContractSyncEsiClient{
+		contractsErr: errors.New("ESI unavailable"),
+	}
+
+	syncer := updaters.NewContractSync(purchaseRepo, charRepo, esiClient)
+	err := syncer.SyncAll(context.Background())
+
+	// SyncAll should not return an error — it logs per-user errors
+	assert.NoError(t, err)
+	assert.Len(t, purchaseRepo.completedCalls, 0)
+}
+
+func Test_ContractSync_RefreshesExpiredToken(t *testing.T) {
+	key := "PT-5"
+	purchaseRepo := &mockContractSyncPurchaseRepo{
+		contractCreated: []*models.PurchaseTransaction{
+			{ID: 5, BuyerUserID: 100, ContractKey: &key},
+		},
+	}
+
+	charRepo := &mockContractSyncCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 2001, UserID: 100, EsiToken: "expired-tok", EsiRefreshToken: "ref",
+					EsiTokenExpiresOn: time.Now().Add(-1 * time.Hour), // expired
+					EsiScopes:         "esi-contracts.read_character_contracts.v1"},
+			},
+		},
+	}
+
+	esiClient := &mockContractSyncEsiClient{
+		refreshedToken: &client.RefreshedToken{
+			AccessToken:  "new-tok",
+			RefreshToken: "new-ref",
+			Expiry:       time.Now().Add(20 * time.Minute),
+		},
+		contractsByChar: map[int64][]*client.EsiContract{
+			2001: {
+				{ContractID: 77777, Type: "item_exchange", Status: "finished", Title: "PT-5 minerals"},
+			},
+		},
+	}
+
+	syncer := updaters.NewContractSync(purchaseRepo, charRepo, esiClient)
+	err := syncer.SyncAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, purchaseRepo.completedCalls, 1)
+	assert.Equal(t, int64(5), purchaseRepo.completedCalls[0].PurchaseID)
+}
+
+func Test_ContractSync_GetPurchasesError(t *testing.T) {
+	purchaseRepo := &mockContractSyncPurchaseRepo{
+		contractCreatedErr: errors.New("db down"),
+	}
+
+	charRepo := &mockContractSyncCharRepo{}
+	esiClient := &mockContractSyncEsiClient{}
+
+	syncer := updaters.NewContractSync(purchaseRepo, charRepo, esiClient)
+	err := syncer.SyncAll(context.Background())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "contract_created purchases")
+}


### PR DESCRIPTION
## Summary
- Background runner scans buyer characters' ESI contracts every 15 minutes, matching finished `item_exchange` contracts by `contract_key` in the title
- Auto-generates `PT-{id}` keys when sellers mark purchases as `contract_created` (custom keys still supported)
- Manual "Complete" button remains as fallback for when sellers forget to include the key

## Files
- `internal/updaters/contractSync.go` — matching logic + auto-completion
- `internal/runners/contractSync.go` — 15-minute background runner
- `internal/client/esiClient.go` — `GetCharacterContracts` + `EsiContract` type
- `internal/controllers/purchases.go` — auto-generate `contract_key` in `MarkContractCreated`
- `internal/repositories/purchaseTransactions.go` — `GetContractCreatedWithKeys`, `CompleteWithContractID`
- `cmd/industry-tool/cmd/root.go` — wiring

## Test plan
- [x] 25 new tests across all layers (updater, runner, ESI client, controller, repository)
- [x] `make test-backend` passes
- [ ] Manual: create purchase → mark contract created → verify auto-generated key → put key in EVE contract title → accept → wait for sync → purchase auto-completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)