### PR TITLE
Add Discord notification to buyer on contract created

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -102,11 +102,13 @@ var rootCmd = &cobra.Command{
 		// Discord integration (optional — only enabled when DISCORD_BOT_TOKEN is set)
 		var discordClient *client.DiscordClient
 		var purchaseNotifier controllers.PurchaseNotifierInterface
+		var contractCreatedNotifier controllers.ContractCreatedNotifierInterface
 		var notificationsUpdater *updaters.NotificationsUpdater
 		if settings.DiscordBotToken != "" {
 			discordClient = client.NewDiscordClient(settings.DiscordBotToken)
 			notificationsUpdater = updaters.NewNotifications(discordNotificationsRepository, discordClient)
 			purchaseNotifier = notificationsUpdater
+			contractCreatedNotifier = notificationsUpdater
 			log.Info("discord notifications enabled")
 		} else {
 			log.Info("discord notifications disabled (no DISCORD_BOT_TOKEN)")
@@ -140,7 +142,7 @@ var rootCmd = &cobra.Command{
 		controllers.NewContacts(router, contactsRepository, contactPermissionsRepository, db)
 		controllers.NewContactPermissions(router, contactPermissionsRepository)
 		controllers.NewForSaleItems(router, forSaleItemsRepository, contactPermissionsRepository)
-		controllers.NewPurchases(router, db, purchaseTransactionsRepository, forSaleItemsRepository, contactPermissionsRepository, usersRepository, purchaseNotifier)
+		controllers.NewPurchases(router, db, purchaseTransactionsRepository, forSaleItemsRepository, contactPermissionsRepository, usersRepository, purchaseNotifier, contractCreatedNotifier)
 		controllers.NewBuyOrders(router, buyOrdersRepository, contactPermissionsRepository, autoFulfillUpdater)
 		controllers.NewItemTypes(router, itemTypesRepository)
 		controllers.NewAnalytics(router, salesAnalyticsRepository)

--- a/docs/features/contract-created-notification.md
+++ b/docs/features/contract-created-notification.md
@@ -1,0 +1,38 @@
+# Contract Created Notification
+
+## Overview
+
+Sends a Discord notification to the **buyer** when a seller marks a purchase as "contract created". This lets buyers know a contract is ready for them to accept in-game without having to manually check the UI.
+
+## Status: Implemented
+
+## Event Type
+
+- **Event key**: `contract_created`
+- **Recipient**: Buyer (`purchase.BuyerUserID`)
+- **Trigger**: Seller calls `POST /v1/purchases/{id}/mark-contract-created`
+
+## Discord Embed
+
+- **Title**: "Contract Created"
+- **Description**: "{SellerName} has created a contract for your purchase"
+- **Color**: #3b82f6 (primary blue)
+- **Fields**: Item, Quantity, Total, Location, Contract Key (if set)
+
+## Key Decisions
+
+1. **Non-blocking**: Notification is sent in a goroutine — never fails the contract creation
+2. **Uses existing infrastructure**: Same Discord notification system as `purchase_created` and `pi_stall`
+3. **Opt-in per target**: Buyers must enable `contract_created` in their notification preferences
+4. **SellerName added to model**: `PurchaseTransaction.SellerName` populated at notification time (not stored in DB)
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `internal/updaters/notifications.go` | `NotifyContractCreated` method + embed builder |
+| `internal/models/models.go` | `SellerName` field on `PurchaseTransaction` |
+| `internal/controllers/purchases.go` | Triggers notification in `MarkContractCreated` |
+| `cmd/industry-tool/cmd/root.go` | Wires `contractCreatedNotifier` |
+| `frontend/packages/components/settings/DiscordSettings.tsx` | `contract_created` event type |
+| `internal/updaters/notifications_test.go` | Unit tests for new notification |

--- a/frontend/packages/components/settings/DiscordSettings.tsx
+++ b/frontend/packages/components/settings/DiscordSettings.tsx
@@ -65,6 +65,7 @@ type Channel = {
 
 const EVENT_TYPES = [
   { value: 'purchase_created', label: 'New Purchase' },
+  { value: 'contract_created', label: 'Contract Created' },
   { value: 'pi_stall', label: 'PI Stall Alert' },
 ];
 

--- a/internal/controllers/purchases_test.go
+++ b/internal/controllers/purchases_test.go
@@ -97,7 +97,7 @@ func Test_PurchaseItem_Success(t *testing.T) {
 
 	// Setup controller
 	purchaseRepo := repositories.NewPurchaseTransactions(db)
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	// Make purchase request
 	reqBody := map[string]interface{}{
@@ -191,7 +191,7 @@ func Test_PurchaseItem_EntireQuantity_MarksInactive(t *testing.T) {
 	assert.NoError(t, forSaleRepo.Upsert(context.Background(), item))
 
 	purchaseRepo := repositories.NewPurchaseTransactions(db)
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	// Purchase entire quantity
 	reqBody := map[string]interface{}{
@@ -255,7 +255,7 @@ func Test_PurchaseItem_NoPermission(t *testing.T) {
 	assert.NoError(t, forSaleRepo.Upsert(context.Background(), item))
 
 	purchaseRepo := repositories.NewPurchaseTransactions(db)
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	reqBody := map[string]interface{}{
 		"forSaleItemId":     item.ID,
@@ -310,7 +310,7 @@ func Test_PurchaseItem_SelfPurchase_Rejected(t *testing.T) {
 	assert.NoError(t, forSaleRepo.Upsert(context.Background(), item))
 
 	purchaseRepo := repositories.NewPurchaseTransactions(db)
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	reqBody := map[string]interface{}{
 		"forSaleItemId":     item.ID,
@@ -387,7 +387,7 @@ func Test_PurchaseItem_QuantityExceeded(t *testing.T) {
 	assert.NoError(t, forSaleRepo.Upsert(context.Background(), item))
 
 	purchaseRepo := repositories.NewPurchaseTransactions(db)
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	reqBody := map[string]interface{}{
 		"forSaleItemId":     item.ID,
@@ -465,7 +465,7 @@ func Test_MarkContractCreated_Success(t *testing.T) {
 	assert.NoError(t, purchaseRepo.Create(context.Background(), tx, purchase))
 	assert.NoError(t, tx.Commit())
 
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	// Mark as contract created
 	contractKey := "PT-4050-30000142-1234567890"
@@ -548,7 +548,7 @@ func Test_CompletePurchase_Success(t *testing.T) {
 	assert.NoError(t, purchaseRepo.Create(context.Background(), tx, purchase))
 	assert.NoError(t, tx.Commit())
 
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/purchases/"+strconv.FormatInt(purchase.ID, 10)+"/complete", nil)
 	args := &web.HandlerArgs{
@@ -622,7 +622,7 @@ func Test_CancelPurchase_RestoresQuantity(t *testing.T) {
 	assert.NoError(t, forSaleRepo.Upsert(context.Background(), item))
 
 	// Make a purchase first
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	reqBody := map[string]interface{}{
 		"forSaleItemId":     item.ID,
@@ -722,7 +722,7 @@ func Test_MarkContractCreated_AutoGeneratesKey(t *testing.T) {
 	assert.NoError(t, purchaseRepo.Create(context.Background(), tx, purchase))
 	assert.NoError(t, tx.Commit())
 
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	// Mark as contract created WITHOUT providing a contractKey (empty body)
 	req := httptest.NewRequest("POST", "/v1/purchases/"+strconv.FormatInt(purchase.ID, 10)+"/mark-contract-created", nil)
@@ -805,7 +805,7 @@ func Test_MarkContractCreated_UsesProvidedKey(t *testing.T) {
 	assert.NoError(t, purchaseRepo.Create(context.Background(), tx, purchase))
 	assert.NoError(t, tx.Commit())
 
-	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil)
+	controller := controllers.NewPurchases(&MockRouter{}, db, purchaseRepo, forSaleRepo, permRepo, userRepo, nil, nil)
 
 	// Mark as contract created WITH a custom contractKey
 	customKey := "CUSTOM-BATCH-99"

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -172,6 +172,7 @@ type PurchaseTransaction struct {
 	BuyerUserID       int64     `json:"buyerUserId"`
 	BuyerName         string    `json:"buyerName"`
 	SellerUserID      int64     `json:"sellerUserId"`
+	SellerName        string    `json:"sellerName"`
 	TypeID            int64     `json:"typeId"`
 	TypeName          string    `json:"typeName"`
 	LocationID        int64     `json:"locationId"`


### PR DESCRIPTION
## Summary
- Buyers receive a Discord notification when a seller marks their purchase as "contract created"
- New `contract_created` event type added to the existing Discord notification system
- Embed includes item name, quantity, total price, location, and contract key
- Non-blocking: notification is sent async and never fails the contract creation

## Test plan
- [x] 3 new unit tests for `NotifyContractCreated` (DM send, no targets, send error)
- [x] All existing controller tests updated for new constructor parameter
- [x] `make test-backend` passes (7 packages)
- [x] `make test-frontend` passes (94 tests, 13 snapshots)
- [ ] Manual: link Discord, enable `contract_created` event, have seller mark contract created, verify DM received

🤖 Generated with [Claude Code](https://claude.com/claude-code)