### PR TITLE
Fix auto-buy/auto-sell duplicate purchase loop

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -96,7 +96,7 @@ var rootCmd = &cobra.Command{
 		marketPricesUpdater := updaters.NewMarketPrices(marketPricesRepository, esiClient)
 		ccpPricesUpdater := updaters.NewCcpPrices(esiClient, marketPricesRepository)
 		costIndicesUpdater := updaters.NewIndustryCostIndices(esiClient, industryCostIndicesRepository)
-		autoSellUpdater := updaters.NewAutoSell(autoSellContainersRepository, forSaleItemsRepository, marketPricesRepository, stockpileMarkersRepository)
+		autoSellUpdater := updaters.NewAutoSell(autoSellContainersRepository, forSaleItemsRepository, marketPricesRepository, stockpileMarkersRepository, purchaseTransactionsRepository)
 		contactRulesUpdater := updaters.NewContactRules(contactsRepository, contactRulesRepository, contactPermissionsRepository, db)
 
 		// Discord integration (optional — only enabled when DISCORD_BOT_TOKEN is set)
@@ -113,7 +113,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		autoBuyConfigsRepository := repositories.NewAutoBuyConfigs(db)
-		autoBuyUpdater := updaters.NewAutoBuy(autoBuyConfigsRepository, buyOrdersRepository, marketPricesRepository)
+		autoBuyUpdater := updaters.NewAutoBuy(autoBuyConfigsRepository, buyOrdersRepository, marketPricesRepository, purchaseTransactionsRepository)
 		autoFulfillUpdater := updaters.NewAutoFulfill(db, buyOrdersRepository, forSaleItemsRepository, purchaseTransactionsRepository, contactPermissionsRepository, usersRepository, purchaseNotifier)
 
 		piUpdater := updaters.NewPiUpdater(usersRepository, charactersRepository, piPlanetsRepository, esiClient, systemRepository, sdeDataRepository)


### PR DESCRIPTION
## Summary
- Auto-sell now subtracts pending/contract_created purchase quantities from sellable inventory, preventing re-listing items already committed to in-flight purchases
- Auto-buy now subtracts pending purchase quantities from stockpile deficits, preventing inflated buy orders when purchases are already in-flight
- Added `GetPendingQuantitiesForSaleContext` and `GetPendingQuantitiesByBuyer` repository methods

## Test plan
- [x] All existing auto-sell tests pass with new purchase repo dependency
- [x] All existing auto-buy tests pass with new purchase repo dependency
- [x] New test: pending purchases reduce sellable quantity
- [x] New test: pending purchases fully covering quantity deactivates listing
- [x] New test: stockpile + pending purchases combined correctly
- [x] New test: pending purchases reduce buy order deficit
- [x] New test: pending purchases fully covering deficit deactivates order
- [x] New test: purchase repo errors handled gracefully
- [x] `make test-backend` passes (all packages ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)