### PR TITLE
Fix auto-fulfill migration for production data

### DIFF
--- a/internal/database/migrations/20260221113833_widen_auto_fulfill_unique_index.up.sql
+++ b/internal/database/migrations/20260221113833_widen_auto_fulfill_unique_index.up.sql
@@ -6,6 +6,26 @@
 -- a new pending purchase for the same (buy_order_id, for_sale_item_id) pair
 -- once the original moved to 'contract_created'.
 
+-- First, cancel duplicate pending purchases that were created while the
+-- original was already in contract_created status. For each duplicated
+-- (buy_order_id, for_sale_item_id) pair, keep the oldest row and cancel the rest.
+update purchase_transactions
+set status = 'cancelled'
+where id in (
+	select id from (
+		select id,
+			row_number() over (
+				partition by buy_order_id, for_sale_item_id
+				order by purchased_at asc
+			) as rn
+		from purchase_transactions
+		where is_auto_fulfilled = true
+			and status in ('pending', 'contract_created')
+			and buy_order_id is not null
+	) ranked
+	where rn > 1
+);
+
 drop index if exists idx_auto_fulfill_unique;
 
 create unique index idx_auto_fulfill_unique


### PR DESCRIPTION
## Summary
- The migration from PR #55 failed on production because existing duplicate rows violated the new unique constraint
- Adds a deduplication step that cancels newer duplicate `purchase_transactions` (keeping the oldest per `buy_order_id + for_sale_item_id` pair) before creating the widened unique index

## Context
Production had rows where the same `(buy_order_id, for_sale_item_id)` pair existed in both `pending` and `contract_created` status — exactly the duplicates that PR #55's code fix prevents going forward. The migration needs to clean these up first.

## Test plan
- [ ] Verify migration applies cleanly on production (where duplicates exist)
- [ ] Confirm `idx_auto_fulfill_unique` now covers both `pending` and `contract_created` statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)