### PR TITLE
Add corporation contract searching to contract sync

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -194,7 +194,7 @@ var rootCmd = &cobra.Command{
 		})
 
 		// Start contract sync scheduler (15 minutes)
-		contractSyncUpdater := updaters.NewContractSync(purchaseTransactionsRepository, charactersRepository, esiClient)
+		contractSyncUpdater := updaters.NewContractSync(purchaseTransactionsRepository, charactersRepository, playerCorporationRepostiory, esiClient)
 		contractSyncRunner := runners.NewContractSyncRunner(contractSyncUpdater, 15*time.Minute)
 		group.Go(func() error {
 			return contractSyncRunner.Run(ctx)

--- a/docs/features/contract-sync.md
+++ b/docs/features/contract-sync.md
@@ -2,20 +2,19 @@
 
 ## Overview
 
-Automatically detects when an EVE Online contract has been accepted by scanning buyer characters' contracts via ESI. Matches contracts to purchases using the `contract_key` in the contract title, then auto-completes the purchase.
+Automatically detects when an EVE Online contract has been accepted by scanning buyer characters' and corporations' contracts via ESI. Matches contracts to purchases using the `contract_key` in the contract title, then auto-completes the purchase.
 
 The manual "Complete" button remains available as a fallback.
 
 ## Status
 
-- **Phase**: Implementation
-- **Branch**: `feature/contract-sync`
+- **Phase**: Complete
 
 ## How It Works
 
 1. Seller marks purchase as "contract created" → app auto-generates a `contract_key` (e.g., `PT-123`)
 2. Seller copies the key into the EVE in-game contract title when creating the contract
-3. Background runner (every 15 minutes) scans buyer characters' ESI contracts
+3. Background runner (every 15 minutes) scans buyer characters' and corporations' ESI contracts
 4. Finds `finished` item_exchange contracts whose title contains a known `contract_key`
 5. Auto-completes all purchases sharing that key
 
@@ -24,22 +23,26 @@ The manual "Complete" button remains available as a fallback.
 - **Matching via title**: Uses the contract title field from ESI to match against `contract_key`. No need for the contract items sub-endpoint.
 - **Auto-generated keys**: Format `PT-{purchaseID}`. Custom keys still supported for grouping multiple purchases.
 - **Manual fallback**: Buyers can still click "Complete" manually if the seller forgot to include the key.
-- **Scope check**: Only processes characters with `esi-contracts.read_character_contracts.v1` scope.
+- **Character + corporation search**: Searches both character contracts (personal) and corporation contracts. A seller can assign the contract to either the buyer's character or their corporation.
+- **Scope check**: Only processes characters with `esi-contracts.read_character_contracts.v1` and corporations with `esi-contracts.read_corporation_contracts.v1`.
 - **15-minute interval**: Balances responsiveness with ESI rate limits.
 
 ## File Structure
 
 | File | Purpose |
 |------|---------|
-| `internal/client/esiClient.go` | `GetCharacterContracts` + `EsiContract` type |
+| `internal/client/esiClient.go` | `GetCharacterContracts`, `GetCorporationContracts` + `EsiContract` type |
 | `internal/controllers/purchases.go` | Auto-generate `contract_key` in `MarkContractCreated` |
 | `internal/repositories/purchaseTransactions.go` | `GetContractCreatedWithKeys`, `CompleteWithContractID` |
-| `internal/updaters/contractSync.go` | Matching logic + auto-completion |
-| `internal/updaters/contractSync_test.go` | Unit tests |
+| `internal/repositories/playerCorporations.go` | `Get` (fetch corps for user), `UpdateTokens` |
+| `internal/updaters/contractSync.go` | Matching logic + auto-completion for characters and corporations |
+| `internal/updaters/contractSync_test.go` | Unit tests (13 tests: 8 character, 5 corporation) |
 | `internal/runners/contractSync.go` | Background runner |
 | `cmd/industry-tool/cmd/root.go` | Wiring |
 
 ## ESI Endpoints Used
 
-- `GET /v1/characters/{character_id}/contracts/` — paginated contract list
-- Scope: `esi-contracts.read_character_contracts.v1` (already in player scopes)
+- `GET /v1/characters/{character_id}/contracts/` — paginated character contract list
+  - Scope: `esi-contracts.read_character_contracts.v1`
+- `GET /v1/corporations/{corporation_id}/contracts/` — paginated corporation contract list
+  - Scope: `esi-contracts.read_corporation_contracts.v1`


### PR DESCRIPTION
## Summary
- Contract sync now searches **both character and corporation** ESI contracts when matching `contract_key` in purchase transactions
- Previously only character contracts were searched, so contracts assigned to a buyer's corporation were never matched
- Added `GetCorporationContracts` to ESI client, new `ContractSyncCorporationRepository` interface, and extended `syncBuyer()` to iterate corporations

## Test plan
- [x] All 13 contract sync updater tests pass (8 existing + 5 new corporation tests)
- [x] 2 new ESI client tests for `GetCorporationContracts`
- [x] `make test-backend` passes with all packages green
- [ ] Manual: Buyer has a corporation → seller creates contract to corp → contract sync finds it and auto-completes the purchase

🤖 Generated with [Claude Code](https://claude.com/claude-code)