### PR TITLE
Fix COALESCE text/integer type conflict in corp division query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,10 @@
 1. **Create a feature branch before writing any code.** `git checkout -b feature/{name}` — do this before touching any files. Never commit directly to main.
 2. **Always run tests with Makefile targets** (`make test-e2e-ci`, `make test-backend`, etc.) — never run test commands directly.
 3. **Write tests for every new backend file.** Every new repository, controller, and updater must have a corresponding `_test.go` file. When asked to "write tests," cover all three layers — not just controllers and updaters.
-4. **Create/update feature docs in `docs/features/`** for every new feature or significant change. Use `lowercase-kebab-case.md` naming (e.g., `sde-import.md`, `reactions-calculator.md`).
-5. **Go slices: initialize as `items := []*Type{}` NOT `var items []*Type`.** Prevents nil JSON marshaling (`null` instead of `[]`).
-6. **Do NOT include Discord usernames or other personal attributions in GitHub issues.**
+4. **All changes must have tests.** Every code change — bug fixes, new features, refactors — must include corresponding test coverage. No code changes without tests.
+5. **Create/update feature docs in `docs/features/`** for every new feature or significant change. Use `lowercase-kebab-case.md` naming (e.g., `sde-import.md`, `reactions-calculator.md`).
+6. **Go slices: initialize as `items := []*Type{}` NOT `var items []*Type`.** Prevents nil JSON marshaling (`null` instead of `[]`).
+7. **Do NOT include Discord usernames or other personal attributions in GitHub issues.**
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix `COALESCE types text and integer cannot be matched` error in `GetStockpileDeficitsForConfig` for corporation division queries
- Root cause: `$5` parameter used as both `$5::text` (for `'CorpSAG' || $5::text`) and `$5::integer` (in `COALESCE($5::integer, 0)`), which PostgreSQL can't resolve
- Fix: build the location flag string (`CorpSAG{N}`) in Go and pass it as a separate `$6` text parameter, keeping `$5` purely integer
- Add CLAUDE.md rule requiring tests for all code changes

## Test plan
- [x] Added `Test_AutoBuyConfigsDeficitsCorpDivisionIsolation` — verifies assets in one division don't leak into another division's deficit query
- [x] Added `Test_AutoBuyConfigsDeficitsCorpDivisionMultipleItems` — verifies multiple item types in a single division with correct per-item deficit calculations
- [x] All existing tests pass (`make test-backend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)