### PR TITLE
Add stockpile-aware multibuy to reactions calculator

### DIFF
--- a/docs/features/stockpile-multibuy.md
+++ b/docs/features/stockpile-multibuy.md
@@ -1,0 +1,36 @@
+# Stockpile-Aware Multibuy
+
+## Overview
+
+Enhances the reactions calculator shopping list with stockpile awareness. When logged in, users can select a location where they store moon goo. The shopping list then shows what they already have in stock and computes the delta (what still needs to be purchased). Users can also set stockpile targets for all shopping list materials at the selected location.
+
+## Features
+
+- **Location picker** — dropdown populated from user's asset locations (only visible when logged in)
+- **In Stock column** — shows quantity of each material at the selected location
+- **Delta column** — shows `max(0, needed - in_stock)` with green checkmark when fully stocked
+- **Copy Multibuy** — copies the full shopping list (unchanged behavior)
+- **Copy Delta** — copies only items where delta > 0, in EVE multibuy format
+- **Delta Cost** — shows total cost of remaining materials to purchase
+- **Set Stockpile** — opens a dialog to set stockpile targets for all shopping list materials
+  - User picks an owner (character or corporation) at the location
+  - Quantities pre-filled from shopping list, editable before saving
+  - Bulk-saves stockpile markers via existing `/api/stockpiles/upsert` endpoint
+- **Persistence** — selected location saved to localStorage across sessions
+
+## Design Decisions
+
+- **Frontend-only**: Uses existing `GET /api/assets/get` and `POST /api/stockpiles/upsert` endpoints. No backend changes needed.
+- **Auth-gated**: Location picker only appears when user is logged in. Unauthenticated users see only the standard "Copy Multibuy" button.
+- **Aggregation**: Assets are summed across all sources at a structure (personal hangar, containers, deliveries, asset safety, corp hangars, corp containers).
+- **Owner selection**: Owners are extracted from assets at the selected structure. This avoids extra API calls for characters/corporations.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `frontend/packages/pages/reactions.tsx` | Session awareness, assets fetch, location state |
+| `frontend/packages/components/reactions/ShoppingList.tsx` | Location dropdown, delta columns, copy delta, set stockpile button |
+| `frontend/packages/components/reactions/StockpileDialog.tsx` | Dialog for setting stockpile targets with editable quantities |
+| `frontend/packages/utils/assetAggregation.ts` | Aggregates assets by type_id, extracts unique owners |
+| `frontend/packages/utils/__tests__/assetAggregation.test.ts` | Unit tests |

--- a/frontend/packages/client/auth/api.ts
+++ b/frontend/packages/client/auth/api.ts
@@ -47,9 +47,6 @@ export let scopesArray = [
 export let playerScope = scopesArray.join(" ");
 
 export let corpScopesArray = [
-  "esi-wallet.read_corporation_wallet.v1",
-  "esi-search.search_structures.v1",
-  "esi-universe.read_structures.v1",
   "esi-wallet.read_corporation_wallets.v1",
   "esi-assets.read_corporation_assets.v1",
   "esi-corporations.read_blueprints.v1",
@@ -59,7 +56,6 @@ export let corpScopesArray = [
   "esi-corporations.read_container_logs.v1",
   "esi-industry.read_corporation_mining.v1",
   "esi-corporations.read_facilities.v1",
-  "esi-corporations.read_freelance_jobs.v1",
   "esi-corporations.read_divisions.v1",
 ];
 export let corpScope = corpScopesArray.join(" ");

--- a/frontend/packages/components/reactions/ShoppingList.tsx
+++ b/frontend/packages/components/reactions/ShoppingList.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -5,19 +6,46 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import { PlanResponse } from "@industry-tool/client/data/models";
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import InventoryIcon from '@mui/icons-material/Inventory';
+import { PlanResponse, AssetsResponse } from "@industry-tool/client/data/models";
 import { formatISK, formatNumber } from "@industry-tool/utils/formatting";
+import { aggregateAssetsByTypeId, getUniqueOwners } from "@industry-tool/utils/assetAggregation";
+import StockpileDialog from './StockpileDialog';
 
 type Props = {
   planData: PlanResponse | null;
   loading: boolean;
+  assets: AssetsResponse | null;
+  isAuthenticated: boolean;
+  stockpileLocationId: number;
+  onStockpileLocationChange: (locationId: number) => void;
 };
 
-export default function ShoppingList({ planData, loading }: Props) {
+type SortKey = 'name' | 'quantity' | 'inStock' | 'delta' | 'price' | 'cost' | 'volume';
+type SortDir = 'asc' | 'desc';
+
+export default function ShoppingList({ planData, loading, assets, isAuthenticated, stockpileLocationId, onStockpileLocationChange }: Props) {
+  const [stockpileDialogOpen, setStockpileDialogOpen] = useState(false);
+  const [sortKey, setSortKey] = useState<SortKey>('name');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir(prev => prev === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'name' ? 'asc' : 'desc');
+    }
+  };
+
   if (loading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
@@ -34,8 +62,20 @@ export default function ShoppingList({ planData, loading }: Props) {
     );
   }
 
+  const locations = assets?.structures ?? [];
+  const selectedStructure = locations.find(s => s.id === stockpileLocationId) || null;
+  const stockpileMap = selectedStructure ? aggregateAssetsByTypeId(selectedStructure) : null;
+
   const totalCost = planData.shopping_list.reduce((sum, item) => sum + item.cost, 0);
   const totalVolume = planData.shopping_list.reduce((sum, item) => sum + item.volume, 0);
+
+  const deltaCost = stockpileMap
+    ? planData.shopping_list.reduce((sum, item) => {
+        const have = stockpileMap.get(item.type_id) || 0;
+        const delta = Math.max(0, item.quantity - have);
+        return sum + (delta * item.price);
+      }, 0)
+    : null;
 
   const copyMultibuy = () => {
     const text = planData.shopping_list
@@ -44,62 +84,189 @@ export default function ShoppingList({ planData, loading }: Props) {
     navigator.clipboard.writeText(text);
   };
 
+  const copyMultibuyDelta = () => {
+    if (!stockpileMap) return;
+    const lines = planData.shopping_list
+      .map(item => {
+        const have = stockpileMap.get(item.type_id) || 0;
+        const delta = Math.max(0, item.quantity - have);
+        return delta > 0 ? `${item.name} ${delta}` : null;
+      })
+      .filter(Boolean);
+    navigator.clipboard.writeText(lines.join('\n'));
+  };
+
   return (
     <Box>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <Box sx={{ display: 'flex', gap: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2, flexWrap: 'wrap', gap: 1 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <Typography variant="body2" color="text.secondary">
             {planData.shopping_list.length} items | Total: {formatISK(totalCost)} | Volume: {formatNumber(totalVolume, 1)} m3
           </Typography>
+          {deltaCost !== null && (
+            <Typography variant="body2" color="success.main">
+              Delta Cost: {formatISK(deltaCost)}
+            </Typography>
+          )}
         </Box>
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<ContentCopyIcon />}
-          onClick={copyMultibuy}
-        >
-          Copy Multibuy
-        </Button>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {isAuthenticated && (
+            <Autocomplete
+              size="small"
+              sx={{ minWidth: 250 }}
+              options={locations}
+              getOptionLabel={(option) => option.name}
+              value={selectedStructure}
+              onChange={(_e, value) => onStockpileLocationChange(value?.id ?? 0)}
+              renderInput={(params) => <TextField {...params} label="Stockpile Location" />}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+            />
+          )}
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<ContentCopyIcon />}
+            onClick={copyMultibuy}
+          >
+            Copy Multibuy
+          </Button>
+          {stockpileMap && (
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<ContentCopyIcon />}
+              onClick={copyMultibuyDelta}
+              color="success"
+            >
+              Copy Delta
+            </Button>
+          )}
+          {selectedStructure && (
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<InventoryIcon />}
+              onClick={() => setStockpileDialogOpen(true)}
+              color="warning"
+            >
+              Set Stockpile
+            </Button>
+          )}
+        </Box>
       </Box>
 
       <TableContainer>
         <Table size="small" sx={{ '& th': { backgroundColor: '#0f1219', fontWeight: 'bold' } }}>
           <TableHead>
             <TableRow>
-              <TableCell>Material</TableCell>
-              <TableCell align="right">Quantity</TableCell>
-              <TableCell align="right">Unit Price</TableCell>
-              <TableCell align="right">Total Cost</TableCell>
-              <TableCell align="right">Volume (m3)</TableCell>
+              <TableCell>
+                <TableSortLabel active={sortKey === 'name'} direction={sortKey === 'name' ? sortDir : 'asc'} onClick={() => handleSort('name')}>
+                  Material
+                </TableSortLabel>
+              </TableCell>
+              <TableCell align="right">
+                <TableSortLabel active={sortKey === 'quantity'} direction={sortKey === 'quantity' ? sortDir : 'desc'} onClick={() => handleSort('quantity')}>
+                  Quantity
+                </TableSortLabel>
+              </TableCell>
+              {stockpileMap && (
+                <TableCell align="right">
+                  <TableSortLabel active={sortKey === 'inStock'} direction={sortKey === 'inStock' ? sortDir : 'desc'} onClick={() => handleSort('inStock')}>
+                    In Stock
+                  </TableSortLabel>
+                </TableCell>
+              )}
+              {stockpileMap && (
+                <TableCell align="right">
+                  <TableSortLabel active={sortKey === 'delta'} direction={sortKey === 'delta' ? sortDir : 'desc'} onClick={() => handleSort('delta')}>
+                    Delta
+                  </TableSortLabel>
+                </TableCell>
+              )}
+              <TableCell align="right">
+                <TableSortLabel active={sortKey === 'price'} direction={sortKey === 'price' ? sortDir : 'desc'} onClick={() => handleSort('price')}>
+                  Unit Price
+                </TableSortLabel>
+              </TableCell>
+              <TableCell align="right">
+                <TableSortLabel active={sortKey === 'cost'} direction={sortKey === 'cost' ? sortDir : 'desc'} onClick={() => handleSort('cost')}>
+                  Total Cost
+                </TableSortLabel>
+              </TableCell>
+              <TableCell align="right">
+                <TableSortLabel active={sortKey === 'volume'} direction={sortKey === 'volume' ? sortDir : 'desc'} onClick={() => handleSort('volume')}>
+                  Volume (m3)
+                </TableSortLabel>
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {planData.shopping_list.map((item) => (
-              <TableRow
-                key={item.type_id}
-                sx={{ '&:nth-of-type(odd)': { backgroundColor: 'rgba(255,255,255,0.02)' } }}
-              >
-                <TableCell>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <img
-                      src={`https://images.evetech.net/types/${item.type_id}/icon?size=32`}
-                      alt=""
-                      width={24}
-                      height={24}
-                      style={{ borderRadius: 2 }}
-                    />
-                    {item.name}
-                  </Box>
-                </TableCell>
-                <TableCell align="right">{formatNumber(item.quantity)}</TableCell>
-                <TableCell align="right">{formatISK(item.price)}</TableCell>
-                <TableCell align="right">{formatISK(item.cost)}</TableCell>
-                <TableCell align="right">{formatNumber(item.volume, 1)}</TableCell>
-              </TableRow>
-            ))}
+            {[...planData.shopping_list]
+              .map((item) => {
+                const have = stockpileMap ? (stockpileMap.get(item.type_id) || 0) : 0;
+                const delta = Math.max(0, item.quantity - have);
+                return { item, have, delta };
+              })
+              .sort((a, b) => {
+                let cmp = 0;
+                switch (sortKey) {
+                  case 'name': cmp = a.item.name.localeCompare(b.item.name); break;
+                  case 'quantity': cmp = a.item.quantity - b.item.quantity; break;
+                  case 'inStock': cmp = a.have - b.have; break;
+                  case 'delta': cmp = a.delta - b.delta; break;
+                  case 'price': cmp = a.item.price - b.item.price; break;
+                  case 'cost': cmp = a.item.cost - b.item.cost; break;
+                  case 'volume': cmp = a.item.volume - b.item.volume; break;
+                }
+                return sortDir === 'asc' ? cmp : -cmp;
+              })
+              .map(({ item, have, delta }) => {
+              const fulfilled = stockpileMap ? delta === 0 : false;
+
+              return (
+                <TableRow
+                  key={item.type_id}
+                  sx={{ '&:nth-of-type(odd)': { backgroundColor: 'rgba(255,255,255,0.02)' } }}
+                >
+                  <TableCell>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <img
+                        src={`https://images.evetech.net/types/${item.type_id}/icon?size=32`}
+                        alt=""
+                        width={24}
+                        height={24}
+                        style={{ borderRadius: 2 }}
+                      />
+                      {item.name}
+                    </Box>
+                  </TableCell>
+                  <TableCell align="right">{formatNumber(item.quantity)}</TableCell>
+                  {stockpileMap && (
+                    <TableCell align="right">{formatNumber(have)}</TableCell>
+                  )}
+                  {stockpileMap && (
+                    <TableCell align="right" sx={fulfilled ? { color: '#10b981' } : undefined}>
+                      {fulfilled ? (
+                        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 0.5 }}>
+                          <CheckCircleIcon sx={{ fontSize: 16 }} />
+                          0
+                        </Box>
+                      ) : (
+                        formatNumber(delta)
+                      )}
+                    </TableCell>
+                  )}
+                  <TableCell align="right">{formatISK(item.price)}</TableCell>
+                  <TableCell align="right">{formatISK(item.cost)}</TableCell>
+                  <TableCell align="right">{formatNumber(item.volume, 1)}</TableCell>
+                </TableRow>
+              );
+            })}
             <TableRow sx={{ '& td': { fontWeight: 'bold', borderTop: '2px solid rgba(255,255,255,0.1)' } }}>
               <TableCell>Total</TableCell>
               <TableCell />
+              {stockpileMap && <TableCell />}
+              {stockpileMap && <TableCell />}
               <TableCell />
               <TableCell align="right">{formatISK(totalCost)}</TableCell>
               <TableCell align="right">{formatNumber(totalVolume, 1)}</TableCell>
@@ -107,6 +274,17 @@ export default function ShoppingList({ planData, loading }: Props) {
           </TableBody>
         </Table>
       </TableContainer>
+
+      {selectedStructure && (
+        <StockpileDialog
+          open={stockpileDialogOpen}
+          onClose={() => setStockpileDialogOpen(false)}
+          shoppingList={planData.shopping_list}
+          locationId={selectedStructure.id}
+          locationName={selectedStructure.name}
+          owners={getUniqueOwners(selectedStructure)}
+        />
+      )}
     </Box>
   );
 }

--- a/frontend/packages/components/reactions/StockpileDialog.tsx
+++ b/frontend/packages/components/reactions/StockpileDialog.tsx
@@ -1,0 +1,215 @@
+import { useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import { ShoppingItem, StockpileMarker } from "@industry-tool/client/data/models";
+import { formatNumber } from "@industry-tool/utils/formatting";
+import { AssetOwner } from "@industry-tool/utils/assetAggregation";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  shoppingList: ShoppingItem[];
+  locationId: number;
+  locationName: string;
+  owners: AssetOwner[];
+};
+
+export default function StockpileDialog({ open, onClose, shoppingList, locationId, locationName, owners }: Props) {
+  const [selectedOwner, setSelectedOwner] = useState('');
+  const [quantities, setQuantities] = useState<Record<number, string>>(() => {
+    const initial: Record<number, string> = {};
+    for (const item of shoppingList) {
+      initial[item.type_id] = item.quantity.toString();
+    }
+    return initial;
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const ownerKey = (o: AssetOwner) => `${o.ownerType}:${o.ownerId}`;
+  const parseOwnerKey = (key: string) => {
+    const [ownerType, ownerId] = key.split(':');
+    return { ownerType, ownerId: parseInt(ownerId, 10) };
+  };
+
+  const handleQuantityChange = (typeId: number, value: string) => {
+    setQuantities(prev => ({ ...prev, [typeId]: value }));
+  };
+
+  const handleSave = async () => {
+    if (!selectedOwner) return;
+
+    const { ownerType, ownerId } = parseOwnerKey(selectedOwner);
+    setSaving(true);
+    setError(null);
+
+    try {
+      for (const item of shoppingList) {
+        const qty = parseInt(quantities[item.type_id]?.replace(/,/g, '') || '0', 10);
+        if (qty <= 0) continue;
+
+        const marker: StockpileMarker = {
+          userId: 0,
+          typeId: item.type_id,
+          ownerType,
+          ownerId,
+          locationId,
+          desiredQuantity: qty,
+        };
+
+        const res = await fetch('/api/stockpiles/upsert', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(marker),
+        });
+
+        if (!res.ok) {
+          throw new Error(`Failed to set stockpile for ${item.name}`);
+        }
+      }
+
+      setSuccess(true);
+      setTimeout(() => {
+        onClose();
+        setSuccess(false);
+      }, 1000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save stockpile targets');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const itemsWithQty = shoppingList.filter(item => {
+    const qty = parseInt(quantities[item.type_id]?.replace(/,/g, '') || '0', 10);
+    return qty > 0;
+  });
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Set Stockpile Targets</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Set desired stockpile quantities at <strong>{locationName}</strong>. Items with quantity 0 will be skipped.
+          </Typography>
+
+          <FormControl size="small" fullWidth>
+            <InputLabel>Owner</InputLabel>
+            <Select
+              value={selectedOwner}
+              label="Owner"
+              onChange={(e) => setSelectedOwner(e.target.value)}
+            >
+              {owners.map(o => (
+                <MenuItem key={ownerKey(o)} value={ownerKey(o)}>
+                  {o.ownerName} ({o.ownerType})
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+              size="small"
+              onClick={() => {
+                const cleared: Record<number, string> = {};
+                for (const item of shoppingList) cleared[item.type_id] = '0';
+                setQuantities(cleared);
+              }}
+            >
+              Clear All
+            </Button>
+            <Button
+              size="small"
+              onClick={() => {
+                const reset: Record<number, string> = {};
+                for (const item of shoppingList) reset[item.type_id] = item.quantity.toString();
+                setQuantities(reset);
+              }}
+            >
+              Reset All
+            </Button>
+          </Box>
+
+          {error && <Alert severity="error">{error}</Alert>}
+          {success && <Alert severity="success">Stockpile targets saved!</Alert>}
+
+          <TableContainer sx={{ maxHeight: 400 }}>
+            <Table size="small" stickyHeader sx={{ '& th': { backgroundColor: '#0f1219', fontWeight: 'bold' } }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Material</TableCell>
+                  <TableCell align="right">Shopping List</TableCell>
+                  <TableCell align="right">Desired Quantity</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {shoppingList.map((item) => (
+                  <TableRow key={item.type_id}>
+                    <TableCell>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <img
+                          src={`https://images.evetech.net/types/${item.type_id}/icon?size=32`}
+                          alt=""
+                          width={24}
+                          height={24}
+                          style={{ borderRadius: 2 }}
+                        />
+                        {item.name}
+                      </Box>
+                    </TableCell>
+                    <TableCell align="right">{formatNumber(item.quantity)}</TableCell>
+                    <TableCell align="right" sx={{ width: 160 }}>
+                      <TextField
+                        size="small"
+                        type="number"
+                        value={quantities[item.type_id] || ''}
+                        onChange={(e) => handleQuantityChange(item.type_id, e.target.value)}
+                        inputProps={{ min: 0 }}
+                        sx={{ width: 140 }}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Typography variant="body2" color="text.secondary" sx={{ mr: 'auto', ml: 1 }}>
+          {itemsWithQty.length} of {shoppingList.length} items will be set
+        </Typography>
+        <Button onClick={onClose} disabled={saving}>Cancel</Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={saving || !selectedOwner}
+          startIcon={saving ? <CircularProgress size={16} /> : undefined}
+        >
+          {saving ? 'Saving...' : 'Set Targets'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/packages/utils/__tests__/assetAggregation.test.ts
+++ b/frontend/packages/utils/__tests__/assetAggregation.test.ts
@@ -1,0 +1,140 @@
+import { aggregateAssetsByTypeId, getUniqueOwners } from '../assetAggregation';
+import { AssetStructure } from '@industry-tool/client/data/models';
+
+const makeAsset = (typeId: number, quantity: number) => ({
+  name: `Item ${typeId}`,
+  typeId,
+  quantity,
+  volume: quantity * 0.01,
+  ownerType: 'character',
+  ownerName: 'Test Char',
+  ownerId: 1,
+});
+
+const emptyStructure: AssetStructure = {
+  id: 1000,
+  name: 'Test Station',
+  solarSystem: 'Jita',
+  region: 'The Forge',
+  hangarAssets: [],
+  hangarContainers: [],
+  deliveries: [],
+  assetSafety: [],
+  corporationHangers: [],
+};
+
+describe('aggregateAssetsByTypeId', () => {
+  it('returns empty map for empty structure', () => {
+    const result = aggregateAssetsByTypeId(emptyStructure);
+    expect(result.size).toBe(0);
+  });
+
+  it('aggregates hangar assets', () => {
+    const structure: AssetStructure = {
+      ...emptyStructure,
+      hangarAssets: [makeAsset(100, 500), makeAsset(200, 300)],
+    };
+    const result = aggregateAssetsByTypeId(structure);
+    expect(result.get(100)).toBe(500);
+    expect(result.get(200)).toBe(300);
+  });
+
+  it('aggregates container assets', () => {
+    const structure: AssetStructure = {
+      ...emptyStructure,
+      hangarContainers: [
+        { id: 1, name: 'Container 1', ownerType: 'character', ownerName: 'Test', ownerId: 1, assets: [makeAsset(100, 200)] },
+        { id: 2, name: 'Container 2', ownerType: 'character', ownerName: 'Test', ownerId: 1, assets: [makeAsset(100, 100)] },
+      ],
+    };
+    const result = aggregateAssetsByTypeId(structure);
+    expect(result.get(100)).toBe(300);
+  });
+
+  it('aggregates corporation hangar assets and containers', () => {
+    const structure: AssetStructure = {
+      ...emptyStructure,
+      corporationHangers: [
+        {
+          id: 1,
+          name: 'Division 1',
+          corporationId: 99,
+          corporationName: 'Test Corp',
+          assets: [makeAsset(100, 1000)],
+          hangarContainers: [
+            { id: 10, name: 'Corp Container', ownerType: 'corporation', ownerName: 'Test Corp', ownerId: 99, assets: [makeAsset(100, 500)] },
+          ],
+        },
+      ],
+    };
+    const result = aggregateAssetsByTypeId(structure);
+    expect(result.get(100)).toBe(1500);
+  });
+
+  it('sums quantities across all sources for same typeId', () => {
+    const structure: AssetStructure = {
+      ...emptyStructure,
+      hangarAssets: [makeAsset(100, 100)],
+      hangarContainers: [
+        { id: 1, name: 'C1', ownerType: 'character', ownerName: 'Test', ownerId: 1, assets: [makeAsset(100, 200)] },
+      ],
+      deliveries: [makeAsset(100, 50)],
+      assetSafety: [makeAsset(100, 25)],
+      corporationHangers: [
+        {
+          id: 1,
+          name: 'Div 1',
+          corporationId: 99,
+          corporationName: 'Corp',
+          assets: [makeAsset(100, 300)],
+          hangarContainers: [
+            { id: 10, name: 'CC', ownerType: 'corporation', ownerName: 'Corp', ownerId: 99, assets: [makeAsset(100, 125)] },
+          ],
+        },
+      ],
+    };
+    const result = aggregateAssetsByTypeId(structure);
+    expect(result.get(100)).toBe(800); // 100 + 200 + 50 + 25 + 300 + 125
+  });
+});
+
+describe('getUniqueOwners', () => {
+  it('returns empty array for empty structure', () => {
+    const result = getUniqueOwners(emptyStructure);
+    expect(result).toEqual([]);
+  });
+
+  it('returns unique owners from hangar and corp assets', () => {
+    const structure: AssetStructure = {
+      ...emptyStructure,
+      hangarAssets: [makeAsset(100, 500)],
+      corporationHangers: [
+        {
+          id: 1,
+          name: 'Div 1',
+          corporationId: 99,
+          corporationName: 'Test Corp',
+          assets: [{ ...makeAsset(200, 300), ownerType: 'corporation', ownerName: 'Test Corp', ownerId: 99 }],
+          hangarContainers: [],
+        },
+      ],
+    };
+    const result = getUniqueOwners(structure);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({ ownerType: 'character', ownerId: 1, ownerName: 'Test Char' });
+    expect(result).toContainEqual({ ownerType: 'corporation', ownerId: 99, ownerName: 'Test Corp' });
+  });
+
+  it('deduplicates same owner across sources', () => {
+    const structure: AssetStructure = {
+      ...emptyStructure,
+      hangarAssets: [makeAsset(100, 500), makeAsset(200, 300)],
+      hangarContainers: [
+        { id: 1, name: 'C1', ownerType: 'character', ownerName: 'Test Char', ownerId: 1, assets: [makeAsset(300, 100)] },
+      ],
+    };
+    const result = getUniqueOwners(structure);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ ownerType: 'character', ownerId: 1, ownerName: 'Test Char' });
+  });
+});

--- a/frontend/packages/utils/assetAggregation.ts
+++ b/frontend/packages/utils/assetAggregation.ts
@@ -1,0 +1,70 @@
+import { Asset, AssetStructure } from "@industry-tool/client/data/models";
+
+export type AssetOwner = {
+    ownerType: string;
+    ownerId: number;
+    ownerName: string;
+};
+
+export function getUniqueOwners(structure: AssetStructure): AssetOwner[] {
+    const seen = new Map<string, AssetOwner>();
+
+    const addOwner = (asset: Asset) => {
+        const key = `${asset.ownerType}:${asset.ownerId}`;
+        if (!seen.has(key)) {
+            seen.set(key, { ownerType: asset.ownerType, ownerId: asset.ownerId, ownerName: asset.ownerName });
+        }
+    };
+
+    for (const asset of structure.hangarAssets) addOwner(asset);
+    for (const container of structure.hangarContainers) {
+        for (const asset of container.assets) addOwner(asset);
+    }
+    for (const hanger of structure.corporationHangers) {
+        for (const asset of hanger.assets) addOwner(asset);
+        for (const container of hanger.hangarContainers) {
+            for (const asset of container.assets) addOwner(asset);
+        }
+    }
+
+    return Array.from(seen.values());
+}
+
+export function aggregateAssetsByTypeId(structure: AssetStructure): Map<number, number> {
+    const totals = new Map<number, number>();
+
+    const add = (typeId: number, qty: number) => {
+        totals.set(typeId, (totals.get(typeId) || 0) + qty);
+    };
+
+    for (const asset of structure.hangarAssets) {
+        add(asset.typeId, asset.quantity);
+    }
+
+    for (const container of structure.hangarContainers) {
+        for (const asset of container.assets) {
+            add(asset.typeId, asset.quantity);
+        }
+    }
+
+    for (const asset of structure.deliveries) {
+        add(asset.typeId, asset.quantity);
+    }
+
+    for (const asset of structure.assetSafety) {
+        add(asset.typeId, asset.quantity);
+    }
+
+    for (const hanger of structure.corporationHangers) {
+        for (const asset of hanger.assets) {
+            add(asset.typeId, asset.quantity);
+        }
+        for (const container of hanger.hangarContainers) {
+            for (const asset of container.assets) {
+                add(asset.typeId, asset.quantity);
+            }
+        }
+    }
+
+    return totals;
+}


### PR DESCRIPTION
## Summary
- Adds location picker (searchable autocomplete) to Shopping List tab — only visible when logged in
- Shows **In Stock** and **Delta** columns when a location is selected, with **Copy Delta** for buying only what's missing
- **Set Stockpile** dialog for bulk-setting stockpile targets with owner selection and editable quantities
- All columns are sortable (click headers to sort)
- Fixes 4 invalid/deprecated ESI corporation scopes (pre-existing bug)
- Frontend-only — no backend changes needed

## Test plan
- [ ] Log in, go to Reactions page, select reactions, open Shopping List tab
- [ ] Verify location dropdown appears with searchable autocomplete
- [ ] Select a location — In Stock and Delta columns appear with correct quantities
- [ ] Copy Delta copies only items where delta > 0
- [ ] Copy Multibuy still copies the full list
- [ ] Set Stockpile opens dialog, pick owner, edit quantities, save
- [ ] Sort by each column header (asc/desc toggle)
- [ ] Log out — location picker and stockpile features disappear
- [ ] Selected location persists across page refreshes
- [ ] Adding a corporation token no longer fails on invalid ESI scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)