### PR TITLE
Add Industry Job Manager (Phase 1)

### DIFF
--- a/cmd/industry-tool/cmd/settings.go
+++ b/cmd/industry-tool/cmd/settings.go
@@ -21,7 +21,9 @@ type Settings struct {
 	DiscordBotToken        string
 	DiscordClientID        string
 	DiscordClientSecret    string
-	PiUpdateIntervalSec    int
+	PiUpdateIntervalSec              int
+	SkillsUpdateIntervalSec          int
+	IndustryJobsUpdateIntervalSec    int
 }
 
 func GetSettings() (*Settings, error) {
@@ -80,6 +82,24 @@ func GetSettings() (*Settings, error) {
 		}
 	} else {
 		settings.PiUpdateIntervalSec = 3600
+	}
+
+	if s := os.Getenv("SKILLS_UPDATE_INTERVAL_SEC"); s != "" {
+		settings.SkillsUpdateIntervalSec, err = strconv.Atoi(s)
+		if err != nil {
+			return nil, errors.Wrapf(err, "SKILLS_UPDATE_INTERVAL_SEC '%s' is not a number", s)
+		}
+	} else {
+		settings.SkillsUpdateIntervalSec = 21600 // 6 hours
+	}
+
+	if s := os.Getenv("INDUSTRY_JOBS_UPDATE_INTERVAL_SEC"); s != "" {
+		settings.IndustryJobsUpdateIntervalSec, err = strconv.Atoi(s)
+		if err != nil {
+			return nil, errors.Wrapf(err, "INDUSTRY_JOBS_UPDATE_INTERVAL_SEC '%s' is not a number", s)
+		}
+	} else {
+		settings.IndustryJobsUpdateIntervalSec = 600 // 10 minutes
 	}
 
 	return settings, nil

--- a/docs/features/industry-job-manager.md
+++ b/docs/features/industry-job-manager.md
@@ -1,0 +1,181 @@
+# Industry Job Manager — Phase 1
+
+## Overview
+
+Track and manage EVE Online industry jobs (manufacturing, reactions, invention) across all characters. Phase 1 provides character skills syncing, ESI industry job tracking, a manufacturing cost calculator, and a job queue with automatic matching to ESI jobs.
+
+## Status
+
+- **Phase 1**: In progress
+- **Phase 2** (planned): Stockpile integration — mark markers as "production sourced", auto-generate queue entries from stockpile deficits
+- **Phase 3** (planned): Multi-alt parallel planning with skill-based character assignment
+- **Phase 4** (planned): Blueprint auto-detection via `GET /characters/{id}/blueprints/`
+
+---
+
+## How It Works
+
+### Data Flow
+
+```
+ESI API                     Background Runners              Database
+────────                    ──────────────────              ────────
+/characters/{id}/skills  →  CharacterSkillsRunner (6h)   →  character_skills
+/characters/{id}/industry/jobs → IndustryJobsRunner (10m) → esi_industry_jobs
+                                     ↓
+                              Queue Matching
+                              (planned → active → completed)
+                                     ↓
+                              industry_job_queue
+
+Frontend                    Backend Controller              Database
+────────                    ──────────────────              ────────
+/industry page           →  GET /v1/industry/jobs         →  esi_industry_jobs
+                            GET /v1/industry/queue         →  industry_job_queue
+                            POST /v1/industry/queue        →  (create planned job)
+                            POST /v1/industry/calculate    →  (manufacturing calc)
+                            GET /v1/industry/blueprints    →  sde_blueprint_*
+                            GET /v1/industry/systems       →  industry_cost_indices
+```
+
+### Background Runners
+
+| Runner | Interval | Default | Env Var | Description |
+|--------|----------|---------|---------|-------------|
+| Character Skills | 6h | 21600s | `SKILLS_UPDATE_INTERVAL_SEC` | Sync character skills from ESI |
+| Industry Jobs | 10m | 600s | `INDUSTRY_JOBS_UPDATE_INTERVAL_SEC` | Sync ESI jobs + queue matching |
+
+### Queue Matching Logic
+
+The industry jobs runner matches planned queue entries to active ESI jobs:
+1. Get `planned` queue entries for user
+2. Get `active` ESI jobs for user
+3. Match by `(blueprint_type_id, activity, runs)` where `esi.start_date > queue.created_at`
+4. Link match: set `queue.esi_job_id`, status → `active`
+5. For already-linked entries: if ESI job `status = 'delivered'`, mark queue → `completed`
+
+Activity ID mapping: manufacturing=1, TE research=3, ME research=4, copying=5, invention=8, reaction=9
+
+---
+
+## Key Decisions
+
+- **ME/TE are user-provided** — ESI industry jobs endpoint doesn't return blueprint ME/TE. Phase 1 uses manual input; blueprint auto-detection in Phase 4.
+- **ESI auth pattern** — Token refresh in updater, pass `token string` to ESI client methods (same as PI pattern).
+- **Manufacturing calculator** — Reuses exported helpers from reactions calculator (`ComputeBatchQty`, `GetPrice`, rig/security multipliers).
+- **Structure TE** — Engineering complexes (Raitaru/Azbel/Sotiyo) provide 1% TE bonus for manufacturing (vs 25% for Tatara reactions).
+
+### Manufacturing Formulas
+
+```
+ME Factor = (1 - blueprint_me/100) * (1 - rig_me * security_mult)
+TE Factor = (1 - blueprint_te/100) * (1 - industry*0.04) * (1 - adv_industry*0.03) * (1 - structure_te) * (1 - rig_te * sec_mult)
+Job Cost  = EIV * (cost_index + SCC_surcharge_0.04 + facility_tax/100)
+```
+
+---
+
+## Database Schema
+
+### character_skills
+
+| Column | Type | Description |
+|--------|------|-------------|
+| character_id | bigint | PK (with skill_id) |
+| user_id | bigint | Owning user |
+| skill_id | bigint | PK (with character_id) |
+| trained_level | int | 0-5 |
+| active_level | int | 0-5 |
+| skillpoints | bigint | SP in skill |
+| updated_at | timestamptz | Last sync |
+
+### esi_industry_jobs
+
+| Column | Type | Description |
+|--------|------|-------------|
+| job_id | bigint | PK (ESI job ID) |
+| installer_id | bigint | Character who installed |
+| user_id | bigint | Owning user |
+| activity_id | int | 1=mfg, 3=TE, 4=ME, 5=copy, 8=inv, 9=react |
+| blueprint_type_id | bigint | Blueprint type |
+| runs | int | Number of runs |
+| cost | float8 | Job install cost |
+| status | text | active/paused/ready/delivered/cancelled |
+| duration | int | Seconds |
+| start_date | timestamptz | Job start |
+| end_date | timestamptz | Expected completion |
+
+### industry_job_queue
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | bigserial | PK |
+| user_id | bigint | Owning user |
+| blueprint_type_id | bigint | Blueprint type |
+| activity | text | manufacturing/reaction/invention/copying |
+| runs | int | Number of runs |
+| me_level | int | Blueprint ME (0-10) |
+| te_level | int | Blueprint TE (0-20) |
+| status | text | planned/active/completed/cancelled |
+| esi_job_id | bigint | Linked ESI job (when active) |
+| estimated_cost | float8 | Calculated total cost |
+| estimated_duration | int | Calculated duration (seconds) |
+
+---
+
+## API Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/v1/industry/jobs` | User | Active ESI jobs (enriched with names) |
+| GET | `/v1/industry/jobs/all` | User | All ESI jobs including completed |
+| GET | `/v1/industry/queue` | User | Job queue entries |
+| POST | `/v1/industry/queue` | User | Create planned job (calculates cost) |
+| PUT | `/v1/industry/queue/{id}` | User | Update planned job |
+| DELETE | `/v1/industry/queue/{id}` | User | Cancel planned/active job |
+| POST | `/v1/industry/calculate` | Backend | Calculate manufacturing cost |
+| GET | `/v1/industry/blueprints` | Backend | Search blueprints by name |
+| GET | `/v1/industry/systems` | Backend | Systems with manufacturing cost indices |
+
+---
+
+## File Structure
+
+### Backend
+
+| File | Purpose |
+|------|---------|
+| `internal/repositories/characterSkills.go` | Character skills CRUD |
+| `internal/repositories/industryJobs.go` | ESI industry jobs CRUD |
+| `internal/repositories/jobQueue.go` | Job queue CRUD |
+| `internal/repositories/sdeData.go` | Manufacturing blueprint/material/system queries (additions) |
+| `internal/calculator/manufacturing.go` | Manufacturing ME/TE/cost calculations |
+| `internal/updaters/characterSkills.go` | Skills sync from ESI |
+| `internal/updaters/industryJobs.go` | Jobs sync + queue matching |
+| `internal/runners/characterSkills.go` | Skills background runner |
+| `internal/runners/industryJobs.go` | Jobs background runner |
+| `internal/controllers/industry.go` | HTTP handlers |
+
+### Frontend
+
+| File | Purpose |
+|------|---------|
+| `pages/industry.tsx` | Page router entry |
+| `packages/pages/industry.tsx` | Main page with 3 tabs |
+| `packages/components/industry/ActiveJobs.tsx` | ESI jobs table |
+| `packages/components/industry/JobQueue.tsx` | Queue table with cancel action |
+| `packages/components/industry/AddJob.tsx` | Form: blueprint search, calculate, add to queue |
+| `pages/api/industry/jobs.ts` | Proxy GET → jobs/queue endpoints |
+| `pages/api/industry/queue.ts` | Proxy GET/POST → queue endpoint |
+| `pages/api/industry/queue/[id].ts` | Proxy PUT/DELETE → queue entry |
+| `pages/api/industry/calculate.ts` | Proxy POST → calculate endpoint |
+| `pages/api/industry/blueprints.ts` | Proxy GET → blueprint search |
+| `pages/api/industry/systems.ts` | Proxy GET → systems endpoint |
+
+### Migrations
+
+| File | Purpose |
+|------|---------|
+| `20260222014855_create_character_skills.up.sql` | Create character_skills table |
+| `20260222014858_create_esi_industry_jobs.up.sql` | Create esi_industry_jobs table |
+| `20260222014858_create_industry_job_queue.up.sql` | Create industry_job_queue table |

--- a/frontend/packages/client/data/models.ts
+++ b/frontend/packages/client/data/models.ts
@@ -353,3 +353,102 @@ export type SupplyChainItem = {
 export type SupplyChainResponse = {
   items: SupplyChainItem[];
 };
+
+// Industry Job Manager Types
+
+export type IndustryJob = {
+  jobId: number;
+  installerId: number;
+  userId: number;
+  facilityId: number;
+  stationId: number;
+  activityId: number;
+  blueprintId: number;
+  blueprintTypeId: number;
+  blueprintLocationId: number;
+  outputLocationId: number;
+  runs: number;
+  cost?: number;
+  licensedRuns?: number;
+  probability?: number;
+  productTypeId?: number;
+  status: string;
+  duration: number;
+  startDate: string;
+  endDate: string;
+  pauseDate?: string;
+  completedDate?: string;
+  completedCharacterId?: number;
+  successfulRuns?: number;
+  solarSystemId?: number;
+  source: string;
+  updatedAt: string;
+  blueprintName?: string;
+  productName?: string;
+  installerName?: string;
+  systemName?: string;
+  activityName?: string;
+};
+
+export type IndustryJobQueueEntry = {
+  id: number;
+  userId: number;
+  characterId?: number;
+  blueprintTypeId: number;
+  activity: string;
+  runs: number;
+  meLevel: number;
+  teLevel: number;
+  systemId?: number;
+  facilityTax: number;
+  status: string;
+  esiJobId?: number;
+  productTypeId?: number;
+  estimatedCost?: number;
+  estimatedDuration?: number;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+  blueprintName?: string;
+  productName?: string;
+  characterName?: string;
+  systemName?: string;
+  esiJobEndDate?: string;
+  esiJobSource?: string;
+};
+
+export type ManufacturingCalcResult = {
+  blueprintTypeId: number;
+  productTypeId: number;
+  productName: string;
+  runs: number;
+  meFactor: number;
+  teFactor: number;
+  secsPerRun: number;
+  totalDuration: number;
+  totalProducts: number;
+  inputCost: number;
+  jobCost: number;
+  totalCost: number;
+  outputValue: number;
+  profit: number;
+  margin: number;
+  materials: ManufacturingMaterial[];
+};
+
+export type ManufacturingMaterial = {
+  typeId: number;
+  name: string;
+  baseQty: number;
+  batchQty: number;
+  price: number;
+  cost: number;
+};
+
+export type BlueprintSearchResult = {
+  BlueprintTypeID: number;
+  BlueprintName: string;
+  ProductTypeID: number;
+  ProductName: string;
+  Activity: string;
+};

--- a/frontend/packages/components/Navbar.tsx
+++ b/frontend/packages/components/Navbar.tsx
@@ -96,6 +96,9 @@ export default function Navbar() {
           <Button color="inherit" href="/reactions">
             Reactions
           </Button>
+          <Button color="inherit" href="/industry">
+            Industry
+          </Button>
           <Button color="inherit" href="/pi">
             Planets
           </Button>

--- a/frontend/packages/components/__tests__/__snapshots__/Navbar.test.tsx.snap
+++ b/frontend/packages/components/__tests__/__snapshots__/Navbar.test.tsx.snap
@@ -90,6 +90,13 @@ exports[`Navbar Component should match snapshot when not authenticated 1`] = `
       </a>
       <a
         class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-plnrbk-MuiButtonBase-root-MuiButton-root"
+        href="/industry"
+        tabindex="0"
+      >
+        Industry
+      </a>
+      <a
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-plnrbk-MuiButtonBase-root-MuiButton-root"
         href="/pi"
         tabindex="0"
       >

--- a/frontend/packages/components/industry/ActiveJobs.tsx
+++ b/frontend/packages/components/industry/ActiveJobs.tsx
@@ -1,0 +1,177 @@
+import { IndustryJob } from "@industry-tool/client/data/models";
+import { formatISK, formatNumber } from "@industry-tool/utils/formatting";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+import CircularProgress from "@mui/material/CircularProgress";
+import Tooltip from "@mui/material/Tooltip";
+import PersonIcon from "@mui/icons-material/Person";
+import CorporateFareIcon from "@mui/icons-material/CorporateFare";
+
+type Props = {
+  jobs: IndustryJob[];
+  loading: boolean;
+};
+
+function getStatusColor(status: string): "success" | "warning" | "info" | "error" | "default" {
+  switch (status) {
+    case "active": return "success";
+    case "ready": return "info";
+    case "paused": return "warning";
+    case "delivered": return "default";
+    case "cancelled": return "error";
+    default: return "default";
+  }
+}
+
+function formatTimeRemaining(endDate: string): string {
+  const end = new Date(endDate);
+  const now = new Date();
+  const diff = end.getTime() - now.getTime();
+
+  if (diff <= 0) return "Ready";
+
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+
+  if (hours > 24) {
+    const days = Math.floor(hours / 24);
+    const remHours = hours % 24;
+    return `${days}d ${remHours}h`;
+  }
+
+  return `${hours}h ${minutes}m`;
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 24) {
+    const days = Math.floor(hours / 24);
+    const remHours = hours % 24;
+    return `${days}d ${remHours}h`;
+  }
+
+  return `${hours}h ${minutes}m`;
+}
+
+export default function ActiveJobs({ jobs, loading }: Props) {
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ backgroundColor: "#0f1219" }}>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="center">Source</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Blueprint</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Product</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Activity</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Runs</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Character</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Status</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Time Left</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Duration</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Cost</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>System</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {jobs.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={11} align="center" sx={{ py: 4, color: "#64748b" }}>
+                No active industry jobs
+              </TableCell>
+            </TableRow>
+          ) : (
+            jobs.map((job) => (
+              <TableRow
+                key={job.jobId}
+                sx={{
+                  "&:nth-of-type(odd)": { backgroundColor: "#0d1117" },
+                  "&:nth-of-type(even)": { backgroundColor: "#12151f" },
+                }}
+              >
+                <TableCell align="center">
+                  <Tooltip title={job.source === "corporation" ? "Corporation Job" : "Character Job"}>
+                    {job.source === "corporation" ? (
+                      <CorporateFareIcon sx={{ color: "#f59e0b", fontSize: 18 }} />
+                    ) : (
+                      <PersonIcon sx={{ color: "#94a3b8", fontSize: 18 }} />
+                    )}
+                  </Tooltip>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#e2e8f0" }}>
+                    {job.blueprintName || `Type ${job.blueprintTypeId}`}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
+                    {job.productName || "-"}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
+                    {job.activityName || `Activity ${job.activityId}`}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  <Typography variant="body2" sx={{ color: "#e2e8f0" }}>
+                    {formatNumber(job.runs)}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                    {job.installerName || "-"}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    label={job.status}
+                    color={getStatusColor(job.status)}
+                    size="small"
+                    variant="outlined"
+                  />
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: job.status === "active" ? "#3b82f6" : "#94a3b8" }}>
+                    {formatTimeRemaining(job.endDate)}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                    {formatDuration(job.duration)}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
+                    {job.cost ? formatISK(job.cost) : "-"}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                    {job.systemName || "-"}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/frontend/packages/components/industry/AddJob.tsx
+++ b/frontend/packages/components/industry/AddJob.tsx
@@ -1,0 +1,411 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  BlueprintSearchResult,
+  ManufacturingCalcResult,
+  ReactionSystem,
+} from "@industry-tool/client/data/models";
+import { formatISK, formatNumber, formatDuration } from "@industry-tool/utils/formatting";
+import Autocomplete from "@mui/material/Autocomplete";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import Paper from "@mui/material/Paper";
+import AddIcon from "@mui/icons-material/Add";
+
+type Props = {
+  onJobAdded: () => void;
+};
+
+export default function AddJob({ onJobAdded }: Props) {
+  const [blueprintQuery, setBlueprintQuery] = useState("");
+  const [blueprintOptions, setBlueprintOptions] = useState<BlueprintSearchResult[]>([]);
+  const [selectedBlueprint, setSelectedBlueprint] = useState<BlueprintSearchResult | null>(null);
+  const [searchLoading, setSearchLoading] = useState(false);
+
+  const [activity, setActivity] = useState("manufacturing");
+  const [runs, setRuns] = useState(1);
+  const [meLevel, setMeLevel] = useState(10);
+  const [teLevel, setTeLevel] = useState(20);
+  const [industrySkill, setIndustrySkill] = useState(5);
+  const [advIndustrySkill, setAdvIndustrySkill] = useState(5);
+  const [structure, setStructure] = useState("raitaru");
+  const [rig, setRig] = useState("t2");
+  const [security, setSecurity] = useState("high");
+  const [facilityTax, setFacilityTax] = useState(1.0);
+  const [systemId, setSystemId] = useState<number>(0);
+  const [notes, setNotes] = useState("");
+
+  const [systems, setSystems] = useState<ReactionSystem[]>([]);
+  const [calcResult, setCalcResult] = useState<ManufacturingCalcResult | null>(null);
+  const [calcLoading, setCalcLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Fetch systems
+  useEffect(() => {
+    fetch("/api/industry/systems")
+      .then((res) => res.json())
+      .then((data) => setSystems(data))
+      .catch((err) => console.error("Failed to fetch systems:", err));
+  }, []);
+
+  // Search blueprints
+  useEffect(() => {
+    if (blueprintQuery.length < 2) {
+      setBlueprintOptions([]);
+      return;
+    }
+
+    const timeout = setTimeout(async () => {
+      setSearchLoading(true);
+      try {
+        const params = new URLSearchParams({ q: blueprintQuery, activity, limit: "20" });
+        const res = await fetch(`/api/industry/blueprints?${params.toString()}`);
+        const data = await res.json();
+        setBlueprintOptions(data || []);
+      } catch (err) {
+        console.error("Failed to search blueprints:", err);
+      } finally {
+        setSearchLoading(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timeout);
+  }, [blueprintQuery, activity]);
+
+  // Calculate cost
+  const calculate = useCallback(async () => {
+    if (!selectedBlueprint || runs <= 0) {
+      setCalcResult(null);
+      return;
+    }
+
+    if (activity !== "manufacturing") {
+      setCalcResult(null);
+      return;
+    }
+
+    setCalcLoading(true);
+    try {
+      const res = await fetch("/api/industry/calculate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          blueprint_type_id: selectedBlueprint.BlueprintTypeID,
+          runs,
+          me_level: meLevel,
+          te_level: teLevel,
+          industry_skill: industrySkill,
+          adv_industry_skill: advIndustrySkill,
+          system_id: systemId || undefined,
+          facility_tax: facilityTax,
+          structure,
+          rig,
+          security,
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setCalcResult(data);
+      }
+    } catch (err) {
+      console.error("Failed to calculate:", err);
+    } finally {
+      setCalcLoading(false);
+    }
+  }, [selectedBlueprint, runs, meLevel, teLevel, industrySkill, advIndustrySkill, systemId, facilityTax, structure, rig, security, activity]);
+
+  useEffect(() => {
+    calculate();
+  }, [calculate]);
+
+  const handleSubmit = async () => {
+    if (!selectedBlueprint || runs <= 0) return;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/industry/queue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          blueprint_type_id: selectedBlueprint.BlueprintTypeID,
+          activity,
+          runs,
+          me_level: meLevel,
+          te_level: teLevel,
+          industry_skill: industrySkill,
+          adv_industry_skill: advIndustrySkill,
+          system_id: systemId || undefined,
+          facility_tax: facilityTax,
+          structure,
+          rig,
+          security,
+          product_type_id: selectedBlueprint.ProductTypeID,
+          notes: notes || undefined,
+        }),
+      });
+
+      if (res.ok) {
+        setSelectedBlueprint(null);
+        setBlueprintQuery("");
+        setNotes("");
+        setCalcResult(null);
+        onJobAdded();
+      }
+    } catch (err) {
+      console.error("Failed to add job:", err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box>
+      {/* Settings Row */}
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mb: 3 }}>
+        <Autocomplete
+          sx={{ minWidth: 300, flexGrow: 1 }}
+          options={blueprintOptions}
+          getOptionLabel={(opt) => opt.ProductName || opt.BlueprintName}
+          value={selectedBlueprint}
+          onChange={(_, value) => setSelectedBlueprint(value)}
+          inputValue={blueprintQuery}
+          onInputChange={(_, value) => setBlueprintQuery(value)}
+          loading={searchLoading}
+          renderInput={(params) => (
+            <TextField {...params} label="Search Blueprint" size="small" />
+          )}
+          renderOption={(props, option) => (
+            <li {...props} key={option.BlueprintTypeID}>
+              <Box>
+                <Typography variant="body2">{option.ProductName}</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {option.BlueprintName} - {option.Activity}
+                </Typography>
+              </Box>
+            </li>
+          )}
+          isOptionEqualToValue={(opt, val) => opt.BlueprintTypeID === val.BlueprintTypeID}
+        />
+
+        <FormControl size="small" sx={{ minWidth: 150 }}>
+          <InputLabel>Activity</InputLabel>
+          <Select value={activity} onChange={(e) => setActivity(e.target.value)} label="Activity">
+            <MenuItem value="manufacturing">Manufacturing</MenuItem>
+            <MenuItem value="reaction">Reaction</MenuItem>
+            <MenuItem value="invention">Invention</MenuItem>
+            <MenuItem value="copying">Copying</MenuItem>
+          </Select>
+        </FormControl>
+
+        <TextField
+          label="Runs"
+          type="number"
+          size="small"
+          value={runs}
+          onChange={(e) => setRuns(Math.max(1, parseInt(e.target.value) || 1))}
+          sx={{ width: 100 }}
+        />
+      </Box>
+
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mb: 3 }}>
+        <TextField
+          label="ME Level"
+          type="number"
+          size="small"
+          value={meLevel}
+          onChange={(e) => setMeLevel(Math.max(0, Math.min(10, parseInt(e.target.value) || 0)))}
+          sx={{ width: 90 }}
+          inputProps={{ min: 0, max: 10 }}
+        />
+        <TextField
+          label="TE Level"
+          type="number"
+          size="small"
+          value={teLevel}
+          onChange={(e) => setTeLevel(Math.max(0, Math.min(20, parseInt(e.target.value) || 0)))}
+          sx={{ width: 90 }}
+          inputProps={{ min: 0, max: 20 }}
+        />
+        <TextField
+          label="Industry Skill"
+          type="number"
+          size="small"
+          value={industrySkill}
+          onChange={(e) => setIndustrySkill(Math.max(0, Math.min(5, parseInt(e.target.value) || 0)))}
+          sx={{ width: 120 }}
+          inputProps={{ min: 0, max: 5 }}
+        />
+        <TextField
+          label="Adv Industry"
+          type="number"
+          size="small"
+          value={advIndustrySkill}
+          onChange={(e) => setAdvIndustrySkill(Math.max(0, Math.min(5, parseInt(e.target.value) || 0)))}
+          sx={{ width: 120 }}
+          inputProps={{ min: 0, max: 5 }}
+        />
+
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel>Structure</InputLabel>
+          <Select value={structure} onChange={(e) => setStructure(e.target.value)} label="Structure">
+            <MenuItem value="station">NPC Station</MenuItem>
+            <MenuItem value="raitaru">Raitaru</MenuItem>
+            <MenuItem value="azbel">Azbel</MenuItem>
+            <MenuItem value="sotiyo">Sotiyo</MenuItem>
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" sx={{ minWidth: 90 }}>
+          <InputLabel>Rig</InputLabel>
+          <Select value={rig} onChange={(e) => setRig(e.target.value)} label="Rig">
+            <MenuItem value="none">None</MenuItem>
+            <MenuItem value="t1">T1</MenuItem>
+            <MenuItem value="t2">T2</MenuItem>
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" sx={{ minWidth: 100 }}>
+          <InputLabel>Security</InputLabel>
+          <Select value={security} onChange={(e) => setSecurity(e.target.value)} label="Security">
+            <MenuItem value="high">Highsec</MenuItem>
+            <MenuItem value="low">Lowsec</MenuItem>
+            <MenuItem value="null">Nullsec</MenuItem>
+          </Select>
+        </FormControl>
+
+        <TextField
+          label="Facility Tax %"
+          type="number"
+          size="small"
+          value={facilityTax}
+          onChange={(e) => setFacilityTax(parseFloat(e.target.value) || 0)}
+          sx={{ width: 120 }}
+        />
+      </Box>
+
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mb: 3, alignItems: "center" }}>
+        <Autocomplete
+          sx={{ minWidth: 250 }}
+          options={systems}
+          getOptionLabel={(opt) => `${opt.name} (${(opt.cost_index * 100).toFixed(2)}%)`}
+          value={systems.find((s) => s.system_id === systemId) || null}
+          onChange={(_, value) => setSystemId(value?.system_id || 0)}
+          renderInput={(params) => (
+            <TextField {...params} label="System (optional)" size="small" />
+          )}
+          isOptionEqualToValue={(opt, val) => opt.system_id === val.system_id}
+        />
+
+        <TextField
+          label="Notes"
+          size="small"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          sx={{ flexGrow: 1, minWidth: 200 }}
+        />
+
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!selectedBlueprint || runs <= 0 || submitting}
+          startIcon={submitting ? <CircularProgress size={16} /> : <AddIcon />}
+          sx={{ height: 40 }}
+        >
+          Add to Queue
+        </Button>
+      </Box>
+
+      {/* Calculation Result */}
+      {calcLoading && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress size={24} />
+        </Box>
+      )}
+
+      {calcResult && !calcLoading && (
+        <Paper sx={{ backgroundColor: "#12151f", p: 2 }}>
+          <Typography variant="subtitle2" sx={{ color: "#3b82f6", mb: 1 }}>
+            Cost Estimate: {calcResult.productName} x{formatNumber(calcResult.totalProducts)}
+          </Typography>
+          <Box sx={{ display: "flex", gap: 4, flexWrap: "wrap", mb: 2 }}>
+            <Box>
+              <Typography variant="caption" sx={{ color: "#64748b" }}>Input Cost</Typography>
+              <Typography variant="body2" sx={{ color: "#e2e8f0" }}>{formatISK(calcResult.inputCost)}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" sx={{ color: "#64748b" }}>Job Cost</Typography>
+              <Typography variant="body2" sx={{ color: "#e2e8f0" }}>{formatISK(calcResult.jobCost)}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" sx={{ color: "#64748b" }}>Total Cost</Typography>
+              <Typography variant="body2" sx={{ color: "#e2e8f0", fontWeight: 600 }}>{formatISK(calcResult.totalCost)}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" sx={{ color: "#64748b" }}>Output Value</Typography>
+              <Typography variant="body2" sx={{ color: "#e2e8f0" }}>{formatISK(calcResult.outputValue)}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" sx={{ color: "#64748b" }}>Profit</Typography>
+              <Typography variant="body2" sx={{ color: calcResult.profit >= 0 ? "#10b981" : "#ef4444" }}>
+                {formatISK(calcResult.profit)}
+              </Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" sx={{ color: "#64748b" }}>Margin</Typography>
+              <Typography variant="body2" sx={{ color: calcResult.margin >= 0 ? "#10b981" : "#ef4444" }}>
+                {calcResult.margin.toFixed(1)}%
+              </Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" sx={{ color: "#64748b" }}>Per Run</Typography>
+              <Typography variant="body2" sx={{ color: "#e2e8f0" }}>{formatDuration(calcResult.secsPerRun)}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" sx={{ color: "#64748b" }}>Total Time</Typography>
+              <Typography variant="body2" sx={{ color: "#e2e8f0" }}>{formatDuration(calcResult.totalDuration)}</Typography>
+            </Box>
+          </Box>
+
+          {calcResult.materials.length > 0 && (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow sx={{ backgroundColor: "#0f1219" }}>
+                    <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Material</TableCell>
+                    <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Base Qty</TableCell>
+                    <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Required</TableCell>
+                    <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Price</TableCell>
+                    <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Cost</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {calcResult.materials.map((mat) => (
+                    <TableRow key={mat.typeId}>
+                      <TableCell sx={{ color: "#e2e8f0" }}>{mat.name}</TableCell>
+                      <TableCell align="right" sx={{ color: "#94a3b8" }}>{formatNumber(mat.baseQty)}</TableCell>
+                      <TableCell align="right" sx={{ color: "#e2e8f0" }}>{formatNumber(mat.batchQty)}</TableCell>
+                      <TableCell align="right" sx={{ color: "#94a3b8" }}>{formatISK(mat.price)}</TableCell>
+                      <TableCell align="right" sx={{ color: "#cbd5e1" }}>{formatISK(mat.cost)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Paper>
+      )}
+    </Box>
+  );
+}

--- a/frontend/packages/components/industry/JobQueue.tsx
+++ b/frontend/packages/components/industry/JobQueue.tsx
@@ -1,0 +1,223 @@
+import { IndustryJobQueueEntry } from "@industry-tool/client/data/models";
+import { formatISK, formatNumber } from "@industry-tool/utils/formatting";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import IconButton from "@mui/material/IconButton";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+import CircularProgress from "@mui/material/CircularProgress";
+import CancelIcon from "@mui/icons-material/Cancel";
+import Tooltip from "@mui/material/Tooltip";
+import PersonIcon from "@mui/icons-material/Person";
+import CorporateFareIcon from "@mui/icons-material/CorporateFare";
+
+type Props = {
+  entries: IndustryJobQueueEntry[];
+  loading: boolean;
+  onCancel: (id: number) => void;
+};
+
+function getStatusColor(status: string): "success" | "warning" | "info" | "error" | "default" {
+  switch (status) {
+    case "planned": return "info";
+    case "active": return "success";
+    case "completed": return "default";
+    case "cancelled": return "error";
+    default: return "default";
+  }
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 24) {
+    const days = Math.floor(hours / 24);
+    const remHours = hours % 24;
+    return `${days}d ${remHours}h`;
+  }
+
+  return `${hours}h ${minutes}m`;
+}
+
+function formatTimeRemaining(endDateStr: string): string {
+  const end = new Date(endDateStr);
+  const now = new Date();
+  const diffMs = end.getTime() - now.getTime();
+
+  if (diffMs <= 0) return "Ready";
+
+  const totalSecs = Math.floor(diffMs / 1000);
+  const days = Math.floor(totalSecs / 86400);
+  const hours = Math.floor((totalSecs % 86400) / 3600);
+  const minutes = Math.floor((totalSecs % 3600) / 60);
+  const seconds = totalSecs % 60;
+
+  const pad = (n: number) => n.toString().padStart(2, "0");
+
+  if (days > 0) {
+    return `${days}D ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+  }
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+function formatEndDate(endDateStr: string): string {
+  const d = new Date(endDateStr);
+  const year = d.getUTCFullYear();
+  const month = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  const day = d.getUTCDate().toString().padStart(2, "0");
+  const hours = d.getUTCHours().toString().padStart(2, "0");
+  const minutes = d.getUTCMinutes().toString().padStart(2, "0");
+  return `${year}.${month}.${day} ${hours}:${minutes}`;
+}
+
+export default function JobQueue({ entries, loading, onCancel }: Props) {
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ backgroundColor: "#0f1219" }}>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Blueprint</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Product</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Activity</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Runs</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">ME/TE</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Character</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Est. Cost</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Est. Duration</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Finishes</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="center">Source</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Status</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Notes</TableCell>
+            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="center">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {entries.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={13} align="center" sx={{ py: 4, color: "#64748b" }}>
+                No jobs in queue
+              </TableCell>
+            </TableRow>
+          ) : (
+            entries.map((entry) => (
+              <TableRow
+                key={entry.id}
+                sx={{
+                  "&:nth-of-type(odd)": { backgroundColor: "#0d1117" },
+                  "&:nth-of-type(even)": { backgroundColor: "#12151f" },
+                }}
+              >
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#e2e8f0" }}>
+                    {entry.blueprintName || `Type ${entry.blueprintTypeId}`}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
+                    {entry.productName || "-"}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#cbd5e1", textTransform: "capitalize" }}>
+                    {entry.activity}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  <Typography variant="body2" sx={{ color: "#e2e8f0" }}>
+                    {formatNumber(entry.runs)}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                    {entry.meLevel}/{entry.teLevel}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                    {entry.characterName || "-"}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
+                    {entry.estimatedCost ? formatISK(entry.estimatedCost) : "-"}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                    {entry.estimatedDuration ? formatDuration(entry.estimatedDuration) : "-"}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  {entry.esiJobEndDate ? (
+                    <Box>
+                      <Typography variant="body2" sx={{ color: "#3b82f6", fontFamily: "monospace", fontWeight: 600 }}>
+                        {formatTimeRemaining(entry.esiJobEndDate)}
+                      </Typography>
+                      <Typography variant="caption" sx={{ color: "#64748b" }}>
+                        {formatEndDate(entry.esiJobEndDate)}
+                      </Typography>
+                    </Box>
+                  ) : (
+                    <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
+                  )}
+                </TableCell>
+                <TableCell align="center">
+                  {entry.esiJobSource ? (
+                    <Tooltip title={entry.esiJobSource === "corporation" ? "Corporation Job" : "Character Job"}>
+                      {entry.esiJobSource === "corporation" ? (
+                        <CorporateFareIcon sx={{ color: "#f59e0b", fontSize: 18 }} />
+                      ) : (
+                        <PersonIcon sx={{ color: "#94a3b8", fontSize: 18 }} />
+                      )}
+                    </Tooltip>
+                  ) : (
+                    <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    label={entry.status}
+                    color={getStatusColor(entry.status)}
+                    size="small"
+                    variant="outlined"
+                  />
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ color: "#94a3b8", maxWidth: 150, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {entry.notes || "-"}
+                  </Typography>
+                </TableCell>
+                <TableCell align="center">
+                  {(entry.status === "planned" || entry.status === "active") && (
+                    <IconButton
+                      size="small"
+                      onClick={() => onCancel(entry.id)}
+                      sx={{ color: "#ef4444" }}
+                      title="Cancel job"
+                    >
+                      <CancelIcon fontSize="small" />
+                    </IconButton>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/frontend/packages/components/industry/__tests__/ActiveJobs.test.tsx
+++ b/frontend/packages/components/industry/__tests__/ActiveJobs.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ActiveJobs from '../ActiveJobs';
+import { IndustryJob } from '@industry-tool/client/data/models';
+
+describe('ActiveJobs Component', () => {
+  it('should match snapshot when loading', () => {
+    const { container } = render(<ActiveJobs jobs={[]} loading={true} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should match snapshot with empty jobs', () => {
+    const { container } = render(<ActiveJobs jobs={[]} loading={false} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display empty message when no jobs', () => {
+    render(<ActiveJobs jobs={[]} loading={false} />);
+    expect(screen.getByText('No active industry jobs')).toBeInTheDocument();
+  });
+
+  it('should match snapshot with jobs', () => {
+    const jobs: IndustryJob[] = [
+      {
+        jobId: 10001,
+        installerId: 1001,
+        userId: 100,
+        facilityId: 60003760,
+        stationId: 60003760,
+        activityId: 1,
+        blueprintId: 9876,
+        blueprintTypeId: 787,
+        blueprintLocationId: 60003760,
+        outputLocationId: 60003760,
+        runs: 10,
+        cost: 1500000,
+        status: 'active',
+        source: 'character',
+        duration: 3600,
+        startDate: '2026-02-22T00:00:00Z',
+        endDate: '2026-02-22T01:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+        blueprintName: 'Rifter Blueprint',
+        productName: 'Rifter',
+        activityName: 'Manufacturing',
+        installerName: 'Test Pilot',
+        systemName: 'Jita',
+      },
+      {
+        jobId: 10002,
+        installerId: 1002,
+        userId: 100,
+        facilityId: 60003760,
+        stationId: 60003760,
+        activityId: 9,
+        blueprintId: 1111,
+        blueprintTypeId: 46166,
+        blueprintLocationId: 60003760,
+        outputLocationId: 60003760,
+        runs: 100,
+        status: 'ready',
+        source: 'corporation',
+        duration: 7200,
+        startDate: '2026-02-21T22:00:00Z',
+        endDate: '2026-02-22T00:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+        blueprintName: 'Reaction Blueprint',
+        activityName: 'Reaction',
+        installerName: 'Corp Alt',
+      },
+    ];
+
+    const { container } = render(<ActiveJobs jobs={jobs} loading={false} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display job details', () => {
+    const jobs: IndustryJob[] = [
+      {
+        jobId: 10001,
+        installerId: 1001,
+        userId: 100,
+        facilityId: 60003760,
+        stationId: 60003760,
+        activityId: 1,
+        blueprintId: 9876,
+        blueprintTypeId: 787,
+        blueprintLocationId: 60003760,
+        outputLocationId: 60003760,
+        runs: 10,
+        cost: 1500000,
+        status: 'active',
+        source: 'character',
+        duration: 3600,
+        startDate: '2026-02-22T00:00:00Z',
+        endDate: '2026-02-22T01:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+        blueprintName: 'Rifter Blueprint',
+        productName: 'Rifter',
+        activityName: 'Manufacturing',
+        installerName: 'Test Pilot',
+        systemName: 'Jita',
+      },
+    ];
+
+    render(<ActiveJobs jobs={jobs} loading={false} />);
+    expect(screen.getByText('Rifter Blueprint')).toBeInTheDocument();
+    expect(screen.getByText('Rifter')).toBeInTheDocument();
+    expect(screen.getByText('Manufacturing')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByText('Test Pilot')).toBeInTheDocument();
+    expect(screen.getByText('Jita')).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/components/industry/__tests__/AddJob.test.tsx
+++ b/frontend/packages/components/industry/__tests__/AddJob.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import AddJob from '../AddJob';
+
+// Mock fetch
+beforeEach(() => {
+  (global.fetch as jest.Mock).mockClear();
+});
+
+describe('AddJob Component', () => {
+  const mockOnJobAdded = jest.fn();
+
+  beforeEach(() => {
+    mockOnJobAdded.mockClear();
+    // Mock systems endpoint
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url === '/api/industry/systems') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            { system_id: 30000142, name: 'Jita', security_status: 0.9, cost_index: 0.05 },
+          ],
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => [] });
+    });
+  });
+
+  it('should match snapshot', async () => {
+    const { container } = render(<AddJob onJobAdded={mockOnJobAdded} />);
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/industry/systems');
+    });
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render the blueprint search field', () => {
+    render(<AddJob onJobAdded={mockOnJobAdded} />);
+    expect(screen.getByLabelText('Search Blueprint')).toBeInTheDocument();
+  });
+
+  it('should render activity selector', () => {
+    render(<AddJob onJobAdded={mockOnJobAdded} />);
+    // MUI Select renders 'Activity' as label and 'Manufacturing' as default value
+    expect(screen.getByText('Manufacturing')).toBeInTheDocument();
+  });
+
+  it('should render runs field', () => {
+    render(<AddJob onJobAdded={mockOnJobAdded} />);
+    expect(screen.getByLabelText('Runs')).toBeInTheDocument();
+  });
+
+  it('should render ME and TE fields', () => {
+    render(<AddJob onJobAdded={mockOnJobAdded} />);
+    expect(screen.getByLabelText('ME Level')).toBeInTheDocument();
+    expect(screen.getByLabelText('TE Level')).toBeInTheDocument();
+  });
+
+  it('should render Add to Queue button', () => {
+    render(<AddJob onJobAdded={mockOnJobAdded} />);
+    expect(screen.getByText('Add to Queue')).toBeInTheDocument();
+  });
+
+  it('should have Add to Queue button disabled by default', () => {
+    render(<AddJob onJobAdded={mockOnJobAdded} />);
+    const button = screen.getByText('Add to Queue').closest('button');
+    expect(button).toBeDisabled();
+  });
+});

--- a/frontend/packages/components/industry/__tests__/JobQueue.test.tsx
+++ b/frontend/packages/components/industry/__tests__/JobQueue.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import JobQueue from '../JobQueue';
+import { IndustryJobQueueEntry } from '@industry-tool/client/data/models';
+
+describe('JobQueue Component', () => {
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    mockOnCancel.mockClear();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-02-22T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should match snapshot when loading', () => {
+    const { container } = render(
+      <JobQueue entries={[]} loading={true} onCancel={mockOnCancel} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should match snapshot with empty queue', () => {
+    const { container } = render(
+      <JobQueue entries={[]} loading={false} onCancel={mockOnCancel} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display empty message when no entries', () => {
+    render(<JobQueue entries={[]} loading={false} onCancel={mockOnCancel} />);
+    expect(screen.getByText('No jobs in queue')).toBeInTheDocument();
+  });
+
+  it('should match snapshot with entries', () => {
+    const entries: IndustryJobQueueEntry[] = [
+      {
+        id: 1,
+        userId: 100,
+        blueprintTypeId: 787,
+        activity: 'manufacturing',
+        runs: 10,
+        meLevel: 10,
+        teLevel: 20,
+        facilityTax: 1.0,
+        status: 'planned',
+        estimatedCost: 5000000,
+        estimatedDuration: 3600,
+        createdAt: '2026-02-22T00:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+        blueprintName: 'Rifter Blueprint',
+        productName: 'Rifter',
+        notes: 'Test note',
+      },
+      {
+        id: 2,
+        userId: 100,
+        blueprintTypeId: 46166,
+        activity: 'reaction',
+        runs: 100,
+        meLevel: 0,
+        teLevel: 0,
+        facilityTax: 0.25,
+        status: 'active',
+        esiJobId: 12345,
+        createdAt: '2026-02-22T00:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+        blueprintName: 'Reaction Formula',
+        esiJobEndDate: '2026-02-26T04:33:00Z',
+      },
+    ];
+
+    const { container } = render(
+      <JobQueue entries={entries} loading={false} onCancel={mockOnCancel} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display entry details', () => {
+    const entries: IndustryJobQueueEntry[] = [
+      {
+        id: 1,
+        userId: 100,
+        blueprintTypeId: 787,
+        activity: 'manufacturing',
+        runs: 10,
+        meLevel: 10,
+        teLevel: 20,
+        facilityTax: 1.0,
+        status: 'planned',
+        createdAt: '2026-02-22T00:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+        blueprintName: 'Rifter Blueprint',
+      },
+    ];
+
+    render(<JobQueue entries={entries} loading={false} onCancel={mockOnCancel} />);
+    expect(screen.getByText('Rifter Blueprint')).toBeInTheDocument();
+    expect(screen.getByText('planned')).toBeInTheDocument();
+    expect(screen.getByText('10/20')).toBeInTheDocument();
+  });
+
+  it('should call onCancel when cancel button is clicked', () => {
+    const entries: IndustryJobQueueEntry[] = [
+      {
+        id: 5,
+        userId: 100,
+        blueprintTypeId: 787,
+        activity: 'manufacturing',
+        runs: 10,
+        meLevel: 10,
+        teLevel: 20,
+        facilityTax: 1.0,
+        status: 'planned',
+        createdAt: '2026-02-22T00:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+      },
+    ];
+
+    render(<JobQueue entries={entries} loading={false} onCancel={mockOnCancel} />);
+    const cancelButton = screen.getByTitle('Cancel job');
+    fireEvent.click(cancelButton);
+    expect(mockOnCancel).toHaveBeenCalledWith(5);
+  });
+
+  it('should display finish time for active entries with esiJobEndDate', () => {
+    const entries: IndustryJobQueueEntry[] = [
+      {
+        id: 10,
+        userId: 100,
+        blueprintTypeId: 787,
+        activity: 'manufacturing',
+        runs: 1,
+        meLevel: 10,
+        teLevel: 20,
+        facilityTax: 1.0,
+        status: 'active',
+        esiJobId: 99999,
+        esiJobEndDate: '2026-02-26T04:33:00Z',
+        createdAt: '2026-02-22T00:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+        blueprintName: 'Rifter Blueprint',
+      },
+    ];
+
+    render(<JobQueue entries={entries} loading={false} onCancel={mockOnCancel} />);
+    expect(screen.getByText('2026.02.26 04:33')).toBeInTheDocument();
+  });
+
+  it('should not show cancel button for completed entries', () => {
+    const entries: IndustryJobQueueEntry[] = [
+      {
+        id: 3,
+        userId: 100,
+        blueprintTypeId: 787,
+        activity: 'manufacturing',
+        runs: 10,
+        meLevel: 10,
+        teLevel: 20,
+        facilityTax: 1.0,
+        status: 'completed',
+        createdAt: '2026-02-22T00:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+      },
+    ];
+
+    render(<JobQueue entries={entries} loading={false} onCancel={mockOnCancel} />);
+    expect(screen.queryByTitle('Cancel job')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/packages/components/industry/__tests__/__snapshots__/ActiveJobs.test.tsx.snap
+++ b/frontend/packages/components/industry/__tests__/__snapshots__/ActiveJobs.test.tsx.snap
@@ -1,0 +1,451 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ActiveJobs Component should match snapshot when loading 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-wg1uo3"
+  >
+    <span
+      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1wxecgq-MuiCircularProgress-root"
+      role="progressbar"
+      style="width: 40px; height: 40px;"
+    >
+      <svg
+        class="MuiCircularProgress-svg css-54pwck-MuiCircularProgress-svg"
+        viewBox="22 22 44 44"
+      >
+        <circle
+          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-19t5dcl-MuiCircularProgress-circle"
+          cx="44"
+          cy="44"
+          fill="none"
+          r="20.2"
+          stroke-width="3.6"
+        />
+      </svg>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`ActiveJobs Component should match snapshot with empty jobs 1`] = `
+<div>
+  <div
+    class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+  >
+    <table
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
+    >
+      <thead
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+            scope="col"
+          >
+            Source
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Blueprint
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Product
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Activity
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Runs
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Character
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Status
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Time Left
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Duration
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Cost
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            System
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1btjunt-MuiTableCell-root"
+            colspan="11"
+          >
+            No active industry jobs
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`ActiveJobs Component should match snapshot with jobs 1`] = `
+<div>
+  <div
+    class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+  >
+    <table
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
+    >
+      <thead
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+            scope="col"
+          >
+            Source
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Blueprint
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Product
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Activity
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Runs
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Character
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Status
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Time Left
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Duration
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Cost
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            System
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root css-ky2cy3-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+          >
+            <svg
+              aria-hidden="true"
+              aria-label="Character Job"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-qahz97-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="PersonIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4m0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4"
+              />
+            </svg>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-yaetr5-MuiTypography-root"
+            >
+              Rifter Blueprint
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              Rifter
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              Manufacturing
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-yaetr5-MuiTypography-root"
+            >
+              10
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              Test Pilot
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-outlinedSuccess css-fko4l-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+              >
+                active
+              </span>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-17fxm6e-MuiTypography-root"
+            >
+              Ready
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              1h 0m
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              1.50M ISK
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              Jita
+            </p>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root css-ky2cy3-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+          >
+            <svg
+              aria-hidden="true"
+              aria-label="Corporation Job"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-64fxvi-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="CorporateFareIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 7V3H2v18h20V7zm-2 12H4v-2h6zm0-4H4v-2h6zm0-4H4V9h6zm0-4H4V5h6zm10 12h-8V9h8zm-2-8h-4v2h4zm0 4h-4v2h4z"
+              />
+            </svg>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-yaetr5-MuiTypography-root"
+            >
+              Reaction Blueprint
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              Reaction
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-yaetr5-MuiTypography-root"
+            >
+              100
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              Corp Alt
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorInfo MuiChip-outlinedInfo css-mr7bkj-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+              >
+                ready
+              </span>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              Ready
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              2h 0m
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;

--- a/frontend/packages/components/industry/__tests__/__snapshots__/AddJob.test.tsx.snap
+++ b/frontend/packages/components/industry/__tests__/__snapshots__/AddJob.test.tsx.snap
@@ -1,0 +1,646 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`AddJob Component should match snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-0"
+  >
+    <div
+      class="MuiBox-root css-9akmpe"
+    >
+      <div
+        class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-7mw91w-MuiAutocomplete-root"
+      >
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1kfabtt-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="false"
+            for="_r_0_"
+            id="_r_0_-label"
+          >
+            Search Blueprint
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1n04w30-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-expanded="false"
+              aria-invalid="false"
+              autocapitalize="none"
+              autocomplete="off"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
+              id="_r_0_"
+              role="combobox"
+              spellcheck="false"
+              type="text"
+              value=""
+            />
+            <div
+              class="MuiAutocomplete-endAdornment css-1uhhrmm-MuiAutocomplete-endAdornment"
+            >
+              <button
+                aria-label="Open"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-2y136s-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                tabindex="-1"
+                title="Open"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="ArrowDropDownIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-1n64csd-MuiNotchedOutlined-root"
+              >
+                <span>
+                  Search Blueprint
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root css-1lo99t4-MuiFormControl-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+        >
+          Activity
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-trm6af-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+            role="combobox"
+            tabindex="0"
+          >
+            Manufacturing
+          </div>
+          <input
+            aria-hidden="true"
+            aria-invalid="false"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            tabindex="-1"
+            value="manufacturing"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                Activity
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root MuiTextField-root css-14k80k5-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+          for="_r_4_"
+          id="_r_4_-label"
+        >
+          Runs
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+            id="_r_4_"
+            type="number"
+            value="1"
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                Runs
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-9akmpe"
+    >
+      <div
+        class="MuiFormControl-root MuiTextField-root css-86befj-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+          for="_r_5_"
+          id="_r_5_-label"
+        >
+          ME Level
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+            id="_r_5_"
+            max="10"
+            min="0"
+            type="number"
+            value="10"
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                ME Level
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root MuiTextField-root css-86befj-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+          for="_r_6_"
+          id="_r_6_-label"
+        >
+          TE Level
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+            id="_r_6_"
+            max="20"
+            min="0"
+            type="number"
+            value="20"
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                TE Level
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root MuiTextField-root css-dd39jk-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+          for="_r_7_"
+          id="_r_7_-label"
+        >
+          Industry Skill
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+            id="_r_7_"
+            max="5"
+            min="0"
+            type="number"
+            value="5"
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                Industry Skill
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root MuiTextField-root css-dd39jk-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+          for="_r_8_"
+          id="_r_8_-label"
+        >
+          Adv Industry
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+            id="_r_8_"
+            max="5"
+            min="0"
+            type="number"
+            value="5"
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                Adv Industry
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root css-2cu920-MuiFormControl-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+        >
+          Structure
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-trm6af-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+            role="combobox"
+            tabindex="0"
+          >
+            Raitaru
+          </div>
+          <input
+            aria-hidden="true"
+            aria-invalid="false"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            tabindex="-1"
+            value="raitaru"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                Structure
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root css-8ba41e-MuiFormControl-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+        >
+          Rig
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-trm6af-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+            role="combobox"
+            tabindex="0"
+          >
+            T2
+          </div>
+          <input
+            aria-hidden="true"
+            aria-invalid="false"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            tabindex="-1"
+            value="t2"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                Rig
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root css-mb7bu8-MuiFormControl-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+        >
+          Security
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-trm6af-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+            role="combobox"
+            tabindex="0"
+          >
+            Highsec
+          </div>
+          <input
+            aria-hidden="true"
+            aria-invalid="false"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            tabindex="-1"
+            value="high"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                Security
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root MuiTextField-root css-dd39jk-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+          for="_r_c_"
+          id="_r_c_-label"
+        >
+          Facility Tax %
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+            id="_r_c_"
+            type="number"
+            value="1"
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                Facility Tax %
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-25poqg"
+    >
+      <div
+        class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1u96ry5-MuiAutocomplete-root"
+      >
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1kfabtt-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="false"
+            for="_r_d_"
+            id="_r_d_-label"
+          >
+            System (optional)
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1n04w30-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-expanded="false"
+              aria-invalid="false"
+              autocapitalize="none"
+              autocomplete="off"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
+              id="_r_d_"
+              role="combobox"
+              spellcheck="false"
+              type="text"
+              value=""
+            />
+            <div
+              class="MuiAutocomplete-endAdornment css-1uhhrmm-MuiAutocomplete-endAdornment"
+            >
+              <button
+                aria-label="Open"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-2y136s-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                tabindex="-1"
+                title="Open"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="ArrowDropDownIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-1n64csd-MuiNotchedOutlined-root"
+              >
+                <span>
+                  System (optional)
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root MuiTextField-root css-14iwpnw-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1kfabtt-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="false"
+          for="_r_g_"
+          id="_r_g_-label"
+        >
+          Notes
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+            id="_r_g_"
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1n64csd-MuiNotchedOutlined-root"
+            >
+              <span>
+                Notes
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1fin47i-MuiButtonBase-root-MuiButton-root"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="AddIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+            />
+          </svg>
+        </span>
+        Add to Queue
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/packages/components/industry/__tests__/__snapshots__/JobQueue.test.tsx.snap
+++ b/frontend/packages/components/industry/__tests__/__snapshots__/JobQueue.test.tsx.snap
@@ -1,0 +1,534 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`JobQueue Component should match snapshot when loading 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-wg1uo3"
+  >
+    <span
+      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1wxecgq-MuiCircularProgress-root"
+      role="progressbar"
+      style="width: 40px; height: 40px;"
+    >
+      <svg
+        class="MuiCircularProgress-svg css-54pwck-MuiCircularProgress-svg"
+        viewBox="22 22 44 44"
+      >
+        <circle
+          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-19t5dcl-MuiCircularProgress-circle"
+          cx="44"
+          cy="44"
+          fill="none"
+          r="20.2"
+          stroke-width="3.6"
+        />
+      </svg>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`JobQueue Component should match snapshot with empty queue 1`] = `
+<div>
+  <div
+    class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+  >
+    <table
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
+    >
+      <thead
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Blueprint
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Product
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Activity
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Runs
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            ME/TE
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Character
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Est. Cost
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Est. Duration
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Finishes
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+            scope="col"
+          >
+            Source
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Status
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Notes
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+            scope="col"
+          >
+            Actions
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1btjunt-MuiTableCell-root"
+            colspan="13"
+          >
+            No jobs in queue
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`JobQueue Component should match snapshot with entries 1`] = `
+<div>
+  <div
+    class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+  >
+    <table
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
+    >
+      <thead
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Blueprint
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Product
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Activity
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Runs
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            ME/TE
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Character
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Est. Cost
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Est. Duration
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Finishes
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+            scope="col"
+          >
+            Source
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Status
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Notes
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+            scope="col"
+          >
+            Actions
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root css-ky2cy3-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-yaetr5-MuiTypography-root"
+            >
+              Rifter Blueprint
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              Rifter
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-hebqoa-MuiTypography-root"
+            >
+              manufacturing
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-yaetr5-MuiTypography-root"
+            >
+              10
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              10
+              /
+              20
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              5.00M ISK
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              1h 0m
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-595iqm-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-595iqm-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorInfo MuiChip-outlinedInfo css-mr7bkj-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+              >
+                planned
+              </span>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-1vbssuc-MuiTypography-root"
+            >
+              Test note
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              title="Cancel job"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="CancelIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2m5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12z"
+                />
+              </svg>
+            </button>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root css-ky2cy3-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-yaetr5-MuiTypography-root"
+            >
+              Reaction Formula
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-hebqoa-MuiTypography-root"
+            >
+              reaction
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-yaetr5-MuiTypography-root"
+            >
+              100
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              0
+              /
+              0
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiBox-root css-0"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body2 css-4v8hqy-MuiTypography-root"
+              >
+                3D 16:33:00
+              </p>
+              <span
+                class="MuiTypography-root MuiTypography-caption css-166jqd1-MuiTypography-root"
+              >
+                2026.02.26 04:33
+              </span>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-595iqm-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-outlinedSuccess css-fko4l-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+              >
+                active
+              </span>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-1vbssuc-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              title="Cancel job"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="CancelIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2m5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12z"
+                />
+              </svg>
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;

--- a/frontend/packages/pages/industry.tsx
+++ b/frontend/packages/pages/industry.tsx
@@ -1,0 +1,125 @@
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { IndustryJob, IndustryJobQueueEntry } from "@industry-tool/client/data/models";
+import Loading from "@industry-tool/components/loading";
+import Unauthorized from "@industry-tool/components/unauthorized";
+import Navbar from "@industry-tool/components/Navbar";
+import ActiveJobs from "@industry-tool/components/industry/ActiveJobs";
+import JobQueue from "@industry-tool/components/industry/JobQueue";
+import AddJob from "@industry-tool/components/industry/AddJob";
+import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import Box from "@mui/material/Box";
+
+export default function Industry() {
+  const { status } = useSession();
+  const [tab, setTab] = useState(() => {
+    if (typeof window !== "undefined") {
+      return parseInt(localStorage.getItem("industry-tab") || "0", 10);
+    }
+    return 0;
+  });
+
+  const [jobs, setJobs] = useState<IndustryJob[]>([]);
+  const [queue, setQueue] = useState<IndustryJobQueueEntry[]>([]);
+  const [jobsLoading, setJobsLoading] = useState(true);
+  const [queueLoading, setQueueLoading] = useState(true);
+
+  const fetchJobs = useCallback(async () => {
+    setJobsLoading(true);
+    try {
+      const res = await fetch("/api/industry/jobs");
+      if (res.ok) {
+        const data = await res.json();
+        setJobs(data || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch jobs:", err);
+    } finally {
+      setJobsLoading(false);
+    }
+  }, []);
+
+  const fetchQueue = useCallback(async () => {
+    setQueueLoading(true);
+    try {
+      const res = await fetch("/api/industry/queue");
+      if (res.ok) {
+        const data = await res.json();
+        setQueue(data || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch queue:", err);
+    } finally {
+      setQueueLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      fetchJobs();
+      fetchQueue();
+    }
+  }, [status, fetchJobs, fetchQueue]);
+
+  const handleCancelEntry = async (id: number) => {
+    try {
+      const res = await fetch(`/api/industry/queue/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        fetchQueue();
+      }
+    } catch (err) {
+      console.error("Failed to cancel queue entry:", err);
+    }
+  };
+
+  const handleJobAdded = () => {
+    fetchQueue();
+  };
+
+  if (status === "loading") {
+    return <Loading />;
+  }
+
+  if (status !== "authenticated") {
+    return <Unauthorized />;
+  }
+
+  const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
+    setTab(newValue);
+    localStorage.setItem("industry-tab", String(newValue));
+  };
+
+  const plannedCount = queue.filter((e) => e.status === "planned").length;
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
+        <Typography variant="h5" sx={{ color: "#e2e8f0", mb: 2, fontWeight: 600 }}>
+          Industry Jobs
+        </Typography>
+        <Box sx={{ borderBottom: 1, borderColor: "rgba(148, 163, 184, 0.15)", mb: 2 }}>
+          <Tabs
+            value={tab}
+            onChange={handleTabChange}
+            sx={{
+              "& .MuiTab-root": { color: "#64748b", textTransform: "none", fontWeight: 500 },
+              "& .Mui-selected": { color: "#3b82f6" },
+              "& .MuiTabs-indicator": { backgroundColor: "#3b82f6" },
+            }}
+          >
+            <Tab label={`Active Jobs (${jobs.length})`} />
+            <Tab label={`Queue${plannedCount > 0 ? ` (${plannedCount})` : ""}`} />
+            <Tab label="Add Job" />
+          </Tabs>
+        </Box>
+        {tab === 0 && <ActiveJobs jobs={jobs} loading={jobsLoading} />}
+        {tab === 1 && <JobQueue entries={queue} loading={queueLoading} onCancel={handleCancelEntry} />}
+        {tab === 2 && <AddJob onJobAdded={handleJobAdded} />}
+      </Container>
+    </>
+  );
+}

--- a/frontend/packages/utils/formatting.ts
+++ b/frontend/packages/utils/formatting.ts
@@ -87,6 +87,26 @@ export function formatNumber(value: number, decimals: number = 0): string {
 }
 
 /**
+ * Format duration in seconds to a human-readable string (e.g. "3d 5h 24m")
+ */
+export function formatDuration(totalSeconds: number): string {
+  if (totalSeconds <= 0) return '0s';
+
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (parts.length === 0 && seconds > 0) parts.push(`${seconds}s`);
+
+  return parts.join(' ');
+}
+
+/**
  * Format compact number (no decimals, with suffixes)
  */
 export function formatCompact(value: number): string {

--- a/frontend/pages/api/industry/blueprints.ts
+++ b/frontend/pages/api/industry/blueprints.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const queryString = new URLSearchParams(
+      req.query as Record<string, string>,
+    ).toString();
+    const url = `${backend}v1/industry/blueprints${queryString ? `?${queryString}` : ""}`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "BACKEND-KEY": backendKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("Industry blueprints API error:", error);
+    return res.status(500).json({ error: "Failed to search blueprints" });
+  }
+}

--- a/frontend/pages/api/industry/calculate.ts
+++ b/frontend/pages/api/industry/calculate.ts
@@ -1,0 +1,35 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const response = await fetch(`${backend}v1/industry/calculate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "BACKEND-KEY": backendKey,
+      },
+      body: JSON.stringify(req.body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("Industry calculate API error:", error);
+    return res.status(500).json({ error: "Failed to calculate manufacturing cost" });
+  }
+}

--- a/frontend/pages/api/industry/jobs.ts
+++ b/frontend/pages/api/industry/jobs.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    const all = req.query.all === "true";
+    const url = all
+      ? `${backend}v1/industry/jobs/all`
+      : `${backend}v1/industry/jobs`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "USER-ID": session.providerAccountId,
+        "BACKEND-KEY": backendKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("Industry jobs API error:", error);
+    return res.status(500).json({ error: "Failed to fetch industry jobs" });
+  }
+}

--- a/frontend/pages/api/industry/queue.ts
+++ b/frontend/pages/api/industry/queue.ts
@@ -1,0 +1,58 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (id: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": id,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    if (req.method === "GET") {
+      const response = await fetch(`${backend}v1/industry/queue`, {
+        method: "GET",
+        headers: getHeaders(session.providerAccountId),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else if (req.method === "POST") {
+      const response = await fetch(`${backend}v1/industry/queue`, {
+        method: "POST",
+        headers: getHeaders(session.providerAccountId),
+        body: JSON.stringify(req.body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Industry queue API error:", error);
+    return res.status(500).json({ error: "Failed to process queue request" });
+  }
+}

--- a/frontend/pages/api/industry/queue/[id].ts
+++ b/frontend/pages/api/industry/queue/[id].ts
@@ -1,0 +1,60 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (id: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": id,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  try {
+    if (req.method === "PUT") {
+      const response = await fetch(`${backend}v1/industry/queue/${id}`, {
+        method: "PUT",
+        headers: getHeaders(session.providerAccountId),
+        body: JSON.stringify(req.body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else if (req.method === "DELETE") {
+      const response = await fetch(`${backend}v1/industry/queue/${id}`, {
+        method: "DELETE",
+        headers: getHeaders(session.providerAccountId),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Industry queue entry API error:", error);
+    return res.status(500).json({ error: "Failed to process queue entry request" });
+  }
+}

--- a/frontend/pages/api/industry/systems.ts
+++ b/frontend/pages/api/industry/systems.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const response = await fetch(`${backend}v1/industry/systems`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "BACKEND-KEY": backendKey,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("Industry systems API error:", error);
+    return res.status(500).json({ error: "Failed to fetch manufacturing systems" });
+  }
+}

--- a/frontend/pages/industry.tsx
+++ b/frontend/pages/industry.tsx
@@ -1,0 +1,3 @@
+import Industry from "@industry-tool/pages/industry";
+
+export default Industry;

--- a/internal/calculator/manufacturing.go
+++ b/internal/calculator/manufacturing.go
@@ -1,0 +1,200 @@
+package calculator
+
+import (
+	"math"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+)
+
+// ManufacturingParams holds user-configurable settings for a manufacturing job calculation
+type ManufacturingParams struct {
+	BlueprintME    int     // 0-10
+	BlueprintTE    int     // 0-20
+	Runs           int
+	Structure      string  // "raitaru", "azbel", "sotiyo", "station"
+	Rig            string  // "none", "t1", "t2"
+	Security       string  // "null", "low", "high"
+	IndustrySkill  int     // 0-5
+	AdvIndustrySkill int   // 0-5
+	FacilityTax    float64 // percentage
+	SystemID       int64
+}
+
+// ManufacturingData holds data fetched from the database for calculations
+type ManufacturingData struct {
+	Blueprint      *repositories.ManufacturingBlueprintRow
+	Materials      []*repositories.ManufacturingMaterialRow
+	CostIndex      float64
+	AdjustedPrices map[int64]float64
+	JitaPrices     map[int64]*models.MarketPrice
+}
+
+// EngineeringSecurityMultiplier returns the rig bonus multiplier for engineering complexes.
+// Engineering complexes use different security multipliers than refineries:
+// Null/WH: 2.1x, Low: 1.9x, High: 1.0x
+func EngineeringSecurityMultiplier(security string) float64 {
+	switch security {
+	case "null":
+		return 2.1
+	case "low":
+		return 1.9
+	default: // "high"
+		return 1.0
+	}
+}
+
+// ComputeManufacturingME calculates the combined ME factor for manufacturing.
+// Manufacturing ME combines blueprint ME (0-10) with structure ME bonus and rig ME.
+// Engineering complexes (Raitaru, Azbel, Sotiyo) provide a 1% material reduction role bonus.
+// combined_me = (1 - blueprint_me/100) * (1 - structure_me) * (1 - rig_me * security_mult)
+func ComputeManufacturingME(blueprintME int, structure, rig, security string) float64 {
+	structME := ManufacturingStructureMEValue(structure)
+	rigME := RigMEValue(rig)
+	secMult := EngineeringSecurityMultiplier(security)
+	return (1.0 - float64(blueprintME)/100.0) * (1.0 - structME) * (1.0 - rigME*secMult)
+}
+
+// ManufacturingStructureMEValue returns the material efficiency bonus for manufacturing structures.
+// Engineering complexes (Raitaru, Azbel, Sotiyo) provide a 1% material reduction role bonus.
+// NPC stations provide no bonus.
+func ManufacturingStructureMEValue(structure string) float64 {
+	switch structure {
+	case "raitaru", "azbel", "sotiyo":
+		return 0.01
+	default: // "station" or unknown
+		return 0
+	}
+}
+
+// ComputeManufacturingTE calculates the combined TE factor for manufacturing.
+// Manufacturing TE combines blueprint TE (0-20) with skills, structure, and rig bonuses.
+// combined_te = (1 - blueprint_te/100) * (1 - industry*0.04) * (1 - adv_industry*0.03) * (1 - structure_te) * (1 - rig_te * sec_mult)
+func ComputeManufacturingTE(blueprintTE, industrySkill, advIndustrySkill int, structure, rig, security string) float64 {
+	rigTE := RigTEValue(rig)
+	structTE := ManufacturingStructureTEValue(structure)
+	secMult := EngineeringSecurityMultiplier(security)
+	return (1.0 - float64(blueprintTE)/100.0) *
+		(1.0 - float64(industrySkill)*0.04) *
+		(1.0 - float64(advIndustrySkill)*0.03) *
+		(1.0 - structTE) *
+		(1.0 - rigTE*secMult)
+}
+
+// ManufacturingStructureTEValue returns the time efficiency bonus for manufacturing structures.
+// Sotiyo: 30%, Azbel: 20%, Raitaru: 15%, Station: 0%
+func ManufacturingStructureTEValue(structure string) float64 {
+	switch structure {
+	case "sotiyo":
+		return 0.30
+	case "azbel":
+		return 0.20
+	case "raitaru":
+		return 0.15
+	default: // "station" or unknown
+		return 0
+	}
+}
+
+// ManufacturingStructureCostBonus returns the job cost reduction for engineering complexes.
+// This bonus reduces only the system cost index portion of the job cost.
+// Sotiyo: 5%, Azbel: 3%, Raitaru: 1%, Station: 0%
+func ManufacturingStructureCostBonus(structure string) float64 {
+	switch structure {
+	case "sotiyo":
+		return 0.05
+	case "azbel":
+		return 0.03
+	case "raitaru":
+		return 0.01
+	default: // "station" or unknown
+		return 0
+	}
+}
+
+// ComputeManufacturingJobCost calculates the industry job cost for one run of a manufacturing job.
+// Uses base quantities (ME 0) for EIV calculation, same as reactions.
+// The structure cost bonus only reduces the system cost index portion:
+// job_cost = EIV × cost_index × (1 - structure_bonus) + EIV × scc_surcharge + EIV × facility_tax
+func ComputeManufacturingJobCost(materials []*repositories.ManufacturingMaterialRow, adjustedPrices map[int64]float64, costIndex, facilityTax float64, structure string) float64 {
+	var eiv float64
+	for _, mat := range materials {
+		adjPrice, ok := adjustedPrices[mat.TypeID]
+		if !ok {
+			continue
+		}
+		eiv += float64(mat.Quantity) * adjPrice
+	}
+	structBonus := ManufacturingStructureCostBonus(structure)
+	return eiv*costIndex*(1.0-structBonus) + eiv*SccSurchargeRate + eiv*(facilityTax/100.0)
+}
+
+// CalculateManufacturingJob calculates the full cost breakdown for a manufacturing job.
+func CalculateManufacturingJob(params *ManufacturingParams, data *ManufacturingData) *models.ManufacturingCalcResult {
+	meFactor := ComputeManufacturingME(params.BlueprintME, params.Structure, params.Rig, params.Security)
+	teFactor := ComputeManufacturingTE(params.BlueprintTE, params.IndustrySkill, params.AdvIndustrySkill, params.Structure, params.Rig, params.Security)
+
+	// Calculate time per run
+	secsPerRun := ComputeSecsPerRun(data.Blueprint.Time, teFactor)
+	totalDuration := secsPerRun * params.Runs
+
+	// Calculate materials
+	materials := []*models.ManufacturingMaterial{}
+	var totalInputCost float64
+
+	for _, mat := range data.Materials {
+		batchQty := ComputeBatchQty(params.Runs, mat.Quantity, meFactor)
+		price := GetPrice(mat.TypeID, "sell", data.JitaPrices)
+		cost := price * float64(batchQty)
+
+		materials = append(materials, &models.ManufacturingMaterial{
+			TypeID:   mat.TypeID,
+			Name:     mat.TypeName,
+			BaseQty:  mat.Quantity,
+			BatchQty: batchQty,
+			Price:    price,
+			Cost:     math.Round(cost*100) / 100,
+		})
+
+		totalInputCost += cost
+	}
+
+	// Job installation cost
+	jobCostPerRun := ComputeManufacturingJobCost(data.Materials, data.AdjustedPrices, data.CostIndex, params.FacilityTax, params.Structure)
+	totalJobCost := jobCostPerRun * float64(params.Runs)
+
+	// Total output
+	totalProducts := data.Blueprint.ProductQuantity * params.Runs
+
+	// Output value
+	outputPrice := GetPrice(data.Blueprint.ProductTypeID, "sell", data.JitaPrices)
+	totalOutputValue := outputPrice * float64(totalProducts)
+
+	// Total cost and profit
+	totalCost := totalInputCost + totalJobCost
+	profit := totalOutputValue - totalCost
+
+	var margin float64
+	if totalOutputValue > 0 {
+		margin = (profit / totalOutputValue) * 100.0
+	}
+
+	return &models.ManufacturingCalcResult{
+		BlueprintTypeID: data.Blueprint.BlueprintTypeID,
+		ProductTypeID:   data.Blueprint.ProductTypeID,
+		ProductName:     data.Blueprint.ProductName,
+		Runs:            params.Runs,
+		MEFactor:        math.Round(meFactor*10000) / 10000,
+		TEFactor:        math.Round(teFactor*10000) / 10000,
+		SecsPerRun:      secsPerRun,
+		TotalDuration:   totalDuration,
+		TotalProducts:   totalProducts,
+		InputCost:       math.Round(totalInputCost*100) / 100,
+		JobCost:         math.Round(totalJobCost*100) / 100,
+		TotalCost:       math.Round(totalCost*100) / 100,
+		OutputValue:     math.Round(totalOutputValue*100) / 100,
+		Profit:          math.Round(profit*100) / 100,
+		Margin:          math.Round(margin*100) / 100,
+		Materials:       materials,
+	}
+}

--- a/internal/calculator/manufacturing_test.go
+++ b/internal/calculator/manufacturing_test.go
@@ -1,0 +1,270 @@
+package calculator
+
+import (
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeManufacturingME(t *testing.T) {
+	tests := []struct {
+		name        string
+		blueprintME int
+		structure   string
+		rig         string
+		security    string
+		expected    float64
+	}{
+		{"ME10 Sotiyo T2 null", 10, "sotiyo", "t2", "null", (1.0 - 0.10) * (1.0 - 0.01) * (1.0 - 0.024*2.1)},
+		{"ME10 Raitaru T2 low", 10, "raitaru", "t2", "low", (1.0 - 0.10) * (1.0 - 0.01) * (1.0 - 0.024*1.9)},
+		{"ME10 Azbel T1 null", 10, "azbel", "t1", "null", (1.0 - 0.10) * (1.0 - 0.01) * (1.0 - 0.02*2.1)},
+		{"ME0 station none low", 0, "station", "none", "low", 1.0},
+		{"ME5 station none low", 5, "station", "none", "low", 0.95},
+		{"ME10 station none high", 10, "station", "none", "high", 0.90},
+		{"ME10 Sotiyo none null", 10, "sotiyo", "none", "null", (1.0 - 0.10) * (1.0 - 0.01)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ComputeManufacturingME(tc.blueprintME, tc.structure, tc.rig, tc.security)
+			assert.InDelta(t, tc.expected, result, 0.0001)
+		})
+	}
+}
+
+func TestEngineeringSecurityMultiplier(t *testing.T) {
+	assert.Equal(t, 2.1, EngineeringSecurityMultiplier("null"))
+	assert.Equal(t, 1.9, EngineeringSecurityMultiplier("low"))
+	assert.Equal(t, 1.0, EngineeringSecurityMultiplier("high"))
+}
+
+func TestManufacturingStructureMEValue(t *testing.T) {
+	assert.Equal(t, 0.01, ManufacturingStructureMEValue("raitaru"))
+	assert.Equal(t, 0.01, ManufacturingStructureMEValue("azbel"))
+	assert.Equal(t, 0.01, ManufacturingStructureMEValue("sotiyo"))
+	assert.Equal(t, 0.0, ManufacturingStructureMEValue("station"))
+	assert.Equal(t, 0.0, ManufacturingStructureMEValue("unknown"))
+}
+
+func TestComputeManufacturingTE(t *testing.T) {
+	tests := []struct {
+		name             string
+		blueprintTE      int
+		industrySkill    int
+		advIndustrySkill int
+		structure        string
+		rig              string
+		security         string
+		expected         float64
+	}{
+		{
+			"TE20 Industry5 AdvIndustry5 Raitaru T2 null",
+			20, 5, 5, "raitaru", "t2", "null",
+			(1.0 - 0.20) * (1.0 - 0.20) * (1.0 - 0.15) * (1.0 - 0.15) * (1.0 - 0.24*2.1),
+		},
+		{
+			"TE0 Industry0 AdvIndustry0 station none high",
+			0, 0, 0, "station", "none", "high",
+			1.0,
+		},
+		{
+			"TE20 Industry5 AdvIndustry0 Sotiyo T1 low",
+			20, 5, 0, "sotiyo", "t1", "low",
+			(1.0 - 0.20) * (1.0 - 0.20) * (1.0) * (1.0 - 0.30) * (1.0 - 0.20*1.9),
+		},
+		{
+			"TE10 Industry3 AdvIndustry2 Azbel none high",
+			10, 3, 2, "azbel", "none", "high",
+			(1.0 - 0.10) * (1.0 - 0.12) * (1.0 - 0.06) * (1.0 - 0.20) * (1.0),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ComputeManufacturingTE(tc.blueprintTE, tc.industrySkill, tc.advIndustrySkill, tc.structure, tc.rig, tc.security)
+			assert.InDelta(t, tc.expected, result, 0.0001)
+		})
+	}
+}
+
+func TestManufacturingStructureTEValue(t *testing.T) {
+	assert.Equal(t, 0.15, ManufacturingStructureTEValue("raitaru"))
+	assert.Equal(t, 0.20, ManufacturingStructureTEValue("azbel"))
+	assert.Equal(t, 0.30, ManufacturingStructureTEValue("sotiyo"))
+	assert.Equal(t, 0.0, ManufacturingStructureTEValue("station"))
+	assert.Equal(t, 0.0, ManufacturingStructureTEValue("unknown"))
+}
+
+func TestManufacturingStructureCostBonus(t *testing.T) {
+	assert.Equal(t, 0.05, ManufacturingStructureCostBonus("sotiyo"))
+	assert.Equal(t, 0.03, ManufacturingStructureCostBonus("azbel"))
+	assert.Equal(t, 0.01, ManufacturingStructureCostBonus("raitaru"))
+	assert.Equal(t, 0.0, ManufacturingStructureCostBonus("station"))
+	assert.Equal(t, 0.0, ManufacturingStructureCostBonus("unknown"))
+}
+
+func TestComputeManufacturingJobCost(t *testing.T) {
+	materials := []*repositories.ManufacturingMaterialRow{
+		{TypeID: 34, Quantity: 1000}, // Tritanium
+		{TypeID: 35, Quantity: 500},  // Pyerite
+	}
+
+	adjustedPrices := map[int64]float64{
+		34: 5.0,  // Tritanium adjusted price
+		35: 10.0, // Pyerite adjusted price
+	}
+
+	// EIV = (1000 * 5.0) + (500 * 10.0) = 5000 + 5000 = 10000
+	// Station (no bonus): EIV*cost_index + EIV*scc + EIV*tax
+	// = 10000*0.01 + 10000*0.04 + 10000*0.05 = 100 + 400 + 500 = 1000
+	result := ComputeManufacturingJobCost(materials, adjustedPrices, 0.01, 5.0, "station")
+	assert.InDelta(t, 1000.0, result, 0.01)
+
+	// Sotiyo (5% bonus on cost index only):
+	// = 10000*0.01*0.95 + 10000*0.04 + 10000*0.05 = 95 + 400 + 500 = 995
+	result = ComputeManufacturingJobCost(materials, adjustedPrices, 0.01, 5.0, "sotiyo")
+	assert.InDelta(t, 995.0, result, 0.01)
+}
+
+func TestComputeManufacturingJobCost_MissingPrices(t *testing.T) {
+	materials := []*repositories.ManufacturingMaterialRow{
+		{TypeID: 34, Quantity: 1000},
+		{TypeID: 99, Quantity: 500}, // no adjusted price
+	}
+
+	adjustedPrices := map[int64]float64{
+		34: 5.0,
+	}
+
+	// EIV = (1000 * 5.0) = 5000 (type 99 missing, skipped)
+	// Station: 5000*0.02 + 5000*0.04 + 0 = 100 + 200 = 300
+	result := ComputeManufacturingJobCost(materials, adjustedPrices, 0.02, 0, "station")
+	assert.InDelta(t, 300.0, result, 0.01)
+}
+
+func TestCalculateManufacturingJob(t *testing.T) {
+	sellPrice34 := 6.0
+	sellPrice35 := 12.0
+	sellProductPrice := 50000.0
+
+	params := &ManufacturingParams{
+		BlueprintME:      10,
+		BlueprintTE:      20,
+		Runs:             10,
+		Structure:        "raitaru",
+		Rig:              "t1",
+		Security:         "low",
+		IndustrySkill:    5,
+		AdvIndustrySkill: 4,
+		FacilityTax:      5.0,
+		SystemID:         30000142,
+	}
+
+	data := &ManufacturingData{
+		Blueprint: &repositories.ManufacturingBlueprintRow{
+			BlueprintTypeID: 787,
+			ProductTypeID:   786,
+			ProductName:     "Test Ship",
+			GroupName:       "Frigate",
+			ProductQuantity: 1,
+			Time:            3600,
+			ProductVolume:   2500,
+			MaxProdLimit:    300,
+		},
+		Materials: []*repositories.ManufacturingMaterialRow{
+			{BlueprintTypeID: 787, TypeID: 34, TypeName: "Tritanium", Quantity: 1000, Volume: 0.01},
+			{BlueprintTypeID: 787, TypeID: 35, TypeName: "Pyerite", Quantity: 500, Volume: 0.01},
+		},
+		CostIndex: 0.01,
+		AdjustedPrices: map[int64]float64{
+			34: 5.0,
+			35: 10.0,
+		},
+		JitaPrices: map[int64]*models.MarketPrice{
+			34:  {TypeID: 34, SellPrice: &sellPrice34},
+			35:  {TypeID: 35, SellPrice: &sellPrice35},
+			786: {TypeID: 786, SellPrice: &sellProductPrice},
+		},
+	}
+
+	result := CalculateManufacturingJob(params, data)
+
+	assert.Equal(t, int64(787), result.BlueprintTypeID)
+	assert.Equal(t, int64(786), result.ProductTypeID)
+	assert.Equal(t, "Test Ship", result.ProductName)
+	assert.Equal(t, 10, result.Runs)
+	assert.Equal(t, 10, result.TotalProducts)
+
+	// ME factor: (1 - 10/100) * (1 - 0.01) * (1 - 0.02 * 1.9) = 0.90 * 0.99 * 0.962
+	expectedME := 0.90 * 0.99 * (1.0 - 0.02*1.9)
+	assert.InDelta(t, expectedME, result.MEFactor, 0.001)
+
+	// TE factor: (1 - 20/100) * (1 - 5*0.04) * (1 - 4*0.03) * (1 - 0.15) * (1 - 0.20*1.9)
+	expectedTE := 0.80 * 0.80 * 0.88 * 0.85 * (1.0 - 0.20*1.9)
+	assert.InDelta(t, expectedTE, result.TEFactor, 0.001)
+
+	// Verify materials are populated
+	assert.Len(t, result.Materials, 2)
+	assert.Equal(t, int64(34), result.Materials[0].TypeID)
+	assert.Equal(t, "Tritanium", result.Materials[0].Name)
+	assert.Equal(t, 1000, result.Materials[0].BaseQty)
+
+	// Job cost should be positive
+	assert.Greater(t, result.JobCost, 0.0)
+	assert.Greater(t, result.InputCost, 0.0)
+	assert.Greater(t, result.TotalCost, 0.0)
+
+	// Output value = 50000 * 10 = 500000
+	assert.InDelta(t, 500000.0, result.OutputValue, 0.01)
+
+	// Profit = output - total cost
+	assert.InDelta(t, result.OutputValue-result.TotalCost, result.Profit, 0.01)
+
+	// Duration should be computed
+	assert.Greater(t, result.SecsPerRun, 0)
+	assert.Equal(t, result.SecsPerRun*10, result.TotalDuration)
+}
+
+func TestCalculateManufacturingJob_NoJitaPrices(t *testing.T) {
+	params := &ManufacturingParams{
+		BlueprintME:      0,
+		BlueprintTE:      0,
+		Runs:             1,
+		Structure:        "station",
+		Rig:              "none",
+		Security:         "high",
+		IndustrySkill:    0,
+		AdvIndustrySkill: 0,
+		FacilityTax:      0,
+		SystemID:         30000142,
+	}
+
+	data := &ManufacturingData{
+		Blueprint: &repositories.ManufacturingBlueprintRow{
+			BlueprintTypeID: 787,
+			ProductTypeID:   786,
+			ProductName:     "Test Ship",
+			ProductQuantity: 1,
+			Time:            3600,
+		},
+		Materials: []*repositories.ManufacturingMaterialRow{
+			{BlueprintTypeID: 787, TypeID: 34, TypeName: "Tritanium", Quantity: 100},
+		},
+		CostIndex:      0.01,
+		AdjustedPrices: map[int64]float64{},
+		JitaPrices:     map[int64]*models.MarketPrice{},
+	}
+
+	result := CalculateManufacturingJob(params, data)
+
+	// With no prices, costs and output should be 0
+	assert.Equal(t, 0.0, result.InputCost)
+	assert.Equal(t, 0.0, result.OutputValue)
+	assert.Equal(t, 1, result.Runs)
+	assert.Equal(t, 1, result.TotalProducts)
+	// ME/TE at 0 blueprint, no rig, no structure = 1.0
+	assert.InDelta(t, 1.0, result.MEFactor, 0.0001)
+	assert.InDelta(t, 1.0, result.TEFactor, 0.0001)
+}

--- a/internal/calculator/plan.go
+++ b/internal/calculator/plan.go
@@ -147,7 +147,7 @@ func ComputePlan(selections []models.PlanSelection, params *CalcParams, data *Ca
 			if existing, ok := shoppingMap[mat.TypeID]; ok {
 				existing.Quantity += totalQty
 			} else {
-				price := getPrice(mat.TypeID, params.InputPrice, data.JitaPrices)
+				price := GetPrice(mat.TypeID, params.InputPrice, data.JitaPrices)
 				shoppingMap[mat.TypeID] = &models.ShoppingItem{
 					TypeID:   mat.TypeID,
 					Name:     mat.TypeName,
@@ -180,7 +180,7 @@ func ComputePlan(selections []models.PlanSelection, params *CalcParams, data *Ca
 			if existing, ok := shoppingMap[mat.TypeID]; ok {
 				existing.Quantity += totalQty
 			} else {
-				price := getPrice(mat.TypeID, params.InputPrice, data.JitaPrices)
+				price := GetPrice(mat.TypeID, params.InputPrice, data.JitaPrices)
 				shoppingMap[mat.TypeID] = &models.ShoppingItem{
 					TypeID:   mat.TypeID,
 					Name:     mat.TypeName,
@@ -219,7 +219,7 @@ func ComputePlan(selections []models.PlanSelection, params *CalcParams, data *Ca
 		runs := intermediateRunsMap[typeID]
 		slots := intermediateSlotsMap[typeID]
 		mats := materialsByReaction[simpleReaction.BlueprintTypeID]
-		jobCostPerRun := computeJobCost(mats, data.AdjustedPrices, data.CostIndex, params.FacilityTax)
+		jobCostPerRun := ComputeReactionJobCost(mats, data.AdjustedPrices, data.CostIndex, params.FacilityTax)
 		totalIntermediateJobCost += jobCostPerRun * float64(runs) * float64(slots)
 	}
 

--- a/internal/client/esiClient_test.go
+++ b/internal/client/esiClient_test.go
@@ -416,3 +416,352 @@ func Test_ClientShouldHandleCorporationContractsError(t *testing.T) {
 	assert.Nil(t, contracts)
 	assert.Contains(t, err.Error(), "failed to get corporation contracts")
 }
+
+func Test_ClientShouldGetCharacterSkills(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient := NewMockHTTPDoer(ctrl)
+
+	mockSkills := client.EsiSkillsResponse{
+		Skills: []client.EsiSkillEntry{
+			{SkillID: 3380, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},
+			{SkillID: 3388, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 45255},
+			{SkillID: 22242, TrainedSkillLevel: 3, ActiveSkillLevel: 3, SkillpointsInSkill: 16000},
+		},
+		TotalSP:   5000000,
+		UnallocSP: 100000,
+	}
+
+	skillsJSON, _ := json.Marshal(mockSkills)
+
+	mockHTTPClient.EXPECT().
+		Do(gomock.Any()).
+		DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "GET", req.Method)
+			assert.Contains(t, req.URL.String(), "/v4/characters/12345/skills/")
+			assert.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(skillsJSON)),
+			}, nil
+		}).
+		Times(1)
+
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "https://esi.test.com")
+
+	resp, err := esiClient.GetCharacterSkills(context.Background(), 12345, "test-token")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(resp.Skills))
+	assert.Equal(t, int64(3380), resp.Skills[0].SkillID)
+	assert.Equal(t, 5, resp.Skills[0].TrainedSkillLevel)
+	assert.Equal(t, 5, resp.Skills[0].ActiveSkillLevel)
+	assert.Equal(t, int64(256000), resp.Skills[0].SkillpointsInSkill)
+	assert.Equal(t, int64(5000000), resp.TotalSP)
+	assert.Equal(t, int64(100000), resp.UnallocSP)
+}
+
+func Test_ClientShouldHandleCharacterSkillsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient := NewMockHTTPDoer(ctrl)
+
+	mockHTTPClient.EXPECT().
+		Do(gomock.Any()).
+		Return(&http.Response{
+			StatusCode: 403,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"error":"token is expired"}`))),
+		}, nil).
+		Times(1)
+
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "https://esi.test.com")
+
+	resp, err := esiClient.GetCharacterSkills(context.Background(), 12345, "expired-token")
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to get character skills")
+}
+
+func Test_ClientShouldGetCharacterIndustryJobs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient := NewMockHTTPDoer(ctrl)
+
+	cost := 1500000.0
+	productTypeID := int64(34)
+	mockJobs := []*client.EsiIndustryJob{
+		{
+			JobID:               12345,
+			InstallerID:         100,
+			FacilityID:          60003760,
+			StationID:           60003760,
+			ActivityID:          1,
+			BlueprintID:         9876,
+			BlueprintTypeID:     787,
+			BlueprintLocationID: 60003760,
+			OutputLocationID:    60003760,
+			Runs:                10,
+			Cost:                &cost,
+			ProductTypeID:       &productTypeID,
+			Status:              "active",
+			Duration:            3600,
+			StartDate:           "2026-02-22T10:00:00Z",
+			EndDate:             "2026-02-22T11:00:00Z",
+		},
+	}
+
+	jobsJSON, _ := json.Marshal(mockJobs)
+
+	mockHTTPClient.EXPECT().
+		Do(gomock.Any()).
+		DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "GET", req.Method)
+			assert.Contains(t, req.URL.String(), "/v1/characters/12345/industry/jobs/")
+			assert.NotContains(t, req.URL.String(), "include_completed=true")
+			assert.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"X-Pages": []string{"1"}},
+				Body:       io.NopCloser(bytes.NewReader(jobsJSON)),
+			}, nil
+		}).
+		Times(1)
+
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "https://esi.test.com")
+
+	jobs, err := esiClient.GetCharacterIndustryJobs(context.Background(), 12345, "test-token", false)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(jobs))
+	assert.Equal(t, int64(12345), jobs[0].JobID)
+	assert.Equal(t, 1, jobs[0].ActivityID)
+	assert.Equal(t, "active", jobs[0].Status)
+	assert.Equal(t, 10, jobs[0].Runs)
+	assert.Equal(t, 1500000.0, *jobs[0].Cost)
+	assert.Equal(t, int64(34), *jobs[0].ProductTypeID)
+}
+
+func Test_ClientShouldGetCharacterIndustryJobsIncludeCompleted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient := NewMockHTTPDoer(ctrl)
+
+	completedDate := "2026-02-22T11:00:00Z"
+	successfulRuns := 10
+	mockJobs := []*client.EsiIndustryJob{
+		{
+			JobID:           12345,
+			InstallerID:     100,
+			FacilityID:      60003760,
+			StationID:       60003760,
+			ActivityID:      1,
+			BlueprintID:     9876,
+			BlueprintTypeID: 787,
+			BlueprintLocationID: 60003760,
+			OutputLocationID:    60003760,
+			Runs:            10,
+			Status:          "delivered",
+			Duration:        3600,
+			StartDate:       "2026-02-22T10:00:00Z",
+			EndDate:         "2026-02-22T11:00:00Z",
+			CompletedDate:   &completedDate,
+			SuccessfulRuns:  &successfulRuns,
+		},
+	}
+
+	jobsJSON, _ := json.Marshal(mockJobs)
+
+	mockHTTPClient.EXPECT().
+		Do(gomock.Any()).
+		DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			assert.Contains(t, req.URL.String(), "include_completed=true")
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"X-Pages": []string{"1"}},
+				Body:       io.NopCloser(bytes.NewReader(jobsJSON)),
+			}, nil
+		}).
+		Times(1)
+
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "https://esi.test.com")
+
+	jobs, err := esiClient.GetCharacterIndustryJobs(context.Background(), 12345, "test-token", true)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(jobs))
+	assert.Equal(t, "delivered", jobs[0].Status)
+	assert.Equal(t, 10, *jobs[0].SuccessfulRuns)
+}
+
+func Test_ClientShouldGetCharacterIndustryJobsMultiplePages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient := NewMockHTTPDoer(ctrl)
+
+	page1Jobs := []*client.EsiIndustryJob{
+		{JobID: 1001, InstallerID: 100, FacilityID: 60003760, StationID: 60003760, ActivityID: 1, BlueprintID: 1, BlueprintTypeID: 787, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 1, Status: "active", Duration: 3600, StartDate: "2026-02-22T10:00:00Z", EndDate: "2026-02-22T11:00:00Z"},
+	}
+	page2Jobs := []*client.EsiIndustryJob{
+		{JobID: 2001, InstallerID: 100, FacilityID: 60003760, StationID: 60003760, ActivityID: 9, BlueprintID: 2, BlueprintTypeID: 788, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 5, Status: "active", Duration: 7200, StartDate: "2026-02-22T12:00:00Z", EndDate: "2026-02-22T14:00:00Z"},
+	}
+
+	page1JSON, _ := json.Marshal(page1Jobs)
+	page2JSON, _ := json.Marshal(page2Jobs)
+
+	callCount := 0
+	mockHTTPClient.EXPECT().
+		Do(gomock.Any()).
+		DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return &http.Response{
+					StatusCode: 200,
+					Header:     http.Header{"X-Pages": []string{"2"}},
+					Body:       io.NopCloser(bytes.NewReader(page1JSON)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"X-Pages": []string{"2"}},
+				Body:       io.NopCloser(bytes.NewReader(page2JSON)),
+			}, nil
+		}).
+		Times(2)
+
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "https://esi.test.com")
+
+	jobs, err := esiClient.GetCharacterIndustryJobs(context.Background(), 12345, "test-token", false)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(jobs))
+	assert.Equal(t, int64(1001), jobs[0].JobID)
+	assert.Equal(t, int64(2001), jobs[1].JobID)
+}
+
+func Test_ClientShouldHandleCharacterIndustryJobsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient := NewMockHTTPDoer(ctrl)
+
+	mockHTTPClient.EXPECT().
+		Do(gomock.Any()).
+		Return(&http.Response{
+			StatusCode: 403,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"error":"forbidden"}`))),
+		}, nil).
+		Times(1)
+
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "https://esi.test.com")
+
+	jobs, err := esiClient.GetCharacterIndustryJobs(context.Background(), 12345, "bad-token", false)
+	assert.Error(t, err)
+	assert.Nil(t, jobs)
+	assert.Contains(t, err.Error(), "failed to get character industry jobs")
+}
+
+func Test_ClientShouldGetCharacterIndustryJobsNoXPagesHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient := NewMockHTTPDoer(ctrl)
+
+	mockJobs := []*client.EsiIndustryJob{
+		{JobID: 5001, InstallerID: 100, FacilityID: 60003760, StationID: 60003760, ActivityID: 1, BlueprintID: 1, BlueprintTypeID: 787, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 1, Status: "active", Duration: 3600, StartDate: "2026-02-22T10:00:00Z", EndDate: "2026-02-22T11:00:00Z"},
+	}
+	jobsJSON, _ := json.Marshal(mockJobs)
+
+	mockHTTPClient.EXPECT().
+		Do(gomock.Any()).
+		Return(&http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewReader(jobsJSON)),
+		}, nil).
+		Times(1)
+
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "https://esi.test.com")
+
+	jobs, err := esiClient.GetCharacterIndustryJobs(context.Background(), 12345, "test-token", false)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(jobs))
+	assert.Equal(t, int64(5001), jobs[0].JobID)
+}
+
+func Test_ClientShouldGetCorporationIndustryJobs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient := NewMockHTTPDoer(ctrl)
+
+	cost := 5000000.0
+	mockJobs := []*client.EsiIndustryJob{
+		{
+			JobID:               99001,
+			InstallerID:         200,
+			FacilityID:          1000000025,
+			StationID:           1000000025,
+			ActivityID:          9,
+			BlueprintID:         5555,
+			BlueprintTypeID:     46166,
+			BlueprintLocationID: 1000000025,
+			OutputLocationID:    1000000025,
+			Runs:                100,
+			Cost:                &cost,
+			Status:              "active",
+			Duration:            14400,
+			StartDate:           "2026-02-22T08:00:00Z",
+			EndDate:             "2026-02-22T12:00:00Z",
+		},
+	}
+
+	jobsJSON, _ := json.Marshal(mockJobs)
+
+	mockHTTPClient.EXPECT().
+		Do(gomock.Any()).
+		DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "GET", req.Method)
+			assert.Contains(t, req.URL.String(), "/v1/corporations/5001/industry/jobs/")
+			assert.Equal(t, "Bearer corp-token", req.Header.Get("Authorization"))
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"X-Pages": []string{"1"}},
+				Body:       io.NopCloser(bytes.NewReader(jobsJSON)),
+			}, nil
+		}).
+		Times(1)
+
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "https://esi.test.com")
+
+	jobs, err := esiClient.GetCorporationIndustryJobs(context.Background(), 5001, "corp-token", false)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(jobs))
+	assert.Equal(t, int64(99001), jobs[0].JobID)
+	assert.Equal(t, 9, jobs[0].ActivityID)
+	assert.Equal(t, "active", jobs[0].Status)
+	assert.Equal(t, 100, jobs[0].Runs)
+	assert.Equal(t, 5000000.0, *jobs[0].Cost)
+}
+
+func Test_ClientShouldHandleCorporationIndustryJobsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient := NewMockHTTPDoer(ctrl)
+
+	mockHTTPClient.EXPECT().
+		Do(gomock.Any()).
+		Return(&http.Response{
+			StatusCode: 403,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"error":"forbidden"}`))),
+		}, nil).
+		Times(1)
+
+	esiClient := client.NewEsiClientWithHTTPClient("test-client-id", "test-client-secret", mockHTTPClient, "https://esi.test.com")
+
+	jobs, err := esiClient.GetCorporationIndustryJobs(context.Background(), 5001, "bad-token", false)
+	assert.Error(t, err)
+	assert.Nil(t, jobs)
+	assert.Contains(t, err.Error(), "failed to get corporation industry jobs")
+}

--- a/internal/controllers/industry.go
+++ b/internal/controllers/industry.go
@@ -1,0 +1,409 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/annymsMthd/industry-tool/internal/calculator"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/pkg/errors"
+)
+
+type IndustryJobsRepository interface {
+	GetActiveJobs(ctx context.Context, userID int64) ([]*models.IndustryJob, error)
+	GetAllJobs(ctx context.Context, userID int64) ([]*models.IndustryJob, error)
+}
+
+type IndustryJobQueueRepository interface {
+	Create(ctx context.Context, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error)
+	GetByUser(ctx context.Context, userID int64) ([]*models.IndustryJobQueueEntry, error)
+	Update(ctx context.Context, id, userID int64, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error)
+	Cancel(ctx context.Context, id, userID int64) error
+}
+
+type IndustrySDERepository interface {
+	GetManufacturingBlueprint(ctx context.Context, blueprintTypeID int64) (*repositories.ManufacturingBlueprintRow, error)
+	GetManufacturingMaterials(ctx context.Context, blueprintTypeID int64) ([]*repositories.ManufacturingMaterialRow, error)
+	SearchBlueprints(ctx context.Context, query string, activity string, limit int) ([]*repositories.BlueprintSearchRow, error)
+	GetManufacturingSystems(ctx context.Context) ([]*models.ReactionSystem, error)
+}
+
+type IndustryMarketRepository interface {
+	GetAllJitaPrices(ctx context.Context) (map[int64]*models.MarketPrice, error)
+	GetAllAdjustedPrices(ctx context.Context) (map[int64]float64, error)
+}
+
+type IndustryCostIndicesRepository interface {
+	GetCostIndex(ctx context.Context, systemID int64, activity string) (*models.IndustryCostIndex, error)
+}
+
+type Industry struct {
+	jobsRepo        IndustryJobsRepository
+	queueRepo       IndustryJobQueueRepository
+	sdeRepo         IndustrySDERepository
+	marketRepo      IndustryMarketRepository
+	costIndicesRepo IndustryCostIndicesRepository
+}
+
+func NewIndustry(
+	router Routerer,
+	jobsRepo IndustryJobsRepository,
+	queueRepo IndustryJobQueueRepository,
+	sdeRepo IndustrySDERepository,
+	marketRepo IndustryMarketRepository,
+	costIndicesRepo IndustryCostIndicesRepository,
+) *Industry {
+	c := &Industry{
+		jobsRepo:        jobsRepo,
+		queueRepo:       queueRepo,
+		sdeRepo:         sdeRepo,
+		marketRepo:      marketRepo,
+		costIndicesRepo: costIndicesRepo,
+	}
+
+	// User-scoped endpoints
+	router.RegisterRestAPIRoute("/v1/industry/jobs", web.AuthAccessUser, c.GetActiveJobs, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/jobs/all", web.AuthAccessUser, c.GetAllJobs, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/queue", web.AuthAccessUser, c.GetQueue, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/queue", web.AuthAccessUser, c.CreateQueueEntry, "POST")
+	router.RegisterRestAPIRoute("/v1/industry/queue/{id}", web.AuthAccessUser, c.UpdateQueueEntry, "PUT")
+	router.RegisterRestAPIRoute("/v1/industry/queue/{id}", web.AuthAccessUser, c.CancelQueueEntry, "DELETE")
+
+	// Backend-scoped endpoints (no user required)
+	router.RegisterRestAPIRoute("/v1/industry/calculate", web.AuthAccessBackend, c.Calculate, "POST")
+	router.RegisterRestAPIRoute("/v1/industry/blueprints", web.AuthAccessBackend, c.SearchBlueprints, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/systems", web.AuthAccessBackend, c.GetSystems, "GET")
+
+	return c
+}
+
+func (c *Industry) GetActiveJobs(args *web.HandlerArgs) (any, *web.HttpError) {
+	jobs, err := c.jobsRepo.GetActiveJobs(args.Request.Context(), *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get active jobs")}
+	}
+	return jobs, nil
+}
+
+func (c *Industry) GetAllJobs(args *web.HandlerArgs) (any, *web.HttpError) {
+	jobs, err := c.jobsRepo.GetAllJobs(args.Request.Context(), *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get all jobs")}
+	}
+	return jobs, nil
+}
+
+func (c *Industry) GetQueue(args *web.HandlerArgs) (any, *web.HttpError) {
+	entries, err := c.queueRepo.GetByUser(args.Request.Context(), *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get job queue")}
+	}
+	return entries, nil
+}
+
+type createQueueRequest struct {
+	BlueprintTypeID   int64    `json:"blueprint_type_id"`
+	Activity          string   `json:"activity"`
+	Runs              int      `json:"runs"`
+	MELevel           int      `json:"me_level"`
+	TELevel           int      `json:"te_level"`
+	CharacterID       *int64   `json:"character_id"`
+	SystemID          *int64   `json:"system_id"`
+	FacilityTax       float64  `json:"facility_tax"`
+	Structure         string   `json:"structure"`
+	Rig               string   `json:"rig"`
+	Security          string   `json:"security"`
+	IndustrySkill     int      `json:"industry_skill"`
+	AdvIndustrySkill  int      `json:"adv_industry_skill"`
+	ProductTypeID     *int64   `json:"product_type_id"`
+	Notes             *string  `json:"notes"`
+}
+
+func (c *Industry) CreateQueueEntry(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+
+	var req createQueueRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if req.BlueprintTypeID <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("blueprint_type_id is required")}
+	}
+	if req.Activity == "" {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("activity is required")}
+	}
+	if req.Runs <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("runs must be positive")}
+	}
+
+	// Calculate estimated cost and duration if this is manufacturing
+	var estimatedCost *float64
+	var estimatedDuration *int
+	var productTypeID *int64
+
+	if req.Activity == "manufacturing" {
+		calcResult, httpErr := c.calculateForBlueprint(ctx, req.BlueprintTypeID, req.Runs, req.MELevel, req.TELevel,
+			req.IndustrySkill, req.AdvIndustrySkill, req.SystemID, req.FacilityTax,
+			withDefault(req.Structure, "station"), withDefault(req.Rig, "none"), withDefault(req.Security, "high"))
+		if httpErr != nil {
+			// Non-fatal: still create the entry without estimates
+			estimatedCost = nil
+			estimatedDuration = nil
+		} else {
+			estimatedCost = &calcResult.TotalCost
+			estimatedDuration = &calcResult.TotalDuration
+			productTypeID = &calcResult.ProductTypeID
+		}
+	}
+
+	// Use explicitly provided product_type_id if given
+	if req.ProductTypeID != nil {
+		productTypeID = req.ProductTypeID
+	}
+
+	entry := &models.IndustryJobQueueEntry{
+		UserID:            *args.User,
+		CharacterID:       req.CharacterID,
+		BlueprintTypeID:   req.BlueprintTypeID,
+		Activity:          req.Activity,
+		Runs:              req.Runs,
+		MELevel:           req.MELevel,
+		TELevel:           req.TELevel,
+		SystemID:          req.SystemID,
+		FacilityTax:       req.FacilityTax,
+		ProductTypeID:     productTypeID,
+		EstimatedCost:     estimatedCost,
+		EstimatedDuration: estimatedDuration,
+		Notes:             req.Notes,
+	}
+
+	created, err := c.queueRepo.Create(ctx, entry)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to create job queue entry")}
+	}
+
+	return created, nil
+}
+
+func (c *Industry) UpdateQueueEntry(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+
+	id, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid queue entry ID")}
+	}
+
+	var req createQueueRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	// Recalculate estimates for manufacturing
+	var estimatedCost *float64
+	var estimatedDuration *int
+	var productTypeID *int64
+
+	if req.Activity == "manufacturing" {
+		calcResult, httpErr := c.calculateForBlueprint(ctx, req.BlueprintTypeID, req.Runs, req.MELevel, req.TELevel,
+			req.IndustrySkill, req.AdvIndustrySkill, req.SystemID, req.FacilityTax,
+			withDefault(req.Structure, "station"), withDefault(req.Rig, "none"), withDefault(req.Security, "high"))
+		if httpErr == nil {
+			estimatedCost = &calcResult.TotalCost
+			estimatedDuration = &calcResult.TotalDuration
+			productTypeID = &calcResult.ProductTypeID
+		}
+	}
+
+	if req.ProductTypeID != nil {
+		productTypeID = req.ProductTypeID
+	}
+
+	entry := &models.IndustryJobQueueEntry{
+		CharacterID:       req.CharacterID,
+		BlueprintTypeID:   req.BlueprintTypeID,
+		Activity:          req.Activity,
+		Runs:              req.Runs,
+		MELevel:           req.MELevel,
+		TELevel:           req.TELevel,
+		SystemID:          req.SystemID,
+		FacilityTax:       req.FacilityTax,
+		ProductTypeID:     productTypeID,
+		EstimatedCost:     estimatedCost,
+		EstimatedDuration: estimatedDuration,
+		Notes:             req.Notes,
+	}
+
+	updated, err := c.queueRepo.Update(ctx, id, *args.User, entry)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to update job queue entry")}
+	}
+	if updated == nil {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.New("queue entry not found or not editable")}
+	}
+
+	return updated, nil
+}
+
+func (c *Industry) CancelQueueEntry(args *web.HandlerArgs) (any, *web.HttpError) {
+	id, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid queue entry ID")}
+	}
+
+	err = c.queueRepo.Cancel(args.Request.Context(), id, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.Wrap(err, "failed to cancel queue entry")}
+	}
+
+	return map[string]string{"status": "cancelled"}, nil
+}
+
+type calculateRequest struct {
+	BlueprintTypeID  int64   `json:"blueprint_type_id"`
+	Runs             int     `json:"runs"`
+	MELevel          int     `json:"me_level"`
+	TELevel          int     `json:"te_level"`
+	IndustrySkill    int     `json:"industry_skill"`
+	AdvIndustrySkill int     `json:"adv_industry_skill"`
+	SystemID         *int64  `json:"system_id"`
+	FacilityTax      float64 `json:"facility_tax"`
+	Structure        string  `json:"structure"`
+	Rig              string  `json:"rig"`
+	Security         string  `json:"security"`
+}
+
+func (c *Industry) Calculate(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+
+	var req calculateRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if req.BlueprintTypeID <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("blueprint_type_id is required")}
+	}
+	if req.Runs <= 0 {
+		req.Runs = 1
+	}
+
+	result, httpErr := c.calculateForBlueprint(ctx, req.BlueprintTypeID, req.Runs, req.MELevel, req.TELevel,
+		req.IndustrySkill, req.AdvIndustrySkill, req.SystemID, req.FacilityTax,
+		withDefault(req.Structure, "station"), withDefault(req.Rig, "none"), withDefault(req.Security, "high"))
+	if httpErr != nil {
+		return nil, httpErr
+	}
+
+	return result, nil
+}
+
+func (c *Industry) SearchBlueprints(args *web.HandlerArgs) (any, *web.HttpError) {
+	q := args.Request.URL.Query()
+	query := q.Get("q")
+	if query == "" {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("query parameter 'q' is required")}
+	}
+
+	activity := q.Get("activity")
+	limit := int(parseInt64(q.Get("limit"), 20))
+	if limit > 100 {
+		limit = 100
+	}
+
+	results, err := c.sdeRepo.SearchBlueprints(args.Request.Context(), query, activity, limit)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to search blueprints")}
+	}
+
+	if results == nil {
+		results = []*repositories.BlueprintSearchRow{}
+	}
+
+	return results, nil
+}
+
+func (c *Industry) GetSystems(args *web.HandlerArgs) (any, *web.HttpError) {
+	systems, err := c.sdeRepo.GetManufacturingSystems(args.Request.Context())
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get manufacturing systems")}
+	}
+
+	if systems == nil {
+		systems = []*models.ReactionSystem{}
+	}
+
+	return systems, nil
+}
+
+// calculateForBlueprint performs the full manufacturing calculation for a given blueprint.
+func (c *Industry) calculateForBlueprint(
+	ctx context.Context,
+	blueprintTypeID int64,
+	runs, meLevel, teLevel, industrySkill, advIndustrySkill int,
+	systemID *int64,
+	facilityTax float64,
+	structure, rig, security string,
+) (*models.ManufacturingCalcResult, *web.HttpError) {
+	blueprint, err := c.sdeRepo.GetManufacturingBlueprint(ctx, blueprintTypeID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get blueprint")}
+	}
+	if blueprint == nil {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.New("blueprint not found")}
+	}
+
+	materials, err := c.sdeRepo.GetManufacturingMaterials(ctx, blueprintTypeID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get materials")}
+	}
+
+	jitaPrices, err := c.marketRepo.GetAllJitaPrices(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get Jita prices")}
+	}
+
+	adjustedPrices, err := c.marketRepo.GetAllAdjustedPrices(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get adjusted prices")}
+	}
+
+	var costIndex float64
+	if systemID != nil && *systemID > 0 {
+		idx, err := c.costIndicesRepo.GetCostIndex(ctx, *systemID, "manufacturing")
+		if err != nil {
+			return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get cost index")}
+		}
+		if idx != nil {
+			costIndex = idx.CostIndex
+		}
+	}
+
+	params := &calculator.ManufacturingParams{
+		BlueprintME:      meLevel,
+		BlueprintTE:      teLevel,
+		Runs:             runs,
+		Structure:        structure,
+		Rig:              rig,
+		Security:         security,
+		IndustrySkill:    industrySkill,
+		AdvIndustrySkill: advIndustrySkill,
+		FacilityTax:      facilityTax,
+	}
+	if systemID != nil {
+		params.SystemID = *systemID
+	}
+
+	data := &calculator.ManufacturingData{
+		Blueprint:      blueprint,
+		Materials:      materials,
+		CostIndex:      costIndex,
+		AdjustedPrices: adjustedPrices,
+		JitaPrices:     jitaPrices,
+	}
+
+	result := calculator.CalculateManufacturingJob(params, data)
+	return result, nil
+}

--- a/internal/controllers/industry_test.go
+++ b/internal/controllers/industry_test.go
@@ -1,0 +1,853 @@
+package controllers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/controllers"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// --- Mock repositories ---
+
+type MockIndustryJobsRepository struct {
+	mock.Mock
+}
+
+func (m *MockIndustryJobsRepository) GetActiveJobs(ctx context.Context, userID int64) ([]*models.IndustryJob, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.IndustryJob), args.Error(1)
+}
+
+func (m *MockIndustryJobsRepository) GetAllJobs(ctx context.Context, userID int64) ([]*models.IndustryJob, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.IndustryJob), args.Error(1)
+}
+
+type MockIndustryJobQueueRepository struct {
+	mock.Mock
+}
+
+func (m *MockIndustryJobQueueRepository) Create(ctx context.Context, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error) {
+	args := m.Called(ctx, entry)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.IndustryJobQueueEntry), args.Error(1)
+}
+
+func (m *MockIndustryJobQueueRepository) GetByUser(ctx context.Context, userID int64) ([]*models.IndustryJobQueueEntry, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.IndustryJobQueueEntry), args.Error(1)
+}
+
+func (m *MockIndustryJobQueueRepository) Update(ctx context.Context, id, userID int64, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error) {
+	args := m.Called(ctx, id, userID, entry)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.IndustryJobQueueEntry), args.Error(1)
+}
+
+func (m *MockIndustryJobQueueRepository) Cancel(ctx context.Context, id, userID int64) error {
+	args := m.Called(ctx, id, userID)
+	return args.Error(0)
+}
+
+type MockIndustrySDERepository struct {
+	mock.Mock
+}
+
+func (m *MockIndustrySDERepository) GetManufacturingBlueprint(ctx context.Context, blueprintTypeID int64) (*repositories.ManufacturingBlueprintRow, error) {
+	args := m.Called(ctx, blueprintTypeID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repositories.ManufacturingBlueprintRow), args.Error(1)
+}
+
+func (m *MockIndustrySDERepository) GetManufacturingMaterials(ctx context.Context, blueprintTypeID int64) ([]*repositories.ManufacturingMaterialRow, error) {
+	args := m.Called(ctx, blueprintTypeID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*repositories.ManufacturingMaterialRow), args.Error(1)
+}
+
+func (m *MockIndustrySDERepository) SearchBlueprints(ctx context.Context, query string, activity string, limit int) ([]*repositories.BlueprintSearchRow, error) {
+	args := m.Called(ctx, query, activity, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*repositories.BlueprintSearchRow), args.Error(1)
+}
+
+func (m *MockIndustrySDERepository) GetManufacturingSystems(ctx context.Context) ([]*models.ReactionSystem, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.ReactionSystem), args.Error(1)
+}
+
+type MockIndustryMarketRepository struct {
+	mock.Mock
+}
+
+func (m *MockIndustryMarketRepository) GetAllJitaPrices(ctx context.Context) (map[int64]*models.MarketPrice, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[int64]*models.MarketPrice), args.Error(1)
+}
+
+func (m *MockIndustryMarketRepository) GetAllAdjustedPrices(ctx context.Context) (map[int64]float64, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[int64]float64), args.Error(1)
+}
+
+type MockIndustryCostIndicesRepository struct {
+	mock.Mock
+}
+
+func (m *MockIndustryCostIndicesRepository) GetCostIndex(ctx context.Context, systemID int64, activity string) (*models.IndustryCostIndex, error) {
+	args := m.Called(ctx, systemID, activity)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.IndustryCostIndex), args.Error(1)
+}
+
+// --- Helper to create controller with mocks ---
+
+type industryMocks struct {
+	jobsRepo        *MockIndustryJobsRepository
+	queueRepo       *MockIndustryJobQueueRepository
+	sdeRepo         *MockIndustrySDERepository
+	marketRepo      *MockIndustryMarketRepository
+	costIndicesRepo *MockIndustryCostIndicesRepository
+}
+
+func setupIndustryController() (*controllers.Industry, *industryMocks) {
+	mocks := &industryMocks{
+		jobsRepo:        new(MockIndustryJobsRepository),
+		queueRepo:       new(MockIndustryJobQueueRepository),
+		sdeRepo:         new(MockIndustrySDERepository),
+		marketRepo:      new(MockIndustryMarketRepository),
+		costIndicesRepo: new(MockIndustryCostIndicesRepository),
+	}
+
+	controller := controllers.NewIndustry(
+		&MockRouter{},
+		mocks.jobsRepo,
+		mocks.queueRepo,
+		mocks.sdeRepo,
+		mocks.marketRepo,
+		mocks.costIndicesRepo,
+	)
+
+	return controller, mocks
+}
+
+// --- GetActiveJobs Tests ---
+
+func Test_IndustryController_GetActiveJobs_Success(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	cost := 1500000.0
+	expectedJobs := []*models.IndustryJob{
+		{
+			JobID:           10001,
+			InstallerID:     1001,
+			UserID:          100,
+			ActivityID:      1,
+			BlueprintTypeID: 787,
+			Runs:            10,
+			Cost:            &cost,
+			Status:          "active",
+			ActivityName:    "Manufacturing",
+			BlueprintName:   "Rifter Blueprint",
+		},
+	}
+
+	mocks.jobsRepo.On("GetActiveJobs", mock.Anything, userID).Return(expectedJobs, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/jobs", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetActiveJobs(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	jobs := result.([]*models.IndustryJob)
+	assert.Len(t, jobs, 1)
+	assert.Equal(t, int64(10001), jobs[0].JobID)
+	assert.Equal(t, "Manufacturing", jobs[0].ActivityName)
+	mocks.jobsRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_GetActiveJobs_Error(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	mocks.jobsRepo.On("GetActiveJobs", mock.Anything, userID).Return(nil, errors.New("database error"))
+
+	req := httptest.NewRequest("GET", "/v1/industry/jobs", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetActiveJobs(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 500, httpErr.StatusCode)
+	mocks.jobsRepo.AssertExpectations(t)
+}
+
+// --- GetAllJobs Tests ---
+
+func Test_IndustryController_GetAllJobs_Success(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	expectedJobs := []*models.IndustryJob{
+		{JobID: 10001, UserID: 100, Status: "active", ActivityName: "Manufacturing"},
+		{JobID: 10002, UserID: 100, Status: "delivered", ActivityName: "Reaction"},
+	}
+
+	mocks.jobsRepo.On("GetAllJobs", mock.Anything, userID).Return(expectedJobs, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/jobs/all", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetAllJobs(args)
+
+	assert.Nil(t, httpErr)
+	jobs := result.([]*models.IndustryJob)
+	assert.Len(t, jobs, 2)
+	mocks.jobsRepo.AssertExpectations(t)
+}
+
+// --- GetQueue Tests ---
+
+func Test_IndustryController_GetQueue_Success(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	expectedEntries := []*models.IndustryJobQueueEntry{
+		{ID: 1, UserID: 100, BlueprintTypeID: 787, Activity: "manufacturing", Runs: 10, Status: "planned"},
+		{ID: 2, UserID: 100, BlueprintTypeID: 46166, Activity: "reaction", Runs: 100, Status: "active"},
+	}
+
+	mocks.queueRepo.On("GetByUser", mock.Anything, userID).Return(expectedEntries, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/queue", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetQueue(args)
+
+	assert.Nil(t, httpErr)
+	entries := result.([]*models.IndustryJobQueueEntry)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "planned", entries[0].Status)
+	assert.Equal(t, "active", entries[1].Status)
+	mocks.queueRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_GetQueue_Error(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	mocks.queueRepo.On("GetByUser", mock.Anything, userID).Return(nil, errors.New("database error"))
+
+	req := httptest.NewRequest("GET", "/v1/industry/queue", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetQueue(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 500, httpErr.StatusCode)
+	mocks.queueRepo.AssertExpectations(t)
+}
+
+// --- CreateQueueEntry Tests ---
+
+func Test_IndustryController_CreateQueueEntry_Reaction(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	body := map[string]any{
+		"blueprint_type_id": 46166,
+		"activity":          "reaction",
+		"runs":              100,
+		"me_level":          0,
+		"te_level":          0,
+		"facility_tax":      0.25,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	expectedEntry := &models.IndustryJobQueueEntry{
+		ID:              1,
+		UserID:          100,
+		BlueprintTypeID: 46166,
+		Activity:        "reaction",
+		Runs:            100,
+		Status:          "planned",
+	}
+
+	mocks.queueRepo.On("Create", mock.Anything, mock.AnythingOfType("*models.IndustryJobQueueEntry")).Return(expectedEntry, nil)
+
+	req := httptest.NewRequest("POST", "/v1/industry/queue", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreateQueueEntry(args)
+
+	assert.Nil(t, httpErr)
+	entry := result.(*models.IndustryJobQueueEntry)
+	assert.Equal(t, int64(1), entry.ID)
+	assert.Equal(t, "reaction", entry.Activity)
+	assert.Equal(t, "planned", entry.Status)
+	mocks.queueRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_CreateQueueEntry_Manufacturing(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	systemID := int64(30000142)
+	body := map[string]any{
+		"blueprint_type_id":  787,
+		"activity":           "manufacturing",
+		"runs":               10,
+		"me_level":           10,
+		"te_level":           20,
+		"industry_skill":     5,
+		"adv_industry_skill": 5,
+		"system_id":          systemID,
+		"facility_tax":       1.0,
+		"structure":          "raitaru",
+		"rig":                "t2",
+		"security":           "high",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	// Set up SDE + market mocks for manufacturing calculation
+	sellPrice := 500000.0
+	blueprint := &repositories.ManufacturingBlueprintRow{
+		BlueprintTypeID: 787,
+		ProductTypeID:   587,
+		ProductName:     "Rifter",
+		ProductQuantity: 1,
+		Time:            3600,
+	}
+	materials := []*repositories.ManufacturingMaterialRow{
+		{BlueprintTypeID: 787, TypeID: 34, TypeName: "Tritanium", Quantity: 22000},
+	}
+	jitaPrices := map[int64]*models.MarketPrice{
+		34:  {TypeID: 34, SellPrice: &sellPrice},
+		587: {TypeID: 587, SellPrice: &sellPrice},
+	}
+	adjustedPrices := map[int64]float64{34: 5.0}
+	costIndex := &models.IndustryCostIndex{SystemID: systemID, Activity: "manufacturing", CostIndex: 0.05}
+
+	mocks.sdeRepo.On("GetManufacturingBlueprint", mock.Anything, int64(787)).Return(blueprint, nil)
+	mocks.sdeRepo.On("GetManufacturingMaterials", mock.Anything, int64(787)).Return(materials, nil)
+	mocks.marketRepo.On("GetAllJitaPrices", mock.Anything).Return(jitaPrices, nil)
+	mocks.marketRepo.On("GetAllAdjustedPrices", mock.Anything).Return(adjustedPrices, nil)
+	mocks.costIndicesRepo.On("GetCostIndex", mock.Anything, systemID, "manufacturing").Return(costIndex, nil)
+
+	mocks.queueRepo.On("Create", mock.Anything, mock.AnythingOfType("*models.IndustryJobQueueEntry")).
+		Return(&models.IndustryJobQueueEntry{
+			ID:              1,
+			UserID:          100,
+			BlueprintTypeID: 787,
+			Activity:        "manufacturing",
+			Runs:            10,
+			Status:          "planned",
+		}, nil)
+
+	req := httptest.NewRequest("POST", "/v1/industry/queue", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreateQueueEntry(args)
+
+	assert.Nil(t, httpErr)
+	entry := result.(*models.IndustryJobQueueEntry)
+	assert.Equal(t, int64(1), entry.ID)
+	assert.Equal(t, "manufacturing", entry.Activity)
+	mocks.queueRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_CreateQueueEntry_InvalidBody(t *testing.T) {
+	controller, _ := setupIndustryController()
+
+	userID := int64(100)
+	req := httptest.NewRequest("POST", "/v1/industry/queue", bytes.NewReader([]byte("invalid json")))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreateQueueEntry(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_IndustryController_CreateQueueEntry_MissingFields(t *testing.T) {
+	controller, _ := setupIndustryController()
+
+	userID := int64(100)
+
+	// Missing blueprint_type_id
+	body := map[string]any{"activity": "manufacturing", "runs": 10}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/v1/industry/queue", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreateQueueEntry(args)
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_IndustryController_CreateQueueEntry_MissingActivity(t *testing.T) {
+	controller, _ := setupIndustryController()
+
+	userID := int64(100)
+	body := map[string]any{"blueprint_type_id": 787, "runs": 10}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/v1/industry/queue", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreateQueueEntry(args)
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_IndustryController_CreateQueueEntry_ZeroRuns(t *testing.T) {
+	controller, _ := setupIndustryController()
+
+	userID := int64(100)
+	body := map[string]any{"blueprint_type_id": 787, "activity": "manufacturing", "runs": 0}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/v1/industry/queue", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreateQueueEntry(args)
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+// --- UpdateQueueEntry Tests ---
+
+func Test_IndustryController_UpdateQueueEntry_Success(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	body := map[string]any{
+		"blueprint_type_id": 787,
+		"activity":          "reaction",
+		"runs":              20,
+		"me_level":          0,
+		"te_level":          0,
+		"facility_tax":      0.5,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	expectedEntry := &models.IndustryJobQueueEntry{
+		ID:              5,
+		UserID:          100,
+		BlueprintTypeID: 787,
+		Activity:        "reaction",
+		Runs:            20,
+		Status:          "planned",
+	}
+
+	mocks.queueRepo.On("Update", mock.Anything, int64(5), userID, mock.AnythingOfType("*models.IndustryJobQueueEntry")).Return(expectedEntry, nil)
+
+	req := httptest.NewRequest("PUT", "/v1/industry/queue/5", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "5"},
+	}
+
+	result, httpErr := controller.UpdateQueueEntry(args)
+
+	assert.Nil(t, httpErr)
+	entry := result.(*models.IndustryJobQueueEntry)
+	assert.Equal(t, int64(5), entry.ID)
+	assert.Equal(t, 20, entry.Runs)
+	mocks.queueRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_UpdateQueueEntry_NotFound(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	body := map[string]any{
+		"blueprint_type_id": 787,
+		"activity":          "reaction",
+		"runs":              20,
+		"facility_tax":      0,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	mocks.queueRepo.On("Update", mock.Anything, int64(999), userID, mock.AnythingOfType("*models.IndustryJobQueueEntry")).Return(nil, nil)
+
+	req := httptest.NewRequest("PUT", "/v1/industry/queue/999", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "999"},
+	}
+
+	result, httpErr := controller.UpdateQueueEntry(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+	mocks.queueRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_UpdateQueueEntry_InvalidID(t *testing.T) {
+	controller, _ := setupIndustryController()
+
+	userID := int64(100)
+	body := map[string]any{"blueprint_type_id": 787, "activity": "reaction", "runs": 20, "facility_tax": 0}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/industry/queue/abc", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "abc"},
+	}
+
+	result, httpErr := controller.UpdateQueueEntry(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+// --- CancelQueueEntry Tests ---
+
+func Test_IndustryController_CancelQueueEntry_Success(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	mocks.queueRepo.On("Cancel", mock.Anything, int64(5), userID).Return(nil)
+
+	req := httptest.NewRequest("DELETE", "/v1/industry/queue/5", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "5"},
+	}
+
+	result, httpErr := controller.CancelQueueEntry(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	mocks.queueRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_CancelQueueEntry_NotFound(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	userID := int64(100)
+	mocks.queueRepo.On("Cancel", mock.Anything, int64(999), userID).Return(errors.New("not found or not cancellable"))
+
+	req := httptest.NewRequest("DELETE", "/v1/industry/queue/999", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "999"},
+	}
+
+	result, httpErr := controller.CancelQueueEntry(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+	mocks.queueRepo.AssertExpectations(t)
+}
+
+// --- Calculate Tests ---
+
+func Test_IndustryController_Calculate_Success(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	systemID := int64(30000142)
+	body := map[string]any{
+		"blueprint_type_id":  787,
+		"runs":               10,
+		"me_level":           10,
+		"te_level":           20,
+		"industry_skill":     5,
+		"adv_industry_skill": 5,
+		"system_id":          systemID,
+		"facility_tax":       1.0,
+		"structure":          "raitaru",
+		"rig":                "t2",
+		"security":           "high",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	sellPrice := 5.0
+	productPrice := 500000.0
+	blueprint := &repositories.ManufacturingBlueprintRow{
+		BlueprintTypeID: 787,
+		ProductTypeID:   587,
+		ProductName:     "Rifter",
+		ProductQuantity: 1,
+		Time:            3600,
+	}
+	materials := []*repositories.ManufacturingMaterialRow{
+		{BlueprintTypeID: 787, TypeID: 34, TypeName: "Tritanium", Quantity: 22000},
+	}
+	jitaPrices := map[int64]*models.MarketPrice{
+		34:  {TypeID: 34, SellPrice: &sellPrice},
+		587: {TypeID: 587, SellPrice: &productPrice},
+	}
+	adjustedPrices := map[int64]float64{34: 5.0}
+	costIndex := &models.IndustryCostIndex{SystemID: systemID, Activity: "manufacturing", CostIndex: 0.05}
+
+	mocks.sdeRepo.On("GetManufacturingBlueprint", mock.Anything, int64(787)).Return(blueprint, nil)
+	mocks.sdeRepo.On("GetManufacturingMaterials", mock.Anything, int64(787)).Return(materials, nil)
+	mocks.marketRepo.On("GetAllJitaPrices", mock.Anything).Return(jitaPrices, nil)
+	mocks.marketRepo.On("GetAllAdjustedPrices", mock.Anything).Return(adjustedPrices, nil)
+	mocks.costIndicesRepo.On("GetCostIndex", mock.Anything, systemID, "manufacturing").Return(costIndex, nil)
+
+	req := httptest.NewRequest("POST", "/v1/industry/calculate", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.Calculate(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	calcResult := result.(*models.ManufacturingCalcResult)
+	assert.Equal(t, int64(787), calcResult.BlueprintTypeID)
+	assert.Equal(t, int64(587), calcResult.ProductTypeID)
+	assert.Equal(t, "Rifter", calcResult.ProductName)
+	assert.Equal(t, 10, calcResult.Runs)
+	assert.Greater(t, calcResult.MEFactor, 0.0)
+	assert.Greater(t, calcResult.TEFactor, 0.0)
+	assert.Greater(t, calcResult.InputCost, 0.0)
+	assert.Len(t, calcResult.Materials, 1)
+	mocks.sdeRepo.AssertExpectations(t)
+	mocks.marketRepo.AssertExpectations(t)
+	mocks.costIndicesRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_Calculate_InvalidBody(t *testing.T) {
+	controller, _ := setupIndustryController()
+
+	req := httptest.NewRequest("POST", "/v1/industry/calculate", bytes.NewReader([]byte("bad")))
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.Calculate(args)
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_IndustryController_Calculate_MissingBlueprintTypeID(t *testing.T) {
+	controller, _ := setupIndustryController()
+
+	body := map[string]any{"runs": 10}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/industry/calculate", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.Calculate(args)
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_IndustryController_Calculate_BlueprintNotFound(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	body := map[string]any{"blueprint_type_id": 99999, "runs": 1}
+	bodyBytes, _ := json.Marshal(body)
+
+	mocks.sdeRepo.On("GetManufacturingBlueprint", mock.Anything, int64(99999)).Return(nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/industry/calculate", bytes.NewReader(bodyBytes))
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.Calculate(args)
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+}
+
+// --- SearchBlueprints Tests ---
+
+func Test_IndustryController_SearchBlueprints_Success(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	expectedResults := []*repositories.BlueprintSearchRow{
+		{BlueprintTypeID: 787, BlueprintName: "Rifter Blueprint", ProductTypeID: 587, ProductName: "Rifter", Activity: "manufacturing"},
+		{BlueprintTypeID: 788, BlueprintName: "Slasher Blueprint", ProductTypeID: 585, ProductName: "Slasher", Activity: "manufacturing"},
+	}
+
+	mocks.sdeRepo.On("SearchBlueprints", mock.Anything, "rifter", "", 20).Return(expectedResults, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/blueprints?q=rifter", nil)
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.SearchBlueprints(args)
+
+	assert.Nil(t, httpErr)
+	results := result.([]*repositories.BlueprintSearchRow)
+	assert.Len(t, results, 2)
+	assert.Equal(t, "Rifter Blueprint", results[0].BlueprintName)
+	mocks.sdeRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_SearchBlueprints_WithActivity(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	expectedResults := []*repositories.BlueprintSearchRow{
+		{BlueprintTypeID: 787, BlueprintName: "Rifter Blueprint", ProductTypeID: 587, ProductName: "Rifter", Activity: "manufacturing"},
+	}
+
+	mocks.sdeRepo.On("SearchBlueprints", mock.Anything, "rifter", "manufacturing", 20).Return(expectedResults, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/blueprints?q=rifter&activity=manufacturing", nil)
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.SearchBlueprints(args)
+
+	assert.Nil(t, httpErr)
+	results := result.([]*repositories.BlueprintSearchRow)
+	assert.Len(t, results, 1)
+	mocks.sdeRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_SearchBlueprints_MissingQuery(t *testing.T) {
+	controller, _ := setupIndustryController()
+
+	req := httptest.NewRequest("GET", "/v1/industry/blueprints", nil)
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.SearchBlueprints(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_IndustryController_SearchBlueprints_NilResults(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	mocks.sdeRepo.On("SearchBlueprints", mock.Anything, "nonexistent", "", 20).Return(nil, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/blueprints?q=nonexistent", nil)
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.SearchBlueprints(args)
+
+	assert.Nil(t, httpErr)
+	results := result.([]*repositories.BlueprintSearchRow)
+	assert.Len(t, results, 0)
+	mocks.sdeRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_SearchBlueprints_CustomLimit(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	mocks.sdeRepo.On("SearchBlueprints", mock.Anything, "rifter", "", 5).Return([]*repositories.BlueprintSearchRow{}, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/blueprints?q=rifter&limit=5", nil)
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.SearchBlueprints(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	mocks.sdeRepo.AssertExpectations(t)
+}
+
+// --- GetSystems Tests ---
+
+func Test_IndustryController_GetSystems_Success(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	expectedSystems := []*models.ReactionSystem{
+		{SystemID: 30000142, Name: "Jita", SecurityStatus: 0.9, CostIndex: 0.05},
+		{SystemID: 30002187, Name: "Amarr", SecurityStatus: 1.0, CostIndex: 0.03},
+	}
+
+	mocks.sdeRepo.On("GetManufacturingSystems", mock.Anything).Return(expectedSystems, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/systems", nil)
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.GetSystems(args)
+
+	assert.Nil(t, httpErr)
+	systems := result.([]*models.ReactionSystem)
+	assert.Len(t, systems, 2)
+	assert.Equal(t, "Jita", systems[0].Name)
+	mocks.sdeRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_GetSystems_NilResults(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	mocks.sdeRepo.On("GetManufacturingSystems", mock.Anything).Return(nil, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/systems", nil)
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.GetSystems(args)
+
+	assert.Nil(t, httpErr)
+	systems := result.([]*models.ReactionSystem)
+	assert.Len(t, systems, 0)
+	mocks.sdeRepo.AssertExpectations(t)
+}
+
+func Test_IndustryController_GetSystems_Error(t *testing.T) {
+	controller, mocks := setupIndustryController()
+
+	mocks.sdeRepo.On("GetManufacturingSystems", mock.Anything).Return(nil, errors.New("database error"))
+
+	req := httptest.NewRequest("GET", "/v1/industry/systems", nil)
+	args := &web.HandlerArgs{Request: req}
+
+	result, httpErr := controller.GetSystems(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 500, httpErr.StatusCode)
+	mocks.sdeRepo.AssertExpectations(t)
+}

--- a/internal/database/migrations/20260222014855_create_character_skills.down.sql
+++ b/internal/database/migrations/20260222014855_create_character_skills.down.sql
@@ -1,0 +1,1 @@
+drop table if exists character_skills;

--- a/internal/database/migrations/20260222014855_create_character_skills.up.sql
+++ b/internal/database/migrations/20260222014855_create_character_skills.up.sql
@@ -1,0 +1,12 @@
+create table character_skills (
+	character_id	bigint		not null,
+	user_id		bigint		not null,
+	skill_id	bigint		not null,
+	trained_level	int		not null default 0,
+	active_level	int		not null default 0,
+	skillpoints	bigint		not null default 0,
+	updated_at	timestamptz	not null default now(),
+	primary key (character_id, skill_id)
+);
+
+create index idx_character_skills_user on character_skills (user_id);

--- a/internal/database/migrations/20260222014858_create_esi_industry_jobs.down.sql
+++ b/internal/database/migrations/20260222014858_create_esi_industry_jobs.down.sql
@@ -1,0 +1,1 @@
+drop table if exists esi_industry_jobs;

--- a/internal/database/migrations/20260222014858_create_esi_industry_jobs.up.sql
+++ b/internal/database/migrations/20260222014858_create_esi_industry_jobs.up.sql
@@ -1,0 +1,30 @@
+create table esi_industry_jobs (
+	job_id			bigint		primary key,
+	installer_id		bigint		not null,
+	user_id			bigint		not null,
+	facility_id		bigint		not null,
+	station_id		bigint		not null,
+	activity_id		int		not null,
+	blueprint_id		bigint		not null,
+	blueprint_type_id	bigint		not null,
+	blueprint_location_id	bigint		not null,
+	output_location_id	bigint		not null,
+	runs			int		not null,
+	cost			float8,
+	licensed_runs		int,
+	probability		float8,
+	product_type_id		bigint,
+	status			text		not null,
+	duration		int		not null,
+	start_date		timestamptz	not null,
+	end_date		timestamptz	not null,
+	pause_date		timestamptz,
+	completed_date		timestamptz,
+	completed_character_id	bigint,
+	successful_runs		int,
+	solar_system_id		bigint,
+	updated_at		timestamptz	not null default now()
+);
+
+create index idx_esi_jobs_user on esi_industry_jobs (user_id);
+create index idx_esi_jobs_status on esi_industry_jobs (status);

--- a/internal/database/migrations/20260222014859_create_industry_job_queue.down.sql
+++ b/internal/database/migrations/20260222014859_create_industry_job_queue.down.sql
@@ -1,0 +1,1 @@
+drop table if exists industry_job_queue;

--- a/internal/database/migrations/20260222014859_create_industry_job_queue.up.sql
+++ b/internal/database/migrations/20260222014859_create_industry_job_queue.up.sql
@@ -1,0 +1,23 @@
+create table industry_job_queue (
+	id			bigserial	primary key,
+	user_id			bigint		not null,
+	character_id		bigint,
+	blueprint_type_id	bigint		not null,
+	activity		text		not null,
+	runs			int		not null,
+	me_level		int		not null default 0,
+	te_level		int		not null default 0,
+	system_id		bigint,
+	facility_tax		float8		not null default 0,
+	status			text		not null default 'planned',
+	esi_job_id		bigint,
+	product_type_id		bigint,
+	estimated_cost		float8,
+	estimated_duration	int,
+	notes			text,
+	created_at		timestamptz	not null default now(),
+	updated_at		timestamptz	not null default now()
+);
+
+create index idx_job_queue_user on industry_job_queue (user_id);
+create index idx_job_queue_status on industry_job_queue (status);

--- a/internal/database/migrations/20260222125510_add_source_to_esi_industry_jobs.down.sql
+++ b/internal/database/migrations/20260222125510_add_source_to_esi_industry_jobs.down.sql
@@ -1,0 +1,1 @@
+alter table esi_industry_jobs drop column source;

--- a/internal/database/migrations/20260222125510_add_source_to_esi_industry_jobs.up.sql
+++ b/internal/database/migrations/20260222125510_add_source_to_esi_industry_jobs.up.sql
@@ -1,0 +1,1 @@
+alter table esi_industry_jobs add column source text not null default 'character';

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -753,3 +753,106 @@ type PiLaunchpadLabel struct {
 	PinID       int64  `json:"pinId"`
 	Label       string `json:"label"`
 }
+
+// Industry Job Manager Models
+
+type CharacterSkill struct {
+	CharacterID  int64     `json:"characterId"`
+	UserID       int64     `json:"userId"`
+	SkillID      int64     `json:"skillId"`
+	TrainedLevel int       `json:"trainedLevel"`
+	ActiveLevel  int       `json:"activeLevel"`
+	Skillpoints  int64     `json:"skillpoints"`
+	UpdatedAt    time.Time `json:"updatedAt"`
+}
+
+type IndustryJob struct {
+	JobID                int64      `json:"jobId"`
+	InstallerID          int64      `json:"installerId"`
+	UserID               int64      `json:"userId"`
+	FacilityID           int64      `json:"facilityId"`
+	StationID            int64      `json:"stationId"`
+	ActivityID           int        `json:"activityId"`
+	BlueprintID          int64      `json:"blueprintId"`
+	BlueprintTypeID      int64      `json:"blueprintTypeId"`
+	BlueprintLocationID  int64      `json:"blueprintLocationId"`
+	OutputLocationID     int64      `json:"outputLocationId"`
+	Runs                 int        `json:"runs"`
+	Cost                 *float64   `json:"cost"`
+	LicensedRuns         *int       `json:"licensedRuns"`
+	Probability          *float64   `json:"probability"`
+	ProductTypeID        *int64     `json:"productTypeId"`
+	Status               string     `json:"status"`
+	Duration             int        `json:"duration"`
+	StartDate            time.Time  `json:"startDate"`
+	EndDate              time.Time  `json:"endDate"`
+	PauseDate            *time.Time `json:"pauseDate"`
+	CompletedDate        *time.Time `json:"completedDate"`
+	CompletedCharacterID *int64     `json:"completedCharacterId"`
+	SuccessfulRuns       *int       `json:"successfulRuns"`
+	SolarSystemID        *int64     `json:"solarSystemId"`
+	Source               string     `json:"source"`
+	UpdatedAt            time.Time  `json:"updatedAt"`
+	// Enriched fields (joined from other tables)
+	BlueprintName string `json:"blueprintName,omitempty"`
+	ProductName   string `json:"productName,omitempty"`
+	InstallerName string `json:"installerName,omitempty"`
+	SystemName    string `json:"systemName,omitempty"`
+	ActivityName  string `json:"activityName,omitempty"`
+}
+
+type IndustryJobQueueEntry struct {
+	ID                int64      `json:"id"`
+	UserID            int64      `json:"userId"`
+	CharacterID       *int64     `json:"characterId"`
+	BlueprintTypeID   int64      `json:"blueprintTypeId"`
+	Activity          string     `json:"activity"`
+	Runs              int        `json:"runs"`
+	MELevel           int        `json:"meLevel"`
+	TELevel           int        `json:"teLevel"`
+	SystemID          *int64     `json:"systemId"`
+	FacilityTax       float64    `json:"facilityTax"`
+	Status            string     `json:"status"`
+	EsiJobID          *int64     `json:"esiJobId"`
+	ProductTypeID     *int64     `json:"productTypeId"`
+	EstimatedCost     *float64   `json:"estimatedCost"`
+	EstimatedDuration *int       `json:"estimatedDuration"`
+	Notes             *string    `json:"notes"`
+	CreatedAt         time.Time  `json:"createdAt"`
+	UpdatedAt         time.Time  `json:"updatedAt"`
+	// Enriched fields
+	BlueprintName string     `json:"blueprintName,omitempty"`
+	ProductName   string     `json:"productName,omitempty"`
+	CharacterName string     `json:"characterName,omitempty"`
+	SystemName    string     `json:"systemName,omitempty"`
+	EsiJobEndDate *time.Time `json:"esiJobEndDate,omitempty"`
+	EsiJobSource  string     `json:"esiJobSource,omitempty"`
+}
+
+type ManufacturingCalcResult struct {
+	BlueprintTypeID int64                   `json:"blueprintTypeId"`
+	ProductTypeID   int64                   `json:"productTypeId"`
+	ProductName     string                  `json:"productName"`
+	Runs            int                     `json:"runs"`
+	MEFactor        float64                 `json:"meFactor"`
+	TEFactor        float64                 `json:"teFactor"`
+	SecsPerRun      int                     `json:"secsPerRun"`
+	TotalDuration   int                     `json:"totalDuration"`
+	TotalProducts   int                     `json:"totalProducts"`
+	InputCost       float64                 `json:"inputCost"`
+	JobCost         float64                 `json:"jobCost"`
+	TotalCost       float64                 `json:"totalCost"`
+	OutputValue     float64                 `json:"outputValue"`
+	Profit          float64                 `json:"profit"`
+	Margin          float64                 `json:"margin"`
+	Materials       []*ManufacturingMaterial `json:"materials"`
+}
+
+type ManufacturingMaterial struct {
+	TypeID   int64   `json:"typeId"`
+	Name     string  `json:"name"`
+	BaseQty  int     `json:"baseQty"`
+	BatchQty int64   `json:"batchQty"`
+	Price    float64 `json:"price"`
+	Cost     float64 `json:"cost"`
+}

--- a/internal/repositories/characterSkills.go
+++ b/internal/repositories/characterSkills.go
@@ -1,0 +1,173 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+type CharacterSkills struct {
+	db *sql.DB
+}
+
+func NewCharacterSkills(db *sql.DB) *CharacterSkills {
+	return &CharacterSkills{db: db}
+}
+
+func (r *CharacterSkills) UpsertSkills(ctx context.Context, characterID, userID int64, skills []*models.CharacterSkill) error {
+	if len(skills) == 0 {
+		return nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction for character skills upsert")
+	}
+	defer tx.Rollback()
+
+	upsertQuery := `
+		INSERT INTO character_skills
+			(character_id, user_id, skill_id, trained_level, active_level, skillpoints, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, now())
+		ON CONFLICT (character_id, skill_id)
+		DO UPDATE SET
+			user_id = EXCLUDED.user_id,
+			trained_level = EXCLUDED.trained_level,
+			active_level = EXCLUDED.active_level,
+			skillpoints = EXCLUDED.skillpoints,
+			updated_at = now()
+	`
+
+	stmt, err := tx.PrepareContext(ctx, upsertQuery)
+	if err != nil {
+		return errors.Wrap(err, "failed to prepare character skill upsert")
+	}
+
+	for _, skill := range skills {
+		_, err = stmt.ExecContext(ctx,
+			characterID,
+			userID,
+			skill.SkillID,
+			skill.TrainedLevel,
+			skill.ActiveLevel,
+			skill.Skillpoints,
+		)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute character skill upsert")
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return errors.Wrap(err, "failed to commit character skills transaction")
+	}
+	return nil
+}
+
+func (r *CharacterSkills) GetSkills(ctx context.Context, characterID int64) ([]*models.CharacterSkill, error) {
+	query := `
+		SELECT character_id, user_id, skill_id, trained_level, active_level, skillpoints, updated_at
+		FROM character_skills
+		WHERE character_id = $1
+		ORDER BY skill_id
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, characterID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query character skills")
+	}
+	defer rows.Close()
+
+	skills := []*models.CharacterSkill{}
+	for rows.Next() {
+		var skill models.CharacterSkill
+		err = rows.Scan(
+			&skill.CharacterID,
+			&skill.UserID,
+			&skill.SkillID,
+			&skill.TrainedLevel,
+			&skill.ActiveLevel,
+			&skill.Skillpoints,
+			&skill.UpdatedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan character skill")
+		}
+		skills = append(skills, &skill)
+	}
+
+	return skills, nil
+}
+
+// GetIndustrySkills returns a map of skill_type_id → active_level for industry-relevant skills
+// for a given character. This is used by the manufacturing calculator.
+func (r *CharacterSkills) GetIndustrySkills(ctx context.Context, characterID int64, skillTypeIDs []int64) (map[int64]int, error) {
+	if len(skillTypeIDs) == 0 {
+		return map[int64]int{}, nil
+	}
+
+	query := `
+		SELECT skill_id, active_level
+		FROM character_skills
+		WHERE character_id = $1
+		  AND skill_id = ANY($2::bigint[])
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, characterID, pq.Array(skillTypeIDs))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query industry skills")
+	}
+	defer rows.Close()
+
+	result := map[int64]int{}
+	for rows.Next() {
+		var skillID int64
+		var level int
+		err = rows.Scan(&skillID, &level)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan industry skill")
+		}
+		result[skillID] = level
+	}
+
+	return result, nil
+}
+
+// GetSkillsForUser returns all skills for all characters belonging to a user.
+func (r *CharacterSkills) GetSkillsForUser(ctx context.Context, userID int64) ([]*models.CharacterSkill, error) {
+	query := `
+		SELECT character_id, user_id, skill_id, trained_level, active_level, skillpoints, updated_at
+		FROM character_skills
+		WHERE user_id = $1
+		ORDER BY character_id, skill_id
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query user skills")
+	}
+	defer rows.Close()
+
+	skills := []*models.CharacterSkill{}
+	for rows.Next() {
+		var skill models.CharacterSkill
+		err = rows.Scan(
+			&skill.CharacterID,
+			&skill.UserID,
+			&skill.SkillID,
+			&skill.TrainedLevel,
+			&skill.ActiveLevel,
+			&skill.Skillpoints,
+			&skill.UpdatedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan user skill")
+		}
+		skills = append(skills, &skill)
+	}
+
+	return skills, nil
+}

--- a/internal/repositories/characterSkills_test.go
+++ b/internal/repositories/characterSkills_test.go
@@ -1,0 +1,190 @@
+package repositories_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_CharacterSkillsShouldUpsertAndGet(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	characterRepo := repositories.NewCharacterRepository(db)
+	skillsRepo := repositories.NewCharacterSkills(db)
+
+	user := &repositories.User{ID: 5000, Name: "Skills Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	char := &repositories.Character{ID: 50001, Name: "Skills Char", UserID: user.ID}
+	err = characterRepo.Add(context.Background(), char)
+	assert.NoError(t, err)
+
+	skills := []*models.CharacterSkill{
+		{SkillID: 3380, TrainedLevel: 5, ActiveLevel: 5, Skillpoints: 256000},
+		{SkillID: 3388, TrainedLevel: 4, ActiveLevel: 4, Skillpoints: 45255},
+		{SkillID: 22242, TrainedLevel: 3, ActiveLevel: 3, Skillpoints: 16000},
+	}
+
+	err = skillsRepo.UpsertSkills(context.Background(), char.ID, user.ID, skills)
+	assert.NoError(t, err)
+
+	result, err := skillsRepo.GetSkills(context.Background(), char.ID)
+	assert.NoError(t, err)
+	assert.Len(t, result, 3)
+	assert.Equal(t, int64(3380), result[0].SkillID)
+	assert.Equal(t, 5, result[0].TrainedLevel)
+	assert.Equal(t, 5, result[0].ActiveLevel)
+	assert.Equal(t, int64(256000), result[0].Skillpoints)
+	assert.Equal(t, char.ID, result[0].CharacterID)
+	assert.Equal(t, user.ID, result[0].UserID)
+}
+
+func Test_CharacterSkillsShouldUpsertExistingSkills(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	characterRepo := repositories.NewCharacterRepository(db)
+	skillsRepo := repositories.NewCharacterSkills(db)
+
+	user := &repositories.User{ID: 5010, Name: "Skills Upsert User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	char := &repositories.Character{ID: 50101, Name: "Upsert Char", UserID: user.ID}
+	err = characterRepo.Add(context.Background(), char)
+	assert.NoError(t, err)
+
+	// Insert initial skills
+	skills := []*models.CharacterSkill{
+		{SkillID: 3380, TrainedLevel: 4, ActiveLevel: 4, Skillpoints: 45000},
+	}
+	err = skillsRepo.UpsertSkills(context.Background(), char.ID, user.ID, skills)
+	assert.NoError(t, err)
+
+	// Upsert with updated levels
+	updatedSkills := []*models.CharacterSkill{
+		{SkillID: 3380, TrainedLevel: 5, ActiveLevel: 5, Skillpoints: 256000},
+	}
+	err = skillsRepo.UpsertSkills(context.Background(), char.ID, user.ID, updatedSkills)
+	assert.NoError(t, err)
+
+	result, err := skillsRepo.GetSkills(context.Background(), char.ID)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, 5, result[0].TrainedLevel)
+	assert.Equal(t, int64(256000), result[0].Skillpoints)
+}
+
+func Test_CharacterSkillsShouldGetIndustrySkills(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	characterRepo := repositories.NewCharacterRepository(db)
+	skillsRepo := repositories.NewCharacterSkills(db)
+
+	user := &repositories.User{ID: 5020, Name: "Industry Skills User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	char := &repositories.Character{ID: 50201, Name: "Industry Char", UserID: user.ID}
+	err = characterRepo.Add(context.Background(), char)
+	assert.NoError(t, err)
+
+	skills := []*models.CharacterSkill{
+		{SkillID: 3380, TrainedLevel: 5, ActiveLevel: 5, Skillpoints: 256000},  // Industry
+		{SkillID: 3388, TrainedLevel: 4, ActiveLevel: 4, Skillpoints: 45255},  // Advanced Industry
+		{SkillID: 22242, TrainedLevel: 3, ActiveLevel: 3, Skillpoints: 16000}, // Some other skill
+		{SkillID: 11529, TrainedLevel: 2, ActiveLevel: 2, Skillpoints: 5000},  // Reactions
+	}
+
+	err = skillsRepo.UpsertSkills(context.Background(), char.ID, user.ID, skills)
+	assert.NoError(t, err)
+
+	// Query only Industry and Reactions skill IDs
+	industrySkills, err := skillsRepo.GetIndustrySkills(context.Background(), char.ID, []int64{3380, 11529})
+	assert.NoError(t, err)
+	assert.Len(t, industrySkills, 2)
+	assert.Equal(t, 5, industrySkills[3380])
+	assert.Equal(t, 2, industrySkills[11529])
+}
+
+func Test_CharacterSkillsShouldReturnEmptyForNoSkills(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	skillsRepo := repositories.NewCharacterSkills(db)
+
+	result, err := skillsRepo.GetSkills(context.Background(), 99999)
+	assert.NoError(t, err)
+	assert.Len(t, result, 0)
+}
+
+func Test_CharacterSkillsShouldHandleEmptyUpsert(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	skillsRepo := repositories.NewCharacterSkills(db)
+
+	err = skillsRepo.UpsertSkills(context.Background(), 99999, 99999, []*models.CharacterSkill{})
+	assert.NoError(t, err)
+}
+
+func Test_CharacterSkillsShouldGetEmptyIndustrySkills(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	skillsRepo := repositories.NewCharacterSkills(db)
+
+	result, err := skillsRepo.GetIndustrySkills(context.Background(), 99999, []int64{})
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func Test_CharacterSkillsShouldGetSkillsForUser(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	characterRepo := repositories.NewCharacterRepository(db)
+	skillsRepo := repositories.NewCharacterSkills(db)
+
+	user := &repositories.User{ID: 5030, Name: "Multi-Char User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	char1 := &repositories.Character{ID: 50301, Name: "Char 1", UserID: user.ID}
+	char2 := &repositories.Character{ID: 50302, Name: "Char 2", UserID: user.ID}
+	err = characterRepo.Add(context.Background(), char1)
+	assert.NoError(t, err)
+	err = characterRepo.Add(context.Background(), char2)
+	assert.NoError(t, err)
+
+	skills1 := []*models.CharacterSkill{
+		{SkillID: 3380, TrainedLevel: 5, ActiveLevel: 5, Skillpoints: 256000},
+	}
+	skills2 := []*models.CharacterSkill{
+		{SkillID: 3380, TrainedLevel: 3, ActiveLevel: 3, Skillpoints: 16000},
+	}
+
+	err = skillsRepo.UpsertSkills(context.Background(), char1.ID, user.ID, skills1)
+	assert.NoError(t, err)
+	err = skillsRepo.UpsertSkills(context.Background(), char2.ID, user.ID, skills2)
+	assert.NoError(t, err)
+
+	result, err := skillsRepo.GetSkillsForUser(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	// Ordered by character_id, skill_id
+	assert.Equal(t, char1.ID, result[0].CharacterID)
+	assert.Equal(t, 5, result[0].ActiveLevel)
+	assert.Equal(t, char2.ID, result[1].CharacterID)
+	assert.Equal(t, 3, result[1].ActiveLevel)
+}

--- a/internal/repositories/industryJobs.go
+++ b/internal/repositories/industryJobs.go
@@ -1,0 +1,308 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/pkg/errors"
+)
+
+type IndustryJobs struct {
+	db *sql.DB
+}
+
+func NewIndustryJobs(db *sql.DB) *IndustryJobs {
+	return &IndustryJobs{db: db}
+}
+
+func (r *IndustryJobs) UpsertJobs(ctx context.Context, userID int64, jobs []*models.IndustryJob) error {
+	if len(jobs) == 0 {
+		return nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction for industry jobs upsert")
+	}
+	defer tx.Rollback()
+
+	upsertQuery := `
+		INSERT INTO esi_industry_jobs
+			(job_id, installer_id, user_id, facility_id, station_id, activity_id,
+			 blueprint_id, blueprint_type_id, blueprint_location_id, output_location_id,
+			 runs, cost, licensed_runs, probability, product_type_id, status,
+			 duration, start_date, end_date, pause_date, completed_date,
+			 completed_character_id, successful_runs, solar_system_id, source, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, now())
+		ON CONFLICT (job_id)
+		DO UPDATE SET
+			status = EXCLUDED.status,
+			pause_date = EXCLUDED.pause_date,
+			completed_date = EXCLUDED.completed_date,
+			completed_character_id = EXCLUDED.completed_character_id,
+			successful_runs = EXCLUDED.successful_runs,
+			source = EXCLUDED.source,
+			updated_at = now()
+	`
+
+	stmt, err := tx.PrepareContext(ctx, upsertQuery)
+	if err != nil {
+		return errors.Wrap(err, "failed to prepare industry job upsert")
+	}
+
+	for _, job := range jobs {
+		_, err = stmt.ExecContext(ctx,
+			job.JobID,
+			job.InstallerID,
+			userID,
+			job.FacilityID,
+			job.StationID,
+			job.ActivityID,
+			job.BlueprintID,
+			job.BlueprintTypeID,
+			job.BlueprintLocationID,
+			job.OutputLocationID,
+			job.Runs,
+			job.Cost,
+			job.LicensedRuns,
+			job.Probability,
+			job.ProductTypeID,
+			job.Status,
+			job.Duration,
+			job.StartDate,
+			job.EndDate,
+			job.PauseDate,
+			job.CompletedDate,
+			job.CompletedCharacterID,
+			job.SuccessfulRuns,
+			job.SolarSystemID,
+			job.Source,
+		)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute industry job upsert")
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return errors.Wrap(err, "failed to commit industry jobs transaction")
+	}
+	return nil
+}
+
+// GetActiveJobs returns active (non-delivered, non-cancelled) ESI industry jobs for a user,
+// enriched with blueprint/product/system names.
+func (r *IndustryJobs) GetActiveJobs(ctx context.Context, userID int64) ([]*models.IndustryJob, error) {
+	query := `
+		SELECT j.job_id, j.installer_id, j.user_id, j.facility_id, j.station_id,
+		       j.activity_id, j.blueprint_id, j.blueprint_type_id, j.blueprint_location_id,
+		       j.output_location_id, j.runs, j.cost, j.licensed_runs, j.probability,
+		       j.product_type_id, j.status, j.duration, j.start_date, j.end_date,
+		       j.pause_date, j.completed_date, j.completed_character_id, j.successful_runs,
+		       j.solar_system_id, j.source, j.updated_at,
+		       COALESCE(bp.type_name, ''),
+		       COALESCE(prod.type_name, ''),
+		       COALESCE(c.name, ''),
+		       COALESCE(ss.name, ss2.name, '')
+		FROM esi_industry_jobs j
+		LEFT JOIN asset_item_types bp ON bp.type_id = j.blueprint_type_id
+		LEFT JOIN asset_item_types prod ON prod.type_id = j.product_type_id
+		LEFT JOIN characters c ON c.id = j.installer_id
+		LEFT JOIN solar_systems ss ON ss.solar_system_id = j.solar_system_id
+		LEFT JOIN stations st ON st.station_id = j.station_id
+		LEFT JOIN solar_systems ss2 ON ss2.solar_system_id = st.solar_system_id
+		WHERE j.user_id = $1
+		  AND j.status IN ('active', 'paused', 'ready')
+		ORDER BY j.end_date ASC
+	`
+
+	return r.queryJobs(ctx, query, userID)
+}
+
+// GetAllJobs returns all ESI industry jobs for a user (including completed/cancelled).
+func (r *IndustryJobs) GetAllJobs(ctx context.Context, userID int64) ([]*models.IndustryJob, error) {
+	query := `
+		SELECT j.job_id, j.installer_id, j.user_id, j.facility_id, j.station_id,
+		       j.activity_id, j.blueprint_id, j.blueprint_type_id, j.blueprint_location_id,
+		       j.output_location_id, j.runs, j.cost, j.licensed_runs, j.probability,
+		       j.product_type_id, j.status, j.duration, j.start_date, j.end_date,
+		       j.pause_date, j.completed_date, j.completed_character_id, j.successful_runs,
+		       j.solar_system_id, j.source, j.updated_at,
+		       COALESCE(bp.type_name, ''),
+		       COALESCE(prod.type_name, ''),
+		       COALESCE(c.name, ''),
+		       COALESCE(ss.name, ss2.name, '')
+		FROM esi_industry_jobs j
+		LEFT JOIN asset_item_types bp ON bp.type_id = j.blueprint_type_id
+		LEFT JOIN asset_item_types prod ON prod.type_id = j.product_type_id
+		LEFT JOIN characters c ON c.id = j.installer_id
+		LEFT JOIN solar_systems ss ON ss.solar_system_id = j.solar_system_id
+		LEFT JOIN stations st ON st.station_id = j.station_id
+		LEFT JOIN solar_systems ss2 ON ss2.solar_system_id = st.solar_system_id
+		WHERE j.user_id = $1
+		ORDER BY j.start_date DESC
+	`
+
+	return r.queryJobs(ctx, query, userID)
+}
+
+// GetActiveJobsForMatching returns active ESI jobs for queue matching (no enriched names needed).
+func (r *IndustryJobs) GetActiveJobsForMatching(ctx context.Context, userID int64) ([]*models.IndustryJob, error) {
+	query := `
+		SELECT job_id, installer_id, user_id, facility_id, station_id,
+		       activity_id, blueprint_id, blueprint_type_id, blueprint_location_id,
+		       output_location_id, runs, cost, licensed_runs, probability,
+		       product_type_id, status, duration, start_date, end_date,
+		       pause_date, completed_date, completed_character_id, successful_runs,
+		       solar_system_id, source, updated_at,
+		       '', '', '', ''
+		FROM esi_industry_jobs
+		WHERE user_id = $1
+		  AND status = 'active'
+		ORDER BY start_date DESC
+	`
+
+	return r.queryJobs(ctx, query, userID)
+}
+
+func (r *IndustryJobs) queryJobs(ctx context.Context, query string, args ...interface{}) ([]*models.IndustryJob, error) {
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query industry jobs")
+	}
+	defer rows.Close()
+
+	jobs := []*models.IndustryJob{}
+	for rows.Next() {
+		var job models.IndustryJob
+		err = rows.Scan(
+			&job.JobID,
+			&job.InstallerID,
+			&job.UserID,
+			&job.FacilityID,
+			&job.StationID,
+			&job.ActivityID,
+			&job.BlueprintID,
+			&job.BlueprintTypeID,
+			&job.BlueprintLocationID,
+			&job.OutputLocationID,
+			&job.Runs,
+			&job.Cost,
+			&job.LicensedRuns,
+			&job.Probability,
+			&job.ProductTypeID,
+			&job.Status,
+			&job.Duration,
+			&job.StartDate,
+			&job.EndDate,
+			&job.PauseDate,
+			&job.CompletedDate,
+			&job.CompletedCharacterID,
+			&job.SuccessfulRuns,
+			&job.SolarSystemID,
+			&job.Source,
+			&job.UpdatedAt,
+			&job.BlueprintName,
+			&job.ProductName,
+			&job.InstallerName,
+			&job.SystemName,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan industry job")
+		}
+
+		job.ActivityName = activityName(job.ActivityID)
+
+		jobs = append(jobs, &job)
+	}
+
+	return jobs, nil
+}
+
+// GetJobByID returns a single ESI industry job by its job_id.
+func (r *IndustryJobs) GetJobByID(ctx context.Context, jobID int64) (*models.IndustryJob, error) {
+	query := `
+		SELECT job_id, installer_id, user_id, facility_id, station_id,
+		       activity_id, blueprint_id, blueprint_type_id, blueprint_location_id,
+		       output_location_id, runs, cost, licensed_runs, probability,
+		       product_type_id, status, duration, start_date, end_date,
+		       pause_date, completed_date, completed_character_id, successful_runs,
+		       solar_system_id, source, updated_at
+		FROM esi_industry_jobs
+		WHERE job_id = $1
+	`
+
+	var job models.IndustryJob
+	err := r.db.QueryRowContext(ctx, query, jobID).Scan(
+		&job.JobID,
+		&job.InstallerID,
+		&job.UserID,
+		&job.FacilityID,
+		&job.StationID,
+		&job.ActivityID,
+		&job.BlueprintID,
+		&job.BlueprintTypeID,
+		&job.BlueprintLocationID,
+		&job.OutputLocationID,
+		&job.Runs,
+		&job.Cost,
+		&job.LicensedRuns,
+		&job.Probability,
+		&job.ProductTypeID,
+		&job.Status,
+		&job.Duration,
+		&job.StartDate,
+		&job.EndDate,
+		&job.PauseDate,
+		&job.CompletedDate,
+		&job.CompletedCharacterID,
+		&job.SuccessfulRuns,
+		&job.SolarSystemID,
+		&job.Source,
+		&job.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get industry job by id")
+	}
+
+	job.ActivityName = activityName(job.ActivityID)
+	return &job, nil
+}
+
+// DeleteOldDeliveredJobs removes delivered/cancelled jobs older than the given cutoff.
+func (r *IndustryJobs) DeleteOldDeliveredJobs(ctx context.Context, userID int64, before time.Time) (int64, error) {
+	result, err := r.db.ExecContext(ctx, `
+		DELETE FROM esi_industry_jobs
+		WHERE user_id = $1
+		  AND status IN ('delivered', 'cancelled', 'reverted')
+		  AND updated_at < $2
+	`, userID, before)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to delete old delivered jobs")
+	}
+	return result.RowsAffected()
+}
+
+func activityName(activityID int) string {
+	switch activityID {
+	case 1:
+		return "Manufacturing"
+	case 3:
+		return "TE Research"
+	case 4:
+		return "ME Research"
+	case 5:
+		return "Copying"
+	case 8:
+		return "Invention"
+	case 9:
+		return "Reaction"
+	default:
+		return "Unknown"
+	}
+}

--- a/internal/repositories/industryJobs_test.go
+++ b/internal/repositories/industryJobs_test.go
@@ -1,0 +1,322 @@
+package repositories_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_IndustryJobsShouldUpsertAndGetActive(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	jobsRepo := repositories.NewIndustryJobs(db)
+
+	user := &repositories.User{ID: 6000, Name: "Jobs Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	cost := 1500000.0
+	productTypeID := int64(34)
+	solarSystemID := int64(30000142) // Jita
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	jobs := []*models.IndustryJob{
+		{
+			JobID:               100001,
+			InstallerID:         60001,
+			FacilityID:          60003760,
+			StationID:           60003760,
+			ActivityID:          1,
+			BlueprintID:         9876,
+			BlueprintTypeID:     787,
+			BlueprintLocationID: 60003760,
+			OutputLocationID:    60003760,
+			Runs:                10,
+			Cost:                &cost,
+			ProductTypeID:       &productTypeID,
+			Status:              "active",
+			Duration:            3600,
+			StartDate:           now,
+			EndDate:             now.Add(time.Hour),
+			SolarSystemID:       &solarSystemID,
+		},
+	}
+
+	err = jobsRepo.UpsertJobs(context.Background(), user.ID, jobs)
+	assert.NoError(t, err)
+
+	activeJobs, err := jobsRepo.GetActiveJobs(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, activeJobs, 1)
+	assert.Equal(t, int64(100001), activeJobs[0].JobID)
+	assert.Equal(t, 1, activeJobs[0].ActivityID)
+	assert.Equal(t, "active", activeJobs[0].Status)
+	assert.Equal(t, 10, activeJobs[0].Runs)
+	assert.Equal(t, 1500000.0, *activeJobs[0].Cost)
+	assert.Equal(t, "Manufacturing", activeJobs[0].ActivityName)
+}
+
+func Test_IndustryJobsShouldUpsertStatusChange(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	jobsRepo := repositories.NewIndustryJobs(db)
+
+	user := &repositories.User{ID: 6010, Name: "Status Change User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	// Insert active job
+	jobs := []*models.IndustryJob{
+		{
+			JobID:               100010,
+			InstallerID:         60001,
+			FacilityID:          60003760,
+			StationID:           60003760,
+			ActivityID:          9,
+			BlueprintID:         1111,
+			BlueprintTypeID:     46166,
+			BlueprintLocationID: 60003760,
+			OutputLocationID:    60003760,
+			Runs:                100,
+			Status:              "active",
+			Duration:            7200,
+			StartDate:           now,
+			EndDate:             now.Add(2 * time.Hour),
+		},
+	}
+
+	err = jobsRepo.UpsertJobs(context.Background(), user.ID, jobs)
+	assert.NoError(t, err)
+
+	// Mark as delivered
+	completedDate := now.Add(2 * time.Hour)
+	successfulRuns := 100
+	jobs[0].Status = "delivered"
+	jobs[0].CompletedDate = &completedDate
+	jobs[0].SuccessfulRuns = &successfulRuns
+
+	err = jobsRepo.UpsertJobs(context.Background(), user.ID, jobs)
+	assert.NoError(t, err)
+
+	// Active query should return empty
+	activeJobs, err := jobsRepo.GetActiveJobs(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, activeJobs, 0)
+
+	// All jobs should show delivered
+	allJobs, err := jobsRepo.GetAllJobs(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, allJobs, 1)
+	assert.Equal(t, "delivered", allJobs[0].Status)
+	assert.Equal(t, "Reaction", allJobs[0].ActivityName)
+}
+
+func Test_IndustryJobsShouldGetJobByID(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	jobsRepo := repositories.NewIndustryJobs(db)
+
+	user := &repositories.User{ID: 6020, Name: "GetByID User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	jobs := []*models.IndustryJob{
+		{
+			JobID:               100020,
+			InstallerID:         60001,
+			FacilityID:          60003760,
+			StationID:           60003760,
+			ActivityID:          8,
+			BlueprintID:         2222,
+			BlueprintTypeID:     999,
+			BlueprintLocationID: 60003760,
+			OutputLocationID:    60003760,
+			Runs:                1,
+			Status:              "active",
+			Duration:            1800,
+			StartDate:           now,
+			EndDate:             now.Add(30 * time.Minute),
+		},
+	}
+
+	err = jobsRepo.UpsertJobs(context.Background(), user.ID, jobs)
+	assert.NoError(t, err)
+
+	job, err := jobsRepo.GetJobByID(context.Background(), 100020)
+	assert.NoError(t, err)
+	assert.NotNil(t, job)
+	assert.Equal(t, int64(100020), job.JobID)
+	assert.Equal(t, "Invention", job.ActivityName)
+
+	// Non-existent job
+	noJob, err := jobsRepo.GetJobByID(context.Background(), 999999)
+	assert.NoError(t, err)
+	assert.Nil(t, noJob)
+}
+
+func Test_IndustryJobsShouldDeleteOldDeliveredJobs(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	jobsRepo := repositories.NewIndustryJobs(db)
+
+	user := &repositories.User{ID: 6030, Name: "Delete Old User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	jobs := []*models.IndustryJob{
+		{
+			JobID:               100030,
+			InstallerID:         60001,
+			FacilityID:          60003760,
+			StationID:           60003760,
+			ActivityID:          1,
+			BlueprintID:         3333,
+			BlueprintTypeID:     787,
+			BlueprintLocationID: 60003760,
+			OutputLocationID:    60003760,
+			Runs:                5,
+			Status:              "delivered",
+			Duration:            3600,
+			StartDate:           now.Add(-48 * time.Hour),
+			EndDate:             now.Add(-47 * time.Hour),
+		},
+		{
+			JobID:               100031,
+			InstallerID:         60001,
+			FacilityID:          60003760,
+			StationID:           60003760,
+			ActivityID:          1,
+			BlueprintID:         4444,
+			BlueprintTypeID:     787,
+			BlueprintLocationID: 60003760,
+			OutputLocationID:    60003760,
+			Runs:                10,
+			Status:              "active",
+			Duration:            3600,
+			StartDate:           now,
+			EndDate:             now.Add(time.Hour),
+		},
+	}
+
+	err = jobsRepo.UpsertJobs(context.Background(), user.ID, jobs)
+	assert.NoError(t, err)
+
+	deleted, err := jobsRepo.DeleteOldDeliveredJobs(context.Background(), user.ID, now.Add(time.Minute))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), deleted)
+
+	// Active job should remain
+	allJobs, err := jobsRepo.GetAllJobs(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, allJobs, 1)
+	assert.Equal(t, int64(100031), allJobs[0].JobID)
+}
+
+func Test_IndustryJobsShouldHandleEmptyUpsert(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	jobsRepo := repositories.NewIndustryJobs(db)
+
+	err = jobsRepo.UpsertJobs(context.Background(), 99999, []*models.IndustryJob{})
+	assert.NoError(t, err)
+}
+
+func Test_IndustryJobsShouldGetActiveJobsForMatching(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	jobsRepo := repositories.NewIndustryJobs(db)
+
+	user := &repositories.User{ID: 6040, Name: "Matching User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	jobs := []*models.IndustryJob{
+		{
+			JobID: 100040, InstallerID: 60001, FacilityID: 60003760, StationID: 60003760,
+			ActivityID: 1, BlueprintID: 5555, BlueprintTypeID: 787,
+			BlueprintLocationID: 60003760, OutputLocationID: 60003760,
+			Runs: 10, Status: "active", Duration: 3600,
+			StartDate: now, EndDate: now.Add(time.Hour),
+		},
+		{
+			JobID: 100041, InstallerID: 60001, FacilityID: 60003760, StationID: 60003760,
+			ActivityID: 1, BlueprintID: 6666, BlueprintTypeID: 787,
+			BlueprintLocationID: 60003760, OutputLocationID: 60003760,
+			Runs: 5, Status: "delivered", Duration: 3600,
+			StartDate: now.Add(-2 * time.Hour), EndDate: now.Add(-time.Hour),
+		},
+	}
+
+	err = jobsRepo.UpsertJobs(context.Background(), user.ID, jobs)
+	assert.NoError(t, err)
+
+	activeJobs, err := jobsRepo.GetActiveJobsForMatching(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, activeJobs, 1)
+	assert.Equal(t, int64(100040), activeJobs[0].JobID)
+}
+
+func Test_IndustryJobsShouldMapActivityNames(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	jobsRepo := repositories.NewIndustryJobs(db)
+
+	user := &repositories.User{ID: 6050, Name: "Activity Names User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	jobs := []*models.IndustryJob{
+		{JobID: 100050, InstallerID: 60001, FacilityID: 60003760, StationID: 60003760, ActivityID: 1, BlueprintID: 1, BlueprintTypeID: 787, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 1, Status: "active", Duration: 3600, StartDate: now, EndDate: now.Add(time.Hour)},
+		{JobID: 100051, InstallerID: 60001, FacilityID: 60003760, StationID: 60003760, ActivityID: 3, BlueprintID: 2, BlueprintTypeID: 787, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 1, Status: "active", Duration: 3600, StartDate: now, EndDate: now.Add(time.Hour)},
+		{JobID: 100052, InstallerID: 60001, FacilityID: 60003760, StationID: 60003760, ActivityID: 4, BlueprintID: 3, BlueprintTypeID: 787, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 1, Status: "active", Duration: 3600, StartDate: now, EndDate: now.Add(time.Hour)},
+		{JobID: 100053, InstallerID: 60001, FacilityID: 60003760, StationID: 60003760, ActivityID: 5, BlueprintID: 4, BlueprintTypeID: 787, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 1, Status: "active", Duration: 3600, StartDate: now, EndDate: now.Add(time.Hour)},
+		{JobID: 100054, InstallerID: 60001, FacilityID: 60003760, StationID: 60003760, ActivityID: 8, BlueprintID: 5, BlueprintTypeID: 787, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 1, Status: "active", Duration: 3600, StartDate: now, EndDate: now.Add(time.Hour)},
+		{JobID: 100055, InstallerID: 60001, FacilityID: 60003760, StationID: 60003760, ActivityID: 9, BlueprintID: 6, BlueprintTypeID: 787, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 1, Status: "active", Duration: 3600, StartDate: now, EndDate: now.Add(time.Hour)},
+	}
+
+	err = jobsRepo.UpsertJobs(context.Background(), user.ID, jobs)
+	assert.NoError(t, err)
+
+	allJobs, err := jobsRepo.GetActiveJobs(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, allJobs, 6)
+
+	nameMap := map[int64]string{}
+	for _, j := range allJobs {
+		nameMap[j.JobID] = j.ActivityName
+	}
+
+	assert.Equal(t, "Manufacturing", nameMap[100050])
+	assert.Equal(t, "TE Research", nameMap[100051])
+	assert.Equal(t, "ME Research", nameMap[100052])
+	assert.Equal(t, "Copying", nameMap[100053])
+	assert.Equal(t, "Invention", nameMap[100054])
+	assert.Equal(t, "Reaction", nameMap[100055])
+}

--- a/internal/repositories/jobQueue.go
+++ b/internal/repositories/jobQueue.go
@@ -1,0 +1,298 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/pkg/errors"
+)
+
+type JobQueue struct {
+	db *sql.DB
+}
+
+func NewJobQueue(db *sql.DB) *JobQueue {
+	return &JobQueue{db: db}
+}
+
+func (r *JobQueue) Create(ctx context.Context, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error) {
+	query := `
+		INSERT INTO industry_job_queue
+			(user_id, character_id, blueprint_type_id, activity, runs,
+			 me_level, te_level, system_id, facility_tax, status,
+			 product_type_id, estimated_cost, estimated_duration, notes)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'planned', $10, $11, $12, $13)
+		RETURNING id, user_id, character_id, blueprint_type_id, activity, runs,
+		          me_level, te_level, system_id, facility_tax, status, esi_job_id,
+		          product_type_id, estimated_cost, estimated_duration, notes,
+		          created_at, updated_at
+	`
+
+	var created models.IndustryJobQueueEntry
+	err := r.db.QueryRowContext(ctx, query,
+		entry.UserID,
+		entry.CharacterID,
+		entry.BlueprintTypeID,
+		entry.Activity,
+		entry.Runs,
+		entry.MELevel,
+		entry.TELevel,
+		entry.SystemID,
+		entry.FacilityTax,
+		entry.ProductTypeID,
+		entry.EstimatedCost,
+		entry.EstimatedDuration,
+		entry.Notes,
+	).Scan(
+		&created.ID,
+		&created.UserID,
+		&created.CharacterID,
+		&created.BlueprintTypeID,
+		&created.Activity,
+		&created.Runs,
+		&created.MELevel,
+		&created.TELevel,
+		&created.SystemID,
+		&created.FacilityTax,
+		&created.Status,
+		&created.EsiJobID,
+		&created.ProductTypeID,
+		&created.EstimatedCost,
+		&created.EstimatedDuration,
+		&created.Notes,
+		&created.CreatedAt,
+		&created.UpdatedAt,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create job queue entry")
+	}
+
+	return &created, nil
+}
+
+func (r *JobQueue) GetByUser(ctx context.Context, userID int64) ([]*models.IndustryJobQueueEntry, error) {
+	query := `
+		SELECT q.id, q.user_id, q.character_id, q.blueprint_type_id, q.activity, q.runs,
+		       q.me_level, q.te_level, q.system_id, q.facility_tax, q.status, q.esi_job_id,
+		       q.product_type_id, q.estimated_cost, q.estimated_duration, q.notes,
+		       q.created_at, q.updated_at,
+		       COALESCE(bp.type_name, ''),
+		       COALESCE(prod.type_name, ''),
+		       COALESCE(c.name, installer.name, ''),
+		       COALESCE(ss.name, ''),
+		       j.end_date,
+		       COALESCE(j.source, '')
+		FROM industry_job_queue q
+		LEFT JOIN asset_item_types bp ON bp.type_id = q.blueprint_type_id
+		LEFT JOIN asset_item_types prod ON prod.type_id = q.product_type_id
+		LEFT JOIN characters c ON c.id = q.character_id
+		LEFT JOIN solar_systems ss ON ss.solar_system_id = q.system_id
+		LEFT JOIN esi_industry_jobs j ON j.job_id = q.esi_job_id
+		LEFT JOIN characters installer ON installer.id = j.installer_id
+		WHERE q.user_id = $1
+		ORDER BY q.created_at DESC
+	`
+
+	return r.queryEntries(ctx, query, userID)
+}
+
+// GetPlannedJobs returns job queue entries with status='planned' for a user.
+func (r *JobQueue) GetPlannedJobs(ctx context.Context, userID int64) ([]*models.IndustryJobQueueEntry, error) {
+	query := `
+		SELECT q.id, q.user_id, q.character_id, q.blueprint_type_id, q.activity, q.runs,
+		       q.me_level, q.te_level, q.system_id, q.facility_tax, q.status, q.esi_job_id,
+		       q.product_type_id, q.estimated_cost, q.estimated_duration, q.notes,
+		       q.created_at, q.updated_at,
+		       '', '', '', '',
+		       CAST(NULL AS timestamptz),
+		       ''
+		FROM industry_job_queue q
+		WHERE q.user_id = $1
+		  AND q.status = 'planned'
+		ORDER BY q.created_at ASC
+	`
+
+	return r.queryEntries(ctx, query, userID)
+}
+
+func (r *JobQueue) Update(ctx context.Context, id, userID int64, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error) {
+	query := `
+		UPDATE industry_job_queue
+		SET character_id = $3,
+		    blueprint_type_id = $4,
+		    activity = $5,
+		    runs = $6,
+		    me_level = $7,
+		    te_level = $8,
+		    system_id = $9,
+		    facility_tax = $10,
+		    product_type_id = $11,
+		    estimated_cost = $12,
+		    estimated_duration = $13,
+		    notes = $14,
+		    updated_at = now()
+		WHERE id = $1 AND user_id = $2 AND status = 'planned'
+		RETURNING id, user_id, character_id, blueprint_type_id, activity, runs,
+		          me_level, te_level, system_id, facility_tax, status, esi_job_id,
+		          product_type_id, estimated_cost, estimated_duration, notes,
+		          created_at, updated_at
+	`
+
+	var updated models.IndustryJobQueueEntry
+	err := r.db.QueryRowContext(ctx, query,
+		id,
+		userID,
+		entry.CharacterID,
+		entry.BlueprintTypeID,
+		entry.Activity,
+		entry.Runs,
+		entry.MELevel,
+		entry.TELevel,
+		entry.SystemID,
+		entry.FacilityTax,
+		entry.ProductTypeID,
+		entry.EstimatedCost,
+		entry.EstimatedDuration,
+		entry.Notes,
+	).Scan(
+		&updated.ID,
+		&updated.UserID,
+		&updated.CharacterID,
+		&updated.BlueprintTypeID,
+		&updated.Activity,
+		&updated.Runs,
+		&updated.MELevel,
+		&updated.TELevel,
+		&updated.SystemID,
+		&updated.FacilityTax,
+		&updated.Status,
+		&updated.EsiJobID,
+		&updated.ProductTypeID,
+		&updated.EstimatedCost,
+		&updated.EstimatedDuration,
+		&updated.Notes,
+		&updated.CreatedAt,
+		&updated.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update job queue entry")
+	}
+
+	return &updated, nil
+}
+
+func (r *JobQueue) Cancel(ctx context.Context, id, userID int64) error {
+	result, err := r.db.ExecContext(ctx, `
+		UPDATE industry_job_queue
+		SET status = 'cancelled', updated_at = now()
+		WHERE id = $1 AND user_id = $2 AND status IN ('planned', 'active')
+	`, id, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to cancel job queue entry")
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected for cancel")
+	}
+	if rows == 0 {
+		return errors.New("job queue entry not found or not cancellable")
+	}
+
+	return nil
+}
+
+// LinkToEsiJob links a planned queue entry to an active ESI job.
+func (r *JobQueue) LinkToEsiJob(ctx context.Context, queueID, esiJobID int64) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE industry_job_queue
+		SET esi_job_id = $2, status = 'active', updated_at = now()
+		WHERE id = $1
+	`, queueID, esiJobID)
+	if err != nil {
+		return errors.Wrap(err, "failed to link queue entry to ESI job")
+	}
+	return nil
+}
+
+// CompleteJob marks a queue entry as completed.
+func (r *JobQueue) CompleteJob(ctx context.Context, queueID int64) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE industry_job_queue
+		SET status = 'completed', updated_at = now()
+		WHERE id = $1
+	`, queueID)
+	if err != nil {
+		return errors.Wrap(err, "failed to complete job queue entry")
+	}
+	return nil
+}
+
+// GetLinkedActiveJobs returns queue entries that are linked to ESI jobs (status='active').
+func (r *JobQueue) GetLinkedActiveJobs(ctx context.Context, userID int64) ([]*models.IndustryJobQueueEntry, error) {
+	query := `
+		SELECT q.id, q.user_id, q.character_id, q.blueprint_type_id, q.activity, q.runs,
+		       q.me_level, q.te_level, q.system_id, q.facility_tax, q.status, q.esi_job_id,
+		       q.product_type_id, q.estimated_cost, q.estimated_duration, q.notes,
+		       q.created_at, q.updated_at,
+		       '', '', '', '',
+		       CAST(NULL AS timestamptz),
+		       ''
+		FROM industry_job_queue q
+		WHERE q.user_id = $1
+		  AND q.status = 'active'
+		  AND q.esi_job_id IS NOT NULL
+		ORDER BY q.created_at ASC
+	`
+
+	return r.queryEntries(ctx, query, userID)
+}
+
+func (r *JobQueue) queryEntries(ctx context.Context, query string, args ...interface{}) ([]*models.IndustryJobQueueEntry, error) {
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query job queue entries")
+	}
+	defer rows.Close()
+
+	entries := []*models.IndustryJobQueueEntry{}
+	for rows.Next() {
+		var entry models.IndustryJobQueueEntry
+		err = rows.Scan(
+			&entry.ID,
+			&entry.UserID,
+			&entry.CharacterID,
+			&entry.BlueprintTypeID,
+			&entry.Activity,
+			&entry.Runs,
+			&entry.MELevel,
+			&entry.TELevel,
+			&entry.SystemID,
+			&entry.FacilityTax,
+			&entry.Status,
+			&entry.EsiJobID,
+			&entry.ProductTypeID,
+			&entry.EstimatedCost,
+			&entry.EstimatedDuration,
+			&entry.Notes,
+			&entry.CreatedAt,
+			&entry.UpdatedAt,
+			&entry.BlueprintName,
+			&entry.ProductName,
+			&entry.CharacterName,
+			&entry.SystemName,
+			&entry.EsiJobEndDate,
+			&entry.EsiJobSource,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan job queue entry")
+		}
+		entries = append(entries, &entry)
+	}
+
+	return entries, nil
+}

--- a/internal/repositories/jobQueue_test.go
+++ b/internal/repositories/jobQueue_test.go
@@ -1,0 +1,297 @@
+package repositories_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_JobQueueShouldCreateAndGetByUser(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 7000, Name: "Queue Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	productTypeID := int64(34)
+	estimatedCost := 5000000.0
+	estimatedDuration := 3600
+	notes := "Test job"
+	systemID := int64(30000142)
+
+	entry := &models.IndustryJobQueueEntry{
+		UserID:            user.ID,
+		BlueprintTypeID:   787,
+		Activity:          "manufacturing",
+		Runs:              10,
+		MELevel:           10,
+		TELevel:           20,
+		SystemID:          &systemID,
+		FacilityTax:       5.0,
+		ProductTypeID:     &productTypeID,
+		EstimatedCost:     &estimatedCost,
+		EstimatedDuration: &estimatedDuration,
+		Notes:             &notes,
+	}
+
+	created, err := queueRepo.Create(context.Background(), entry)
+	assert.NoError(t, err)
+	assert.NotNil(t, created)
+	assert.Equal(t, user.ID, created.UserID)
+	assert.Equal(t, int64(787), created.BlueprintTypeID)
+	assert.Equal(t, "manufacturing", created.Activity)
+	assert.Equal(t, 10, created.Runs)
+	assert.Equal(t, 10, created.MELevel)
+	assert.Equal(t, 20, created.TELevel)
+	assert.Equal(t, "planned", created.Status)
+	assert.Nil(t, created.EsiJobID)
+	assert.NotZero(t, created.ID)
+
+	entries, err := queueRepo.GetByUser(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, created.ID, entries[0].ID)
+}
+
+func Test_JobQueueShouldUpdatePlannedEntry(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 7010, Name: "Update Queue User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	entry := &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            10,
+		MELevel:         0,
+		TELevel:         0,
+		FacilityTax:     0,
+	}
+
+	created, err := queueRepo.Create(context.Background(), entry)
+	assert.NoError(t, err)
+
+	// Update the entry
+	updateEntry := &models.IndustryJobQueueEntry{
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            20,
+		MELevel:         10,
+		TELevel:         20,
+		FacilityTax:     3.5,
+	}
+
+	updated, err := queueRepo.Update(context.Background(), created.ID, user.ID, updateEntry)
+	assert.NoError(t, err)
+	assert.NotNil(t, updated)
+	assert.Equal(t, 20, updated.Runs)
+	assert.Equal(t, 10, updated.MELevel)
+	assert.Equal(t, 20, updated.TELevel)
+	assert.Equal(t, 3.5, updated.FacilityTax)
+}
+
+func Test_JobQueueShouldNotUpdateNonPlannedEntry(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 7020, Name: "Non-Planned User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	entry := &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            10,
+		FacilityTax:     0,
+	}
+
+	created, err := queueRepo.Create(context.Background(), entry)
+	assert.NoError(t, err)
+
+	// Link to ESI job (makes it 'active')
+	err = queueRepo.LinkToEsiJob(context.Background(), created.ID, 999999)
+	assert.NoError(t, err)
+
+	// Update should return nil (no rows affected)
+	updated, err := queueRepo.Update(context.Background(), created.ID, user.ID, entry)
+	assert.NoError(t, err)
+	assert.Nil(t, updated)
+}
+
+func Test_JobQueueShouldCancelEntry(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 7030, Name: "Cancel Queue User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	entry := &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            10,
+		FacilityTax:     0,
+	}
+
+	created, err := queueRepo.Create(context.Background(), entry)
+	assert.NoError(t, err)
+
+	err = queueRepo.Cancel(context.Background(), created.ID, user.ID)
+	assert.NoError(t, err)
+
+	entries, err := queueRepo.GetByUser(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "cancelled", entries[0].Status)
+}
+
+func Test_JobQueueShouldNotCancelOtherUsersEntry(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user1 := &repositories.User{ID: 7040, Name: "Owner"}
+	user2 := &repositories.User{ID: 7041, Name: "Other"}
+	err = userRepo.Add(context.Background(), user1)
+	assert.NoError(t, err)
+	err = userRepo.Add(context.Background(), user2)
+	assert.NoError(t, err)
+
+	entry := &models.IndustryJobQueueEntry{
+		UserID:          user1.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            10,
+		FacilityTax:     0,
+	}
+
+	created, err := queueRepo.Create(context.Background(), entry)
+	assert.NoError(t, err)
+
+	// User2 should not be able to cancel user1's entry
+	err = queueRepo.Cancel(context.Background(), created.ID, user2.ID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found or not cancellable")
+}
+
+func Test_JobQueueShouldLinkAndComplete(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 7050, Name: "Link Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	entry := &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            10,
+		FacilityTax:     0,
+	}
+
+	created, err := queueRepo.Create(context.Background(), entry)
+	assert.NoError(t, err)
+
+	// Link to ESI job
+	esiJobID := int64(12345)
+	err = queueRepo.LinkToEsiJob(context.Background(), created.ID, esiJobID)
+	assert.NoError(t, err)
+
+	// Verify it's active
+	linked, err := queueRepo.GetLinkedActiveJobs(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, linked, 1)
+	assert.Equal(t, "active", linked[0].Status)
+	assert.Equal(t, &esiJobID, linked[0].EsiJobID)
+
+	// Complete the job
+	err = queueRepo.CompleteJob(context.Background(), created.ID)
+	assert.NoError(t, err)
+
+	// No more linked active jobs
+	linked, err = queueRepo.GetLinkedActiveJobs(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, linked, 0)
+}
+
+func Test_JobQueueShouldGetPlannedJobs(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 7060, Name: "Planned Jobs User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	// Create two planned entries
+	entry1 := &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            10,
+		FacilityTax:     0,
+	}
+	entry2 := &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 46166,
+		Activity:        "reaction",
+		Runs:            100,
+		FacilityTax:     0,
+	}
+
+	created1, err := queueRepo.Create(context.Background(), entry1)
+	assert.NoError(t, err)
+	created2, err := queueRepo.Create(context.Background(), entry2)
+	assert.NoError(t, err)
+
+	// Link first one to ESI job (makes it active)
+	err = queueRepo.LinkToEsiJob(context.Background(), created1.ID, 55555)
+	assert.NoError(t, err)
+
+	// Only second entry should be planned
+	planned, err := queueRepo.GetPlannedJobs(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, planned, 1)
+	assert.Equal(t, created2.ID, planned[0].ID)
+	assert.Equal(t, "reaction", planned[0].Activity)
+}
+
+func Test_JobQueueShouldReturnEmptyForNoEntries(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	queueRepo := repositories.NewJobQueue(db)
+
+	entries, err := queueRepo.GetByUser(context.Background(), 99999)
+	assert.NoError(t, err)
+	assert.Len(t, entries, 0)
+}

--- a/internal/runners/characterSkills.go
+++ b/internal/runners/characterSkills.go
@@ -1,0 +1,59 @@
+package runners
+
+import (
+	"context"
+	"time"
+
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+)
+
+type CharacterSkillsUpdater interface {
+	UpdateAllUsers(ctx context.Context) error
+}
+
+type CharacterSkillsRunner struct {
+	updater       CharacterSkillsUpdater
+	interval      time.Duration
+	tickerFactory TickerFactory
+}
+
+func NewCharacterSkillsRunner(updater CharacterSkillsUpdater, interval time.Duration) *CharacterSkillsRunner {
+	return &CharacterSkillsRunner{
+		updater:  updater,
+		interval: interval,
+		tickerFactory: func(d time.Duration) Ticker {
+			return &realTicker{time.NewTicker(d)}
+		},
+	}
+}
+
+func (r *CharacterSkillsRunner) WithTickerFactory(factory TickerFactory) *CharacterSkillsRunner {
+	r.tickerFactory = factory
+	return r
+}
+
+func (r *CharacterSkillsRunner) Run(ctx context.Context) error {
+	ticker := r.tickerFactory(r.interval)
+	defer ticker.Stop()
+
+	log.Info("updating character skills on startup")
+	if err := r.updater.UpdateAllUsers(ctx); err != nil {
+		log.Error("failed to update character skills on startup", "error", err)
+	} else {
+		log.Info("character skills updated successfully")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C():
+			log.Info("updating character skills (scheduled)")
+			if err := r.updater.UpdateAllUsers(ctx); err != nil {
+				log.Error("failed to update character skills", "error", err)
+			} else {
+				log.Info("character skills updated successfully")
+			}
+		}
+	}
+}

--- a/internal/runners/industryJobs.go
+++ b/internal/runners/industryJobs.go
@@ -1,0 +1,59 @@
+package runners
+
+import (
+	"context"
+	"time"
+
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+)
+
+type IndustryJobsUpdater interface {
+	UpdateAllUsers(ctx context.Context) error
+}
+
+type IndustryJobsRunner struct {
+	updater       IndustryJobsUpdater
+	interval      time.Duration
+	tickerFactory TickerFactory
+}
+
+func NewIndustryJobsRunner(updater IndustryJobsUpdater, interval time.Duration) *IndustryJobsRunner {
+	return &IndustryJobsRunner{
+		updater:  updater,
+		interval: interval,
+		tickerFactory: func(d time.Duration) Ticker {
+			return &realTicker{time.NewTicker(d)}
+		},
+	}
+}
+
+func (r *IndustryJobsRunner) WithTickerFactory(factory TickerFactory) *IndustryJobsRunner {
+	r.tickerFactory = factory
+	return r
+}
+
+func (r *IndustryJobsRunner) Run(ctx context.Context) error {
+	ticker := r.tickerFactory(r.interval)
+	defer ticker.Stop()
+
+	log.Info("updating industry jobs on startup")
+	if err := r.updater.UpdateAllUsers(ctx); err != nil {
+		log.Error("failed to update industry jobs on startup", "error", err)
+	} else {
+		log.Info("industry jobs updated successfully")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C():
+			log.Info("updating industry jobs (scheduled)")
+			if err := r.updater.UpdateAllUsers(ctx); err != nil {
+				log.Error("failed to update industry jobs", "error", err)
+			} else {
+				log.Info("industry jobs updated successfully")
+			}
+		}
+	}
+}

--- a/internal/updaters/characterSkills.go
+++ b/internal/updaters/characterSkills.go
@@ -1,0 +1,130 @@
+package updaters
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/client"
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+
+	"github.com/pkg/errors"
+)
+
+type SkillsCharacterSkillsRepository interface {
+	UpsertSkills(ctx context.Context, characterID, userID int64, skills []*models.CharacterSkill) error
+}
+
+type SkillsEsiClient interface {
+	GetCharacterSkills(ctx context.Context, characterID int64, token string) (*client.EsiSkillsResponse, error)
+	RefreshAccessToken(ctx context.Context, refreshToken string) (*client.RefreshedToken, error)
+}
+
+type SkillsUserRepository interface {
+	GetAllIDs(ctx context.Context) ([]int64, error)
+}
+
+type SkillsCharacterRepository interface {
+	GetAll(ctx context.Context, baseUserID int64) ([]*repositories.Character, error)
+	UpdateTokens(ctx context.Context, id, userID int64, token, refreshToken string, expiresOn time.Time) error
+}
+
+type CharacterSkillsUpdater struct {
+	userRepo      SkillsUserRepository
+	characterRepo SkillsCharacterRepository
+	skillsRepo    SkillsCharacterSkillsRepository
+	esiClient     SkillsEsiClient
+}
+
+func NewCharacterSkillsUpdater(
+	userRepo SkillsUserRepository,
+	characterRepo SkillsCharacterRepository,
+	skillsRepo SkillsCharacterSkillsRepository,
+	esiClient SkillsEsiClient,
+) *CharacterSkillsUpdater {
+	return &CharacterSkillsUpdater{
+		userRepo:      userRepo,
+		characterRepo: characterRepo,
+		skillsRepo:    skillsRepo,
+		esiClient:     esiClient,
+	}
+}
+
+func (u *CharacterSkillsUpdater) UpdateAllUsers(ctx context.Context) error {
+	userIDs, err := u.userRepo.GetAllIDs(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get user IDs for skills update")
+	}
+
+	for _, userID := range userIDs {
+		if err := u.UpdateUserSkills(ctx, userID); err != nil {
+			log.Error("failed to update skills for user", "userID", userID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (u *CharacterSkillsUpdater) UpdateUserSkills(ctx context.Context, userID int64) error {
+	characters, err := u.characterRepo.GetAll(ctx, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get user characters for skills update")
+	}
+
+	for _, char := range characters {
+		if !strings.Contains(char.EsiScopes, "esi-skills.read_skills.v1") {
+			continue
+		}
+
+		if err := u.updateCharacterSkills(ctx, char, userID); err != nil {
+			log.Error("failed to update skills for character", "characterID", char.ID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (u *CharacterSkillsUpdater) updateCharacterSkills(ctx context.Context, char *repositories.Character, userID int64) error {
+	token := char.EsiToken
+
+	if time.Now().After(char.EsiTokenExpiresOn) {
+		refreshed, err := u.esiClient.RefreshAccessToken(ctx, char.EsiRefreshToken)
+		if err != nil {
+			return errors.Wrapf(err, "failed to refresh token for character %d", char.ID)
+		}
+		token = refreshed.AccessToken
+
+		err = u.characterRepo.UpdateTokens(ctx, char.ID, char.UserID, refreshed.AccessToken, refreshed.RefreshToken, refreshed.Expiry)
+		if err != nil {
+			return errors.Wrapf(err, "failed to persist refreshed token for character %d", char.ID)
+		}
+		log.Info("refreshed ESI token for character (skills)", "characterID", char.ID)
+	}
+
+	esiSkills, err := u.esiClient.GetCharacterSkills(ctx, char.ID, token)
+	if err != nil {
+		return errors.Wrap(err, "failed to get character skills from ESI")
+	}
+
+	skills := []*models.CharacterSkill{}
+	for _, s := range esiSkills.Skills {
+		skills = append(skills, &models.CharacterSkill{
+			CharacterID:  char.ID,
+			UserID:       userID,
+			SkillID:      s.SkillID,
+			TrainedLevel: s.TrainedSkillLevel,
+			ActiveLevel:  s.ActiveSkillLevel,
+			Skillpoints:  s.SkillpointsInSkill,
+		})
+	}
+
+	err = u.skillsRepo.UpsertSkills(ctx, char.ID, userID, skills)
+	if err != nil {
+		return errors.Wrap(err, "failed to upsert character skills")
+	}
+
+	log.Info("updated character skills", "characterID", char.ID, "count", len(skills))
+	return nil
+}

--- a/internal/updaters/characterSkills_test.go
+++ b/internal/updaters/characterSkills_test.go
@@ -1,0 +1,184 @@
+package updaters_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/client"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/updaters"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Mocks ---
+
+type mockSkillsRepo struct {
+	upsertedSkills map[int64][]*models.CharacterSkill // keyed by characterID
+	upsertErr      error
+}
+
+func (m *mockSkillsRepo) UpsertSkills(ctx context.Context, characterID, userID int64, skills []*models.CharacterSkill) error {
+	if m.upsertErr != nil {
+		return m.upsertErr
+	}
+	if m.upsertedSkills == nil {
+		m.upsertedSkills = map[int64][]*models.CharacterSkill{}
+	}
+	m.upsertedSkills[characterID] = skills
+	return nil
+}
+
+type mockSkillsEsiClient struct {
+	skillsByChar   map[int64]*client.EsiSkillsResponse
+	skillsErr      error
+	refreshedToken *client.RefreshedToken
+	refreshErr     error
+}
+
+func (m *mockSkillsEsiClient) GetCharacterSkills(ctx context.Context, characterID int64, token string) (*client.EsiSkillsResponse, error) {
+	if m.skillsErr != nil {
+		return nil, m.skillsErr
+	}
+	return m.skillsByChar[characterID], nil
+}
+
+func (m *mockSkillsEsiClient) RefreshAccessToken(ctx context.Context, refreshToken string) (*client.RefreshedToken, error) {
+	if m.refreshErr != nil {
+		return nil, m.refreshErr
+	}
+	return m.refreshedToken, nil
+}
+
+type mockSkillsUserRepo struct {
+	userIDs []int64
+	err     error
+}
+
+func (m *mockSkillsUserRepo) GetAllIDs(ctx context.Context) ([]int64, error) {
+	return m.userIDs, m.err
+}
+
+type mockSkillsCharRepo struct {
+	charactersByUser map[int64][]*repositories.Character
+	getErr           error
+	tokenUpdateErr   error
+}
+
+func (m *mockSkillsCharRepo) GetAll(ctx context.Context, baseUserID int64) ([]*repositories.Character, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	return m.charactersByUser[baseUserID], nil
+}
+
+func (m *mockSkillsCharRepo) UpdateTokens(ctx context.Context, id, userID int64, token, refreshToken string, expiresOn time.Time) error {
+	return m.tokenUpdateErr
+}
+
+// --- Tests ---
+
+func Test_CharacterSkillsUpdater_UpdatesSkills(t *testing.T) {
+	skillsRepo := &mockSkillsRepo{}
+	esiClient := &mockSkillsEsiClient{
+		skillsByChar: map[int64]*client.EsiSkillsResponse{
+			1001: {
+				Skills: []client.EsiSkillEntry{
+					{SkillID: 3380, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},
+					{SkillID: 3388, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 45255},
+				},
+				TotalSP: 5000000,
+			},
+		},
+	}
+	userRepo := &mockSkillsUserRepo{userIDs: []int64{100}}
+	charRepo := &mockSkillsCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 1001, Name: "Test Char", UserID: 100, EsiToken: "valid-token", EsiScopes: "esi-skills.read_skills.v1", EsiTokenExpiresOn: time.Now().Add(time.Hour)},
+			},
+		},
+	}
+
+	updater := updaters.NewCharacterSkillsUpdater(userRepo, charRepo, skillsRepo, esiClient)
+	err := updater.UpdateAllUsers(context.Background())
+	assert.NoError(t, err)
+
+	assert.Len(t, skillsRepo.upsertedSkills[1001], 2)
+	assert.Equal(t, int64(3380), skillsRepo.upsertedSkills[1001][0].SkillID)
+	assert.Equal(t, 5, skillsRepo.upsertedSkills[1001][0].TrainedLevel)
+}
+
+func Test_CharacterSkillsUpdater_SkipsWithoutScope(t *testing.T) {
+	skillsRepo := &mockSkillsRepo{}
+	esiClient := &mockSkillsEsiClient{
+		skillsByChar: map[int64]*client.EsiSkillsResponse{},
+	}
+	userRepo := &mockSkillsUserRepo{userIDs: []int64{100}}
+	charRepo := &mockSkillsCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 1001, Name: "No Scope Char", UserID: 100, EsiToken: "valid-token", EsiScopes: "esi-assets.read_assets.v1", EsiTokenExpiresOn: time.Now().Add(time.Hour)},
+			},
+		},
+	}
+
+	updater := updaters.NewCharacterSkillsUpdater(userRepo, charRepo, skillsRepo, esiClient)
+	err := updater.UpdateAllUsers(context.Background())
+	assert.NoError(t, err)
+
+	// No skills should have been upserted
+	assert.Empty(t, skillsRepo.upsertedSkills)
+}
+
+func Test_CharacterSkillsUpdater_RefreshesExpiredToken(t *testing.T) {
+	skillsRepo := &mockSkillsRepo{}
+	esiClient := &mockSkillsEsiClient{
+		skillsByChar: map[int64]*client.EsiSkillsResponse{
+			1001: {Skills: []client.EsiSkillEntry{{SkillID: 3380, TrainedSkillLevel: 3, ActiveSkillLevel: 3, SkillpointsInSkill: 16000}}},
+		},
+		refreshedToken: &client.RefreshedToken{
+			AccessToken:  "new-token",
+			RefreshToken: "new-refresh",
+			Expiry:       time.Now().Add(20 * time.Minute),
+		},
+	}
+	userRepo := &mockSkillsUserRepo{userIDs: []int64{100}}
+	charRepo := &mockSkillsCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 1001, Name: "Expired Token Char", UserID: 100, EsiToken: "expired-token", EsiRefreshToken: "refresh-token", EsiScopes: "esi-skills.read_skills.v1", EsiTokenExpiresOn: time.Now().Add(-time.Hour)},
+			},
+		},
+	}
+
+	updater := updaters.NewCharacterSkillsUpdater(userRepo, charRepo, skillsRepo, esiClient)
+	err := updater.UpdateAllUsers(context.Background())
+	assert.NoError(t, err)
+
+	assert.Len(t, skillsRepo.upsertedSkills[1001], 1)
+}
+
+func Test_CharacterSkillsUpdater_HandlesEsiError(t *testing.T) {
+	skillsRepo := &mockSkillsRepo{}
+	esiClient := &mockSkillsEsiClient{
+		skillsErr: assert.AnError,
+	}
+	userRepo := &mockSkillsUserRepo{userIDs: []int64{100}}
+	charRepo := &mockSkillsCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 1001, Name: "Error Char", UserID: 100, EsiToken: "valid-token", EsiScopes: "esi-skills.read_skills.v1", EsiTokenExpiresOn: time.Now().Add(time.Hour)},
+			},
+		},
+	}
+
+	updater := updaters.NewCharacterSkillsUpdater(userRepo, charRepo, skillsRepo, esiClient)
+	// Should not return error (logs it instead, continues to next user)
+	err := updater.UpdateAllUsers(context.Background())
+	assert.NoError(t, err)
+
+	// No skills should have been upserted
+	assert.Empty(t, skillsRepo.upsertedSkills)
+}

--- a/internal/updaters/industryJobs.go
+++ b/internal/updaters/industryJobs.go
@@ -1,0 +1,340 @@
+package updaters
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/client"
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+
+	"github.com/pkg/errors"
+)
+
+// Activity ID to activity name mapping for queue matching
+var activityIDToName = map[int]string{
+	1: "manufacturing",
+	3: "te_research",
+	4: "me_research",
+	5: "copying",
+	8: "invention",
+	9: "reaction",
+}
+
+type IndustryJobsRepository interface {
+	UpsertJobs(ctx context.Context, userID int64, jobs []*models.IndustryJob) error
+	GetActiveJobsForMatching(ctx context.Context, userID int64) ([]*models.IndustryJob, error)
+	GetJobByID(ctx context.Context, jobID int64) (*models.IndustryJob, error)
+}
+
+type IndustryJobQueueRepository interface {
+	GetPlannedJobs(ctx context.Context, userID int64) ([]*models.IndustryJobQueueEntry, error)
+	GetLinkedActiveJobs(ctx context.Context, userID int64) ([]*models.IndustryJobQueueEntry, error)
+	LinkToEsiJob(ctx context.Context, queueID, esiJobID int64) error
+	CompleteJob(ctx context.Context, queueID int64) error
+}
+
+type IndustryEsiClient interface {
+	GetCharacterIndustryJobs(ctx context.Context, characterID int64, token string, includeCompleted bool) ([]*client.EsiIndustryJob, error)
+	GetCorporationIndustryJobs(ctx context.Context, corporationID int64, token string, includeCompleted bool) ([]*client.EsiIndustryJob, error)
+	RefreshAccessToken(ctx context.Context, refreshToken string) (*client.RefreshedToken, error)
+}
+
+type IndustryUserRepository interface {
+	GetAllIDs(ctx context.Context) ([]int64, error)
+}
+
+type IndustryCharacterRepository interface {
+	GetAll(ctx context.Context, baseUserID int64) ([]*repositories.Character, error)
+	UpdateTokens(ctx context.Context, id, userID int64, token, refreshToken string, expiresOn time.Time) error
+}
+
+type IndustryCorporationRepository interface {
+	Get(ctx context.Context, user int64) ([]repositories.PlayerCorporation, error)
+	UpdateTokens(ctx context.Context, id, userID int64, token, refreshToken string, expiresOn time.Time) error
+}
+
+type IndustryJobsUpdater struct {
+	userRepo      IndustryUserRepository
+	characterRepo IndustryCharacterRepository
+	corpRepo      IndustryCorporationRepository
+	jobsRepo      IndustryJobsRepository
+	queueRepo     IndustryJobQueueRepository
+	esiClient     IndustryEsiClient
+}
+
+func NewIndustryJobsUpdater(
+	userRepo IndustryUserRepository,
+	characterRepo IndustryCharacterRepository,
+	corpRepo IndustryCorporationRepository,
+	jobsRepo IndustryJobsRepository,
+	queueRepo IndustryJobQueueRepository,
+	esiClient IndustryEsiClient,
+) *IndustryJobsUpdater {
+	return &IndustryJobsUpdater{
+		userRepo:      userRepo,
+		characterRepo: characterRepo,
+		corpRepo:      corpRepo,
+		jobsRepo:      jobsRepo,
+		queueRepo:     queueRepo,
+		esiClient:     esiClient,
+	}
+}
+
+func (u *IndustryJobsUpdater) UpdateAllUsers(ctx context.Context) error {
+	userIDs, err := u.userRepo.GetAllIDs(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get user IDs for industry jobs update")
+	}
+
+	for _, userID := range userIDs {
+		if err := u.UpdateUserJobs(ctx, userID); err != nil {
+			log.Error("failed to update industry jobs for user", "userID", userID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (u *IndustryJobsUpdater) UpdateUserJobs(ctx context.Context, userID int64) error {
+	characters, err := u.characterRepo.GetAll(ctx, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get user characters for industry jobs update")
+	}
+
+	for _, char := range characters {
+		if !strings.Contains(char.EsiScopes, "esi-industry.read_character_jobs.v1") {
+			continue
+		}
+
+		if err := u.updateCharacterJobs(ctx, char, userID); err != nil {
+			log.Error("failed to update industry jobs for character", "characterID", char.ID, "error", err)
+		}
+	}
+
+	// Fetch corporation industry jobs
+	corporations, err := u.corpRepo.Get(ctx, userID)
+	if err != nil {
+		log.Error("failed to get user corporations for industry jobs update", "userID", userID, "error", err)
+	} else {
+		for _, corp := range corporations {
+			if !strings.Contains(corp.EsiScopes, "esi-industry.read_corporation_jobs.v1") {
+				continue
+			}
+
+			if err := u.updateCorporationJobs(ctx, corp, userID); err != nil {
+				log.Error("failed to update industry jobs for corporation", "corporationID", corp.ID, "error", err)
+			}
+		}
+	}
+
+	// After all characters and corporations are fetched, match queue entries
+	if err := u.matchQueueEntries(ctx, userID); err != nil {
+		log.Error("failed to match queue entries", "userID", userID, "error", err)
+	}
+
+	return nil
+}
+
+func (u *IndustryJobsUpdater) updateCharacterJobs(ctx context.Context, char *repositories.Character, userID int64) error {
+	token := char.EsiToken
+
+	if time.Now().After(char.EsiTokenExpiresOn) {
+		refreshed, err := u.esiClient.RefreshAccessToken(ctx, char.EsiRefreshToken)
+		if err != nil {
+			return errors.Wrapf(err, "failed to refresh token for character %d", char.ID)
+		}
+		token = refreshed.AccessToken
+
+		err = u.characterRepo.UpdateTokens(ctx, char.ID, char.UserID, refreshed.AccessToken, refreshed.RefreshToken, refreshed.Expiry)
+		if err != nil {
+			return errors.Wrapf(err, "failed to persist refreshed token for character %d", char.ID)
+		}
+		log.Info("refreshed ESI token for character (industry)", "characterID", char.ID)
+	}
+
+	esiJobs, err := u.esiClient.GetCharacterIndustryJobs(ctx, char.ID, token, true)
+	if err != nil {
+		return errors.Wrap(err, "failed to get character industry jobs from ESI")
+	}
+
+	jobs, err := convertEsiJobs(esiJobs, userID, "character")
+	if err != nil {
+		return err
+	}
+
+	err = u.jobsRepo.UpsertJobs(ctx, userID, jobs)
+	if err != nil {
+		return errors.Wrap(err, "failed to upsert industry jobs")
+	}
+
+	log.Info("updated industry jobs", "characterID", char.ID, "count", len(jobs))
+	return nil
+}
+
+func (u *IndustryJobsUpdater) updateCorporationJobs(ctx context.Context, corp repositories.PlayerCorporation, userID int64) error {
+	token := corp.EsiToken
+
+	if time.Now().After(corp.EsiExpiresOn) {
+		refreshed, err := u.esiClient.RefreshAccessToken(ctx, corp.EsiRefreshToken)
+		if err != nil {
+			return errors.Wrapf(err, "failed to refresh token for corporation %d", corp.ID)
+		}
+		token = refreshed.AccessToken
+
+		err = u.corpRepo.UpdateTokens(ctx, corp.ID, corp.UserID, token, refreshed.RefreshToken, refreshed.Expiry)
+		if err != nil {
+			return errors.Wrapf(err, "failed to persist refreshed token for corporation %d", corp.ID)
+		}
+		log.Info("refreshed ESI token for corporation (industry)", "corporationID", corp.ID)
+	}
+
+	esiJobs, err := u.esiClient.GetCorporationIndustryJobs(ctx, corp.ID, token, true)
+	if err != nil {
+		return errors.Wrap(err, "failed to get corporation industry jobs from ESI")
+	}
+
+	jobs, err := convertEsiJobs(esiJobs, userID, "corporation")
+	if err != nil {
+		return err
+	}
+
+	err = u.jobsRepo.UpsertJobs(ctx, userID, jobs)
+	if err != nil {
+		return errors.Wrap(err, "failed to upsert corporation industry jobs")
+	}
+
+	log.Info("updated corporation industry jobs", "corporationID", corp.ID, "count", len(jobs))
+	return nil
+}
+
+// convertEsiJobs converts ESI industry job responses into domain models.
+// source should be "character" or "corporation".
+func convertEsiJobs(esiJobs []*client.EsiIndustryJob, userID int64, source string) ([]*models.IndustryJob, error) {
+	jobs := []*models.IndustryJob{}
+	for _, ej := range esiJobs {
+		// Corporation endpoint uses location_id instead of station_id
+		stationID := ej.StationID
+		if stationID == 0 && ej.LocationID != 0 {
+			stationID = ej.LocationID
+		}
+
+		job := &models.IndustryJob{
+			JobID:                ej.JobID,
+			InstallerID:          ej.InstallerID,
+			UserID:               userID,
+			FacilityID:           ej.FacilityID,
+			StationID:            stationID,
+			ActivityID:           ej.ActivityID,
+			BlueprintID:          ej.BlueprintID,
+			BlueprintTypeID:      ej.BlueprintTypeID,
+			BlueprintLocationID:  ej.BlueprintLocationID,
+			OutputLocationID:     ej.OutputLocationID,
+			Runs:                 ej.Runs,
+			Cost:                 ej.Cost,
+			LicensedRuns:         ej.LicensedRuns,
+			Probability:          ej.Probability,
+			ProductTypeID:        ej.ProductTypeID,
+			Status:               ej.Status,
+			Duration:             ej.Duration,
+			CompletedCharacterID: ej.CompletedCharacterID,
+			SuccessfulRuns:       ej.SuccessfulRuns,
+			Source:               source,
+		}
+
+		startDate, err := time.Parse(time.RFC3339, ej.StartDate)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse start_date for job %d", ej.JobID)
+		}
+		job.StartDate = startDate
+
+		endDate, err := time.Parse(time.RFC3339, ej.EndDate)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse end_date for job %d", ej.JobID)
+		}
+		job.EndDate = endDate
+
+		if ej.PauseDate != nil {
+			t, err := time.Parse(time.RFC3339, *ej.PauseDate)
+			if err == nil {
+				job.PauseDate = &t
+			}
+		}
+		if ej.CompletedDate != nil {
+			t, err := time.Parse(time.RFC3339, *ej.CompletedDate)
+			if err == nil {
+				job.CompletedDate = &t
+			}
+		}
+
+		jobs = append(jobs, job)
+	}
+	return jobs, nil
+}
+
+// matchQueueEntries matches planned queue entries to active ESI jobs and
+// checks if linked active entries have been delivered.
+func (u *IndustryJobsUpdater) matchQueueEntries(ctx context.Context, userID int64) error {
+	// 1. Match planned entries to active ESI jobs
+	planned, err := u.queueRepo.GetPlannedJobs(ctx, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get planned queue entries")
+	}
+
+	if len(planned) > 0 {
+		activeEsiJobs, err := u.jobsRepo.GetActiveJobsForMatching(ctx, userID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get active ESI jobs for matching")
+		}
+
+		for _, entry := range planned {
+			for _, esiJob := range activeEsiJobs {
+				activityName := activityIDToName[esiJob.ActivityID]
+				if esiJob.BlueprintTypeID == entry.BlueprintTypeID &&
+					activityName == entry.Activity &&
+					esiJob.Runs == entry.Runs &&
+					esiJob.StartDate.After(entry.CreatedAt) {
+
+					err := u.queueRepo.LinkToEsiJob(ctx, entry.ID, esiJob.JobID)
+					if err != nil {
+						log.Error("failed to link queue entry to ESI job", "queueID", entry.ID, "jobID", esiJob.JobID, "error", err)
+					} else {
+						log.Info("linked queue entry to ESI job", "queueID", entry.ID, "jobID", esiJob.JobID)
+					}
+					break
+				}
+			}
+		}
+	}
+
+	// 2. Check if linked active entries have been delivered
+	linkedActive, err := u.queueRepo.GetLinkedActiveJobs(ctx, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get linked active queue entries")
+	}
+
+	for _, entry := range linkedActive {
+		if entry.EsiJobID == nil {
+			continue
+		}
+
+		esiJob, err := u.jobsRepo.GetJobByID(ctx, *entry.EsiJobID)
+		if err != nil {
+			log.Error("failed to get ESI job for completion check", "jobID", *entry.EsiJobID, "error", err)
+			continue
+		}
+
+		if esiJob != nil && esiJob.Status == "delivered" {
+			err := u.queueRepo.CompleteJob(ctx, entry.ID)
+			if err != nil {
+				log.Error("failed to complete queue entry", "queueID", entry.ID, "error", err)
+			} else {
+				log.Info("completed queue entry", "queueID", entry.ID, "jobID", *entry.EsiJobID)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/updaters/industryJobs_test.go
+++ b/internal/updaters/industryJobs_test.go
@@ -1,0 +1,399 @@
+package updaters_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/client"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/updaters"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Mocks ---
+
+type mockIndustryJobsRepo struct {
+	upsertedJobs map[int64][]*models.IndustryJob // keyed by userID
+	upsertErr    error
+	activeJobs   []*models.IndustryJob
+	jobByID      map[int64]*models.IndustryJob
+}
+
+func (m *mockIndustryJobsRepo) UpsertJobs(ctx context.Context, userID int64, jobs []*models.IndustryJob) error {
+	if m.upsertErr != nil {
+		return m.upsertErr
+	}
+	if m.upsertedJobs == nil {
+		m.upsertedJobs = map[int64][]*models.IndustryJob{}
+	}
+	m.upsertedJobs[userID] = jobs
+	return nil
+}
+
+func (m *mockIndustryJobsRepo) GetActiveJobsForMatching(ctx context.Context, userID int64) ([]*models.IndustryJob, error) {
+	return m.activeJobs, nil
+}
+
+func (m *mockIndustryJobsRepo) GetJobByID(ctx context.Context, jobID int64) (*models.IndustryJob, error) {
+	if m.jobByID != nil {
+		return m.jobByID[jobID], nil
+	}
+	return nil, nil
+}
+
+type mockJobQueueRepo struct {
+	plannedJobs    []*models.IndustryJobQueueEntry
+	linkedJobs     []*models.IndustryJobQueueEntry
+	linkedCalls    []linkCall
+	completedCalls []int64
+}
+
+type linkCall struct {
+	QueueID  int64
+	EsiJobID int64
+}
+
+func (m *mockJobQueueRepo) GetPlannedJobs(ctx context.Context, userID int64) ([]*models.IndustryJobQueueEntry, error) {
+	return m.plannedJobs, nil
+}
+
+func (m *mockJobQueueRepo) GetLinkedActiveJobs(ctx context.Context, userID int64) ([]*models.IndustryJobQueueEntry, error) {
+	return m.linkedJobs, nil
+}
+
+func (m *mockJobQueueRepo) LinkToEsiJob(ctx context.Context, queueID, esiJobID int64) error {
+	m.linkedCalls = append(m.linkedCalls, linkCall{QueueID: queueID, EsiJobID: esiJobID})
+	return nil
+}
+
+func (m *mockJobQueueRepo) CompleteJob(ctx context.Context, queueID int64) error {
+	m.completedCalls = append(m.completedCalls, queueID)
+	return nil
+}
+
+type mockIndustryEsiClient struct {
+	jobsByChar     map[int64][]*client.EsiIndustryJob
+	jobsByCorp     map[int64][]*client.EsiIndustryJob
+	jobsErr        error
+	refreshedToken *client.RefreshedToken
+	refreshErr     error
+}
+
+func (m *mockIndustryEsiClient) GetCharacterIndustryJobs(ctx context.Context, characterID int64, token string, includeCompleted bool) ([]*client.EsiIndustryJob, error) {
+	if m.jobsErr != nil {
+		return nil, m.jobsErr
+	}
+	return m.jobsByChar[characterID], nil
+}
+
+func (m *mockIndustryEsiClient) GetCorporationIndustryJobs(ctx context.Context, corporationID int64, token string, includeCompleted bool) ([]*client.EsiIndustryJob, error) {
+	if m.jobsErr != nil {
+		return nil, m.jobsErr
+	}
+	if m.jobsByCorp != nil {
+		return m.jobsByCorp[corporationID], nil
+	}
+	return nil, nil
+}
+
+func (m *mockIndustryEsiClient) RefreshAccessToken(ctx context.Context, refreshToken string) (*client.RefreshedToken, error) {
+	if m.refreshErr != nil {
+		return nil, m.refreshErr
+	}
+	return m.refreshedToken, nil
+}
+
+type mockIndustryUserRepo struct {
+	userIDs []int64
+}
+
+func (m *mockIndustryUserRepo) GetAllIDs(ctx context.Context) ([]int64, error) {
+	return m.userIDs, nil
+}
+
+type mockIndustryCharRepo struct {
+	charactersByUser map[int64][]*repositories.Character
+}
+
+func (m *mockIndustryCharRepo) GetAll(ctx context.Context, baseUserID int64) ([]*repositories.Character, error) {
+	return m.charactersByUser[baseUserID], nil
+}
+
+func (m *mockIndustryCharRepo) UpdateTokens(ctx context.Context, id, userID int64, token, refreshToken string, expiresOn time.Time) error {
+	return nil
+}
+
+type mockIndustryCorpRepo struct {
+	corpsByUser map[int64][]repositories.PlayerCorporation
+}
+
+func (m *mockIndustryCorpRepo) Get(ctx context.Context, user int64) ([]repositories.PlayerCorporation, error) {
+	if m.corpsByUser != nil {
+		return m.corpsByUser[user], nil
+	}
+	return nil, nil
+}
+
+func (m *mockIndustryCorpRepo) UpdateTokens(ctx context.Context, id, userID int64, token, refreshToken string, expiresOn time.Time) error {
+	return nil
+}
+
+// --- Tests ---
+
+func Test_IndustryJobsUpdater_FetchesAndUpsertsJobs(t *testing.T) {
+	now := time.Now().UTC()
+	cost := 1500000.0
+	jobsRepo := &mockIndustryJobsRepo{}
+	queueRepo := &mockJobQueueRepo{}
+	esiClient := &mockIndustryEsiClient{
+		jobsByChar: map[int64][]*client.EsiIndustryJob{
+			1001: {
+				{
+					JobID: 100001, InstallerID: 1001, FacilityID: 60003760, StationID: 60003760,
+					ActivityID: 1, BlueprintID: 9876, BlueprintTypeID: 787,
+					BlueprintLocationID: 60003760, OutputLocationID: 60003760,
+					Runs: 10, Cost: &cost, Status: "active", Duration: 3600,
+					StartDate: now.Format(time.RFC3339), EndDate: now.Add(time.Hour).Format(time.RFC3339),
+				},
+			},
+		},
+	}
+	userRepo := &mockIndustryUserRepo{userIDs: []int64{100}}
+	charRepo := &mockIndustryCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 1001, Name: "Industry Char", UserID: 100, EsiToken: "token", EsiScopes: "esi-industry.read_character_jobs.v1", EsiTokenExpiresOn: now.Add(time.Hour)},
+			},
+		},
+	}
+
+	updater := updaters.NewIndustryJobsUpdater(userRepo, charRepo, &mockIndustryCorpRepo{}, jobsRepo, queueRepo, esiClient)
+	err := updater.UpdateAllUsers(context.Background())
+	assert.NoError(t, err)
+
+	assert.Len(t, jobsRepo.upsertedJobs[100], 1)
+	assert.Equal(t, int64(100001), jobsRepo.upsertedJobs[100][0].JobID)
+	assert.Equal(t, "active", jobsRepo.upsertedJobs[100][0].Status)
+	assert.Equal(t, "character", jobsRepo.upsertedJobs[100][0].Source)
+	assert.Equal(t, int64(60003760), jobsRepo.upsertedJobs[100][0].StationID)
+}
+
+func Test_IndustryJobsUpdater_MatchesQueueEntries(t *testing.T) {
+	now := time.Now().UTC()
+	createdAt := now.Add(-time.Hour)
+
+	jobsRepo := &mockIndustryJobsRepo{
+		activeJobs: []*models.IndustryJob{
+			{
+				JobID: 100001, BlueprintTypeID: 787, ActivityID: 1, Runs: 10,
+				StartDate: now, Status: "active",
+			},
+		},
+	}
+	queueRepo := &mockJobQueueRepo{
+		plannedJobs: []*models.IndustryJobQueueEntry{
+			{
+				ID: 1, BlueprintTypeID: 787, Activity: "manufacturing", Runs: 10,
+				CreatedAt: createdAt, Status: "planned",
+			},
+		},
+	}
+	esiClient := &mockIndustryEsiClient{
+		jobsByChar: map[int64][]*client.EsiIndustryJob{},
+	}
+	userRepo := &mockIndustryUserRepo{userIDs: []int64{100}}
+	charRepo := &mockIndustryCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {},
+		},
+	}
+
+	updater := updaters.NewIndustryJobsUpdater(userRepo, charRepo, &mockIndustryCorpRepo{}, jobsRepo, queueRepo, esiClient)
+	err := updater.UpdateUserJobs(context.Background(), 100)
+	assert.NoError(t, err)
+
+	assert.Len(t, queueRepo.linkedCalls, 1)
+	assert.Equal(t, int64(1), queueRepo.linkedCalls[0].QueueID)
+	assert.Equal(t, int64(100001), queueRepo.linkedCalls[0].EsiJobID)
+}
+
+func Test_IndustryJobsUpdater_DoesNotMatchWrongActivity(t *testing.T) {
+	now := time.Now().UTC()
+	createdAt := now.Add(-time.Hour)
+
+	jobsRepo := &mockIndustryJobsRepo{
+		activeJobs: []*models.IndustryJob{
+			{
+				JobID: 100001, BlueprintTypeID: 787, ActivityID: 9, Runs: 10,
+				StartDate: now, Status: "active",
+			},
+		},
+	}
+	queueRepo := &mockJobQueueRepo{
+		plannedJobs: []*models.IndustryJobQueueEntry{
+			{
+				ID: 1, BlueprintTypeID: 787, Activity: "manufacturing", Runs: 10,
+				CreatedAt: createdAt, Status: "planned",
+			},
+		},
+	}
+	esiClient := &mockIndustryEsiClient{jobsByChar: map[int64][]*client.EsiIndustryJob{}}
+	userRepo := &mockIndustryUserRepo{userIDs: []int64{100}}
+	charRepo := &mockIndustryCharRepo{charactersByUser: map[int64][]*repositories.Character{100: {}}}
+
+	updater := updaters.NewIndustryJobsUpdater(userRepo, charRepo, &mockIndustryCorpRepo{}, jobsRepo, queueRepo, esiClient)
+	err := updater.UpdateUserJobs(context.Background(), 100)
+	assert.NoError(t, err)
+
+	assert.Len(t, queueRepo.linkedCalls, 0)
+}
+
+func Test_IndustryJobsUpdater_CompletesDeliveredJobs(t *testing.T) {
+	esiJobID := int64(100001)
+
+	jobsRepo := &mockIndustryJobsRepo{
+		activeJobs: []*models.IndustryJob{},
+		jobByID: map[int64]*models.IndustryJob{
+			100001: {JobID: 100001, Status: "delivered"},
+		},
+	}
+	queueRepo := &mockJobQueueRepo{
+		plannedJobs: []*models.IndustryJobQueueEntry{},
+		linkedJobs: []*models.IndustryJobQueueEntry{
+			{
+				ID: 5, EsiJobID: &esiJobID, Status: "active",
+			},
+		},
+	}
+	esiClient := &mockIndustryEsiClient{jobsByChar: map[int64][]*client.EsiIndustryJob{}}
+	userRepo := &mockIndustryUserRepo{userIDs: []int64{100}}
+	charRepo := &mockIndustryCharRepo{charactersByUser: map[int64][]*repositories.Character{100: {}}}
+
+	updater := updaters.NewIndustryJobsUpdater(userRepo, charRepo, &mockIndustryCorpRepo{}, jobsRepo, queueRepo, esiClient)
+	err := updater.UpdateUserJobs(context.Background(), 100)
+	assert.NoError(t, err)
+
+	assert.Len(t, queueRepo.completedCalls, 1)
+	assert.Equal(t, int64(5), queueRepo.completedCalls[0])
+}
+
+func Test_IndustryJobsUpdater_DoesNotCompleteActiveJobs(t *testing.T) {
+	esiJobID := int64(100001)
+
+	jobsRepo := &mockIndustryJobsRepo{
+		activeJobs: []*models.IndustryJob{},
+		jobByID: map[int64]*models.IndustryJob{
+			100001: {JobID: 100001, Status: "active"},
+		},
+	}
+	queueRepo := &mockJobQueueRepo{
+		plannedJobs: []*models.IndustryJobQueueEntry{},
+		linkedJobs: []*models.IndustryJobQueueEntry{
+			{
+				ID: 5, EsiJobID: &esiJobID, Status: "active",
+			},
+		},
+	}
+	esiClient := &mockIndustryEsiClient{jobsByChar: map[int64][]*client.EsiIndustryJob{}}
+	userRepo := &mockIndustryUserRepo{userIDs: []int64{100}}
+	charRepo := &mockIndustryCharRepo{charactersByUser: map[int64][]*repositories.Character{100: {}}}
+
+	updater := updaters.NewIndustryJobsUpdater(userRepo, charRepo, &mockIndustryCorpRepo{}, jobsRepo, queueRepo, esiClient)
+	err := updater.UpdateUserJobs(context.Background(), 100)
+	assert.NoError(t, err)
+
+	assert.Len(t, queueRepo.completedCalls, 0)
+}
+
+func Test_IndustryJobsUpdater_SkipsWithoutScope(t *testing.T) {
+	jobsRepo := &mockIndustryJobsRepo{}
+	queueRepo := &mockJobQueueRepo{}
+	esiClient := &mockIndustryEsiClient{}
+	userRepo := &mockIndustryUserRepo{userIDs: []int64{100}}
+	charRepo := &mockIndustryCharRepo{
+		charactersByUser: map[int64][]*repositories.Character{
+			100: {
+				{ID: 1001, Name: "No Scope Char", UserID: 100, EsiToken: "token", EsiScopes: "esi-assets.read_assets.v1", EsiTokenExpiresOn: time.Now().Add(time.Hour)},
+			},
+		},
+	}
+
+	updater := updaters.NewIndustryJobsUpdater(userRepo, charRepo, &mockIndustryCorpRepo{}, jobsRepo, queueRepo, esiClient)
+	err := updater.UpdateAllUsers(context.Background())
+	assert.NoError(t, err)
+
+	assert.Empty(t, jobsRepo.upsertedJobs)
+}
+
+func Test_IndustryJobsUpdater_FetchesCorporationJobs(t *testing.T) {
+	now := time.Now().UTC()
+	cost := 2500000.0
+
+	jobsRepo := &mockIndustryJobsRepo{}
+	queueRepo := &mockJobQueueRepo{}
+	esiClient := &mockIndustryEsiClient{
+		jobsByChar: map[int64][]*client.EsiIndustryJob{},
+		jobsByCorp: map[int64][]*client.EsiIndustryJob{
+			98000001: {
+				{
+					JobID: 200001, InstallerID: 1001, FacilityID: 60003760, LocationID: 60003760,
+					ActivityID: 9, BlueprintID: 5555, BlueprintTypeID: 46166,
+					BlueprintLocationID: 60003760, OutputLocationID: 60003760,
+					Runs: 100, Cost: &cost, Status: "active", Duration: 7200,
+					StartDate: now.Format(time.RFC3339), EndDate: now.Add(2 * time.Hour).Format(time.RFC3339),
+				},
+			},
+		},
+	}
+	userRepo := &mockIndustryUserRepo{userIDs: []int64{100}}
+	charRepo := &mockIndustryCharRepo{charactersByUser: map[int64][]*repositories.Character{100: {}}}
+	corpRepo := &mockIndustryCorpRepo{
+		corpsByUser: map[int64][]repositories.PlayerCorporation{
+			100: {
+				{ID: 98000001, UserID: 100, Name: "Test Corp", EsiToken: "corp-token", EsiScopes: "esi-industry.read_corporation_jobs.v1", EsiExpiresOn: now.Add(time.Hour)},
+			},
+		},
+	}
+
+	updater := updaters.NewIndustryJobsUpdater(userRepo, charRepo, corpRepo, jobsRepo, queueRepo, esiClient)
+	err := updater.UpdateUserJobs(context.Background(), 100)
+	assert.NoError(t, err)
+
+	assert.Len(t, jobsRepo.upsertedJobs[100], 1)
+	assert.Equal(t, int64(200001), jobsRepo.upsertedJobs[100][0].JobID)
+	assert.Equal(t, "active", jobsRepo.upsertedJobs[100][0].Status)
+	assert.Equal(t, 9, jobsRepo.upsertedJobs[100][0].ActivityID)
+	assert.Equal(t, "corporation", jobsRepo.upsertedJobs[100][0].Source)
+	assert.Equal(t, int64(60003760), jobsRepo.upsertedJobs[100][0].StationID, "location_id should be normalized to station_id for corp jobs")
+}
+
+func Test_IndustryJobsUpdater_SkipsCorpsWithoutScope(t *testing.T) {
+	now := time.Now().UTC()
+
+	jobsRepo := &mockIndustryJobsRepo{}
+	queueRepo := &mockJobQueueRepo{}
+	esiClient := &mockIndustryEsiClient{
+		jobsByChar: map[int64][]*client.EsiIndustryJob{},
+		jobsByCorp: map[int64][]*client.EsiIndustryJob{
+			98000001: {{JobID: 200001, InstallerID: 1001, FacilityID: 60003760, StationID: 60003760, ActivityID: 1, BlueprintID: 1, BlueprintTypeID: 787, BlueprintLocationID: 60003760, OutputLocationID: 60003760, Runs: 1, Status: "active", Duration: 3600, StartDate: now.Format(time.RFC3339), EndDate: now.Add(time.Hour).Format(time.RFC3339)}},
+		},
+	}
+	userRepo := &mockIndustryUserRepo{userIDs: []int64{100}}
+	charRepo := &mockIndustryCharRepo{charactersByUser: map[int64][]*repositories.Character{100: {}}}
+	corpRepo := &mockIndustryCorpRepo{
+		corpsByUser: map[int64][]repositories.PlayerCorporation{
+			100: {
+				{ID: 98000001, UserID: 100, Name: "No Scope Corp", EsiToken: "corp-token", EsiScopes: "esi-corporations.read_structures.v1", EsiExpiresOn: now.Add(time.Hour)},
+			},
+		},
+	}
+
+	updater := updaters.NewIndustryJobsUpdater(userRepo, charRepo, corpRepo, jobsRepo, queueRepo, esiClient)
+	err := updater.UpdateUserJobs(context.Background(), 100)
+	assert.NoError(t, err)
+
+	// Should not have upserted any jobs since corp lacks the industry scope
+	assert.Empty(t, jobsRepo.upsertedJobs)
+}

--- a/makefile
+++ b/makefile
@@ -56,7 +56,7 @@ test-backend:
 	@echo "Running backend tests with coverage..."
 	@mkdir -p artifacts/coverage/backend
 	$(DOCKER_COMPOSE) -f docker-compose.test.yaml run --rm backend-test \
-		sh -c "go test -v -coverprofile=/artifacts/coverage/backend/coverage.out ./internal/... && \
+		sh -c "go test -v -p 1 -coverprofile=/artifacts/coverage/backend/coverage.out ./internal/... && \
 		       go tool cover -html=/artifacts/coverage/backend/coverage.out -o /artifacts/coverage/backend/coverage.html"
 	@echo "✓ Backend coverage report: artifacts/coverage/backend/coverage.html"
 


### PR DESCRIPTION
## Summary
- Full-stack industry job tracking: ESI job syncing (character + corporation), manufacturing cost calculator, job queue with ESI matching, and character skills updater
- Frontend: Industry page with 3 tabs (Active Jobs, Job Queue, Add Job), source indicators (character/corp icons), installer names, system name resolution, finish time countdown
- Backend: 3 new DB tables, 5 repositories, 2 updaters, 2 runners, 1 controller with 9 endpoints, manufacturing calculator reusing reactions engine
- Corporation endpoint `location_id` → `station_id` normalization, system name resolved via stations table JOIN

## Test plan
- [x] `make test-backend` — all updater/controller/repository/calculator tests pass
- [x] `make test-frontend` — 13 suites, 128 tests, 23 snapshots pass
- [ ] Manual: verify skills/jobs sync in logs after server start
- [ ] Manual: create planned job via UI, verify queue matching after starting job in-game
- [ ] Manual: verify character and corporation jobs both appear with correct source icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)