### PR TITLE
Fix auto-sell duplicate listings after purchase completion

### DIFF
--- a/internal/database/migrations/20260222143509_add_completed_at.down.sql
+++ b/internal/database/migrations/20260222143509_add_completed_at.down.sql
@@ -1,0 +1,2 @@
+alter table purchase_transactions
+	drop column completed_at;

--- a/internal/database/migrations/20260222143509_add_completed_at.up.sql
+++ b/internal/database/migrations/20260222143509_add_completed_at.up.sql
@@ -1,0 +1,2 @@
+alter table purchase_transactions
+	add column completed_at timestamp;


### PR DESCRIPTION
## Summary
- Adds `completed_at` timestamp column to `purchase_transactions`
- Extends the 1-hour asset hold to also cover `completed` purchases (previously only `contract_created` was held)
- Fixes race condition where contract sync completing a purchase would immediately drop the hold, allowing auto-sell to re-list items still visible in stale ESI asset caches

## Test plan
- [x] `make test-backend` passes
- [x] `CompleteWithContractID` sets `completed_at`
- [x] `UpdateStatus` to `completed` sets `completed_at`
- [x] `GetPendingQuantitiesForSaleContext` counts recently completed purchases
- [x] Stale completed purchases (>1 hour) are not counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)