### PR TITLE
Filter market prices to Jita 4-4 station only

### DIFF
--- a/internal/updaters/marketPrices.go
+++ b/internal/updaters/marketPrices.go
@@ -12,6 +12,7 @@ import (
 )
 
 const JitaRegionID = 10000002
+const JitaStationID = 60003760
 const UpdateInterval = 6 * time.Hour
 
 type MarketPricesRepository interface {
@@ -78,9 +79,12 @@ func (u *MarketPrices) UpdateJitaMarket(ctx context.Context) error {
 		return errors.Wrap(err, "failed to fetch market orders from ESI")
 	}
 
-	// Group orders by type_id
+	// Group orders by type_id, filtering to Jita 4-4 station only
 	ordersByType := make(map[int64][]*client.MarketOrder)
 	for _, order := range orders {
+		if order.LocationID != JitaStationID {
+			continue
+		}
 		ordersByType[order.TypeID] = append(ordersByType[order.TypeID], order)
 	}
 


### PR DESCRIPTION
## Summary
- Filters ESI market orders to only include Jita IV - Moon 4 - Caldari Navy Assembly Plant (station 60003760) when calculating best bid/ask prices
- Previously used all orders across the entire Forge region, which included Perimeter and citadel orders causing prices to differ from Janice

## Test plan
- [x] Existing tests updated with `LocationID: 60003760` on all mock orders
- [x] New test `FiltersNonJitaOrders` verifies Perimeter and citadel orders are excluded
- [x] `make test-backend` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)