### PR TITLE
Add Industry Job Manager Phase 2

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -80,6 +80,8 @@ var rootCmd = &cobra.Command{
 		characterSkillsRepository := repositories.NewCharacterSkills(db)
 		industryJobsRepository := repositories.NewIndustryJobs(db)
 		jobQueueRepository := repositories.NewJobQueue(db)
+		productionPlansRepository := repositories.NewProductionPlans(db)
+		planRunsRepository := repositories.NewPlanRuns(db)
 
 		var esiClient *client.EsiClient
 		if settings.EsiBaseURL != "" {
@@ -161,6 +163,9 @@ var rootCmd = &cobra.Command{
 		}
 		controllers.NewPi(router, piPlanetsRepository, piTaxConfigRepository, sdeDataRepository, charactersRepository, systemRepository, itemTypesRepository, marketPricesRepository, piLaunchpadLabelsRepository, stockpileMarkersRepository)
 		controllers.NewIndustry(router, industryJobsRepository, jobQueueRepository, sdeDataRepository, marketPricesRepository, industryCostIndicesRepository)
+		userStationsRepository := repositories.NewUserStations(db)
+		controllers.NewProductionPlans(router, productionPlansRepository, sdeDataRepository, jobQueueRepository, marketPricesRepository, industryCostIndicesRepository, charactersRepository, playerCorporationRepostiory, userStationsRepository, planRunsRepository)
+		controllers.NewUserStations(router, userStationsRepository)
 
 		group.Go(router.Run(ctx))
 

--- a/docs/features/industry-job-manager/batch-configure.md
+++ b/docs/features/industry-job-manager/batch-configure.md
@@ -1,0 +1,100 @@
+# Batch Configure Production Plan Steps
+
+## Overview
+
+The Batch Configure tab in the Production Plan Editor groups production steps that produce the same item (same `productTypeId` + `activity`) and allows configuring all instances at once. This simplifies setup for production chains where the same material (e.g., fuel blocks) appears in multiple places in the tree.
+
+## Status
+
+- **Phase**: Implemented
+- **Branch**: `feature/production-plans`
+
+## How It Works
+
+### Grouping Logic
+
+Steps are grouped by `productTypeId + activity`. For each group, the UI shows:
+- Product icon, name, and activity type
+- Count of steps in the group
+- Summary values: if all steps share the same value, it's shown directly; if they differ, a "Mixed" chip is displayed
+
+### Batch Edit
+
+Clicking "Edit" on a group opens a dialog identical to the single-step EditStepDialog, with the same fields:
+- ME/TE levels, skills, structure, rig, security, facility tax
+- Preferred station selection (auto-populates structure/rig/security/tax)
+- Input location (owner, division, container)
+- Output location (owner, division, container)
+
+On save, all steps in the group are updated in a single batch API call.
+
+### Material Toggle (Buy / Produce)
+
+Each group row can be expanded to reveal the materials required by that step. For each material:
+
+- **Status detection**: The component checks all steps in the group for child steps producing that material, yielding one of three statuses:
+  - `all` — every step in the group has a child step producing this material → shown as "Produce" chip
+  - `none` — no step in the group has a child step for this material → shown as "Buy" chip
+  - `mixed` — some steps produce it, others don't → shown as "Mixed" chip
+- **Toggle action**: Clicking the toggle button switches between buy and produce for **all** steps in the group simultaneously:
+  - If status is `all` or `mixed`: deletes all child steps for that material across the group (switches to Buy)
+  - If status is `none`: creates child steps for all steps that don't have one (switches to Produce)
+- Only materials with a blueprint (`hasBlueprint: true`) show a toggle button
+- Materials are fetched lazily on first expand from the first step's materials endpoint
+- Status is recomputed when `plan.steps` changes (e.g., after a toggle action)
+
+## API
+
+### `PUT /v1/industry/plans/{id}/steps/batch`
+
+Batch updates multiple steps with the same parameters.
+
+**Request body:**
+```json
+{
+  "step_ids": [10, 20, 30],
+  "me_level": 10,
+  "te_level": 20,
+  "industry_skill": 5,
+  "adv_industry_skill": 5,
+  "structure": "raitaru",
+  "rig": "t2",
+  "security": "high",
+  "facility_tax": 1.0,
+  "user_station_id": 5,
+  "source_owner_type": "corporation",
+  "source_owner_id": 2001,
+  "source_division_number": 2,
+  "source_container_id": null,
+  "source_location_id": 60003760,
+  "output_owner_type": "corporation",
+  "output_owner_id": 2001,
+  "output_division_number": 3,
+  "output_container_id": null
+}
+```
+
+**Response:**
+```json
+{
+  "status": "updated",
+  "rows_affected": 3
+}
+```
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `internal/repositories/productionPlans.go` | `BatchUpdateSteps` method — transaction-based batch UPDATE with `WHERE s.id = ANY($1)` |
+| `internal/controllers/productionPlans.go` | `BatchUpdateSteps` handler, request validation, route at `/v1/industry/plans/{id}/steps/batch` |
+| `frontend/pages/api/industry/plans/[id]/steps/batch.ts` | Next.js API proxy |
+| `frontend/packages/components/industry/ProductionPlanEditor.tsx` | Tab UI (Step Tree / Batch Configure) |
+| `frontend/packages/components/industry/BatchConfigureTab.tsx` | Grouping table + BatchEditStepDialog |
+
+## Key Decisions
+
+1. **Route ordering**: The `/steps/batch` route is registered before `/steps/{stepId}` to prevent Gorilla mux from matching "batch" as a step ID.
+2. **Transaction**: Batch update uses a database transaction to ensure all-or-nothing semantics.
+3. **Ownership verification**: The batch update query JOINs through `production_plans` to verify the requesting user owns the plan, same as the single-step update.
+4. **No partial updates**: All fields are set for all steps — there's no "only update ME/TE" mode. The dialog pre-populates from the first step in the group.

--- a/docs/features/industry-job-manager/preferred-stations.md
+++ b/docs/features/industry-job-manager/preferred-stations.md
@@ -1,0 +1,191 @@
+# Preferred Stations
+
+## Overview
+
+Save station configurations linked to real player-owned structures. Users paste in-game structure fitting scans to auto-detect structure type, rigs, and services. Production plan steps reference preferred stations by FK, so structure/rig/security/tax/name are derived at query time and changes propagate automatically.
+
+## Status
+
+- **Phase 1**: Complete — station CRUD, scan parser, plan step integration with activity-aware rig matching
+- **Phase 2**: Complete — plan-level default stations (manufacturing + reaction), auto-assigned to new steps
+- **Phase 3**: Complete — independent input and output hangar configuration per step with transfer indicators
+
+---
+
+## How It Works
+
+### Data Flow
+
+```
+Frontend                    Backend Controller              Database
+────────                    ──────────────────              ────────
+/stations page           →  GET /v1/user-stations         →  user_stations + rigs + services
+                            POST /v1/user-stations        →  (create with rigs + services)
+                            PUT /v1/user-stations/{id}    →  (update station + replace rigs/services)
+                            DELETE /v1/user-stations/{id}  →  (cascade delete rigs + services)
+                            POST /v1/user-stations/parse-scan → (pure parser, no DB)
+
+Plan Step Edit              Backend (plan step update)      Database
+──────────                  ──────────────────────          ────────
+Select preferred station →  PUT .../steps/{id}             →  production_plan_steps.user_station_id
+                            GET .../plans/{id}             →  JOIN user_stations → derive fields
+```
+
+### Scan Parser
+
+Parses EVE Online structure fitting scan text to extract structure type, rigs, and services.
+
+**Sections parsed**: Rig Slots, Service Slots (High/Medium/Low Power Slots are ignored)
+
+**Rig categories**:
+| Keyword | Category |
+|---------|----------|
+| Ship Manufacturing | ship |
+| Structure and Component | component |
+| Equipment Manufacturing | equipment |
+| Ammunition Manufacturing | ammo |
+| Drone and Fighter | drone |
+| Biochemical/Composite/Hybrid/Polymer Reactor | reaction |
+| Thukker Component | component |
+
+**Structure detection from rig size prefix**:
+| Prefix | Manufacturing | Reaction |
+|--------|--------------|----------|
+| XL-Set | Sotiyo | — |
+| L-Set | Azbel | Tatara |
+| M-Set | Raitaru | Athanor |
+
+**Service → activity mapping**:
+| Service | Activity |
+|---------|----------|
+| Manufacturing Plant, Capital/Supercapital Shipyard | manufacturing |
+| Biochemical/Composite/Hybrid/Polymer Reactor | reaction |
+
+### Rig Category Matching
+
+When a plan step references a station, the correct rig is determined by the step's activity and SDE product category:
+
+**Manufacturing steps**: SDE category → rig category (6=ship, 7=equipment, 8=ammo, 18/87=drone, else=component)
+
+**Reaction steps**: Always use rig category "reaction"
+
+---
+
+## Schema
+
+### user_stations
+| Column | Type | Description |
+|--------|------|-------------|
+| id | bigserial | Primary key |
+| user_id | bigint | FK → users |
+| station_id | bigint | FK → stations (real structure) |
+| structure | text | Calculator value: raitaru, azbel, sotiyo, tatara, athanor |
+| facility_tax | numeric(5,2) | Tax percentage |
+
+### user_station_rigs
+| Column | Type | Description |
+|--------|------|-------------|
+| id | bigserial | Primary key |
+| user_station_id | bigint | FK → user_stations (cascade) |
+| rig_name | text | Full rig name from scan |
+| category | text | ship, component, equipment, ammo, drone, reaction |
+| tier | text | t1 or t2 |
+
+### user_station_services
+| Column | Type | Description |
+|--------|------|-------------|
+| id | bigserial | Primary key |
+| user_station_id | bigint | FK → user_stations (cascade) |
+| service_name | text | Full service name from scan |
+| activity | text | manufacturing or reaction |
+
+### production_plan_steps (added columns)
+| Column | Type | Description |
+|--------|------|-------------|
+| user_station_id | bigint | Nullable FK → user_stations (on delete set null) |
+| source_location_id | bigint | Input station ID (derived from user_station_id) |
+| source_owner_type | text | Input owner: "character" or "corporation" |
+| source_owner_id | bigint | Input owner ID |
+| source_division_number | int | Input corp hangar division (1-7) |
+| source_container_id | bigint | Input container item ID (optional) |
+| output_owner_type | text | Output owner: "character" or "corporation" |
+| output_owner_id | bigint | Output owner ID |
+| output_division_number | int | Output corp hangar division (1-7) |
+| output_container_id | bigint | Output container item ID (optional) |
+
+### production_plans (added columns)
+| Column | Type | Description |
+|--------|------|-------------|
+| default_manufacturing_station_id | bigint | Nullable FK → user_stations (on delete set null) |
+| default_reaction_station_id | bigint | Nullable FK → user_stations (on delete set null) |
+
+When creating a plan, users can select default stations. All steps created in that plan auto-inherit the appropriate station based on their activity (manufacturing or reaction).
+
+---
+
+## Key Decisions
+
+- **Individual rig storage**: Rigs stored as separate rows with category and tier, enabling per-item rig matching
+- **Reference, not copy**: Plan steps reference stations by FK. Station config changes propagate to all steps using that station
+- **Activity-aware filtering**: EditStepDialog only shows stations whose services match the step's activity
+- **Enriched query**: Station name, system, security derived via JOINs (not duplicated)
+- **rigCategory enrichment**: Computed in SQL via SDE category CASE expression when fetching plan steps
+- **Plan-level default stations**: Each plan stores default manufacturing + reaction station IDs. Backend auto-assigns `user_station_id` on step creation based on activity. Different plans can use different stations.
+- **Single input location per step**: All materials for a production step come from the same hangar/container, matching EVE Online's behavior where a job pulls all materials from one location. Enforced by one set of source fields per step.
+- **Containers nested within hangars**: Selection flow is Owner → Division (corp only) → Container (optional). A container is always within the context of its parent hangar.
+- **Independent output per step**: Each step independently configures its output location (owner/division/container). No auto-linking — different steps can output to different hangars/stations.
+- **Transfer indicator**: When a child step's station differs from the parent step's station, a warning "Transfer" badge appears in the tree, indicating items must be moved between stations in-game.
+- **Backend enrichment for display names**: Source and output owner/division/container names resolved via LEFT JOINs in `GetByID`, avoiding extra frontend API calls.
+
+---
+
+## Input/Output Hangar Configuration
+
+Each production plan step can specify WHERE materials come from (input) and WHERE completed items go (output). Both use the same location hierarchy:
+
+**Owner** (character or corporation) → **Division** (corp hangar division 1-7, only for corporations) → **Container** (optional, a named container within the hangar)
+
+Both input and output are always at the step's own preferred station — in EVE Online, a job's materials and output are at the same station where the job runs.
+
+### How It Works
+
+1. User selects a preferred station for a step
+2. "Input Location" and "Output Location" sections appear in EditStepDialog
+3. Backend returns available characters, corporations (with division names), and containers at that station via `GET /v1/industry/plans/hangars?user_station_id=X`
+4. User selects owner, division (if corp), and optionally a container for both input and output
+5. Input fields saved: `source_owner_type`, `source_owner_id`, `source_division_number`, `source_container_id`, `source_location_id`
+6. Output fields saved: `output_owner_type`, `output_owner_id`, `output_division_number`, `output_container_id`
+7. Display names resolved via LEFT JOINs when fetching the plan
+
+### Transfer Indicator
+
+When a child step runs at a different station than its parent step, a warning "Transfer" badge appears in the step tree. This indicates items must be moved between stations in-game (e.g., reaction products from a Tatara need to be hauled to an Azbel for manufacturing).
+
+---
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `migrations/20260222175330_create_user_stations.up.sql` | Tables + FK on plan steps |
+| `internal/models/models.go` | UserStation, UserStationRig, ScanResult types |
+| `internal/parser/scan.go` | Structure scan parser |
+| `internal/parser/scan_test.go` | Parser tests (11 cases) |
+| `internal/repositories/userStations.go` | CRUD with rigs + JOINs |
+| `internal/repositories/userStations_test.go` | Integration tests (7 cases) |
+| `internal/controllers/userStations.go` | HTTP handlers |
+| `internal/controllers/userStations_test.go` | Controller tests (7 cases) |
+| `internal/repositories/productionPlans.go` | rigCategory enrichment + station override + default station columns + container query + source name enrichment |
+| `internal/controllers/productionPlans.go` | Auto-assign station to steps from plan defaults + GetHangars endpoint |
+| `migrations/20260222185246_add_plan_default_stations.up.sql` | Default station columns on plans |
+| `frontend/packages/components/stations/StationsList.tsx` | Station list table |
+| `frontend/packages/components/stations/StationDialog.tsx` | Add/edit dialog with scan |
+| `frontend/packages/components/industry/ProductionPlanEditor.tsx` | Station dropdown in EditStepDialog |
+| `frontend/packages/components/industry/ProductionPlansList.tsx` | Default station dropdowns in CreatePlanDialog |
+| `frontend/packages/pages/stations.tsx` | Page wrapper |
+| `frontend/pages/api/stations/user-stations.ts` | API proxy (GET + POST) |
+| `frontend/pages/api/stations/user-stations/[id].ts` | API proxy (PUT + DELETE) |
+| `frontend/pages/api/stations/parse-scan.ts` | API proxy (POST) |
+| `frontend/pages/api/industry/plans/hangars.ts` | API proxy for hangars endpoint |
+| `migrations/20260222220229_add_step_output_location.up.sql` | Output location columns on plan steps |
+| `frontend/packages/client/data/models.ts` | HangarsResponse type + enriched source/output fields on ProductionPlanStep |

--- a/frontend/packages/client/data/models.ts
+++ b/frontend/packages/client/data/models.ts
@@ -452,3 +452,145 @@ export type BlueprintSearchResult = {
   ProductName: string;
   Activity: string;
 };
+
+// Production Plans
+
+export type ProductionPlan = {
+  id: number;
+  userId: number;
+  productTypeId: number;
+  name: string;
+  notes?: string;
+  defaultManufacturingStationId?: number;
+  defaultReactionStationId?: number;
+  createdAt: string;
+  updatedAt: string;
+  productName?: string;
+  steps?: ProductionPlanStep[];
+};
+
+export type ProductionPlanStep = {
+  id: number;
+  planId: number;
+  parentStepId?: number;
+  productTypeId: number;
+  blueprintTypeId: number;
+  activity: string;
+  meLevel: number;
+  teLevel: number;
+  industrySkill: number;
+  advIndustrySkill: number;
+  structure: string;
+  rig: string;
+  security: string;
+  facilityTax: number;
+  stationName?: string;
+  sourceLocationId?: number;
+  sourceContainerId?: number;
+  sourceDivisionNumber?: number;
+  sourceOwnerType?: string;
+  sourceOwnerId?: number;
+  userStationId?: number;
+  productName?: string;
+  blueprintName?: string;
+  rigCategory?: string;
+  sourceOwnerName?: string;
+  sourceDivisionName?: string;
+  sourceContainerName?: string;
+  outputOwnerType?: string;
+  outputOwnerId?: number;
+  outputDivisionNumber?: number;
+  outputContainerId?: number;
+  outputOwnerName?: string;
+  outputDivisionName?: string;
+  outputContainerName?: string;
+};
+
+export type HangarsResponse = {
+  characters: { id: number; name: string }[];
+  corporations: {
+    id: number;
+    name: string;
+    divisions: Record<string, string>;
+  }[];
+  containers: {
+    id: number;
+    name: string;
+    ownerType: string;
+    ownerId: number;
+    divisionNumber?: number;
+  }[];
+};
+
+export type PlanMaterial = {
+  typeId: number;
+  typeName: string;
+  quantity: number;
+  volume: number;
+  hasBlueprint: boolean;
+  blueprintTypeId?: number;
+  activity?: string;
+  isProduced: boolean;
+};
+
+export type GenerateJobsResult = {
+  created: IndustryJobQueueEntry[];
+  skipped: GenerateJobSkipped[];
+};
+
+export type GenerateJobSkipped = {
+  typeId: number;
+  typeName: string;
+  reason: string;
+};
+
+// User Stations
+
+export type UserStation = {
+  id: number;
+  userId: number;
+  stationId: number;
+  structure: string;
+  facilityTax: number;
+  createdAt: string;
+  updatedAt: string;
+  stationName?: string;
+  solarSystemName?: string;
+  securityStatus?: number;
+  security?: string;
+  rigs: UserStationRig[];
+  services: UserStationService[];
+  activities: string[];
+};
+
+export type UserStationRig = {
+  id: number;
+  userStationId: number;
+  rigName: string;
+  category: string;
+  tier: string;
+};
+
+export type UserStationService = {
+  id: number;
+  userStationId: number;
+  serviceName: string;
+  activity: string;
+};
+
+export type ScanResult = {
+  structure: string;
+  rigs: ScanRig[];
+  services: ScanService[];
+};
+
+export type ScanRig = {
+  name: string;
+  category: string;
+  tier: string;
+};
+
+export type ScanService = {
+  name: string;
+  activity: string;
+};

--- a/frontend/packages/components/Navbar.tsx
+++ b/frontend/packages/components/Navbar.tsx
@@ -99,6 +99,12 @@ export default function Navbar() {
           <Button color="inherit" href="/industry">
             Industry
           </Button>
+          <Button color="inherit" href="/production-plans">
+            Plans
+          </Button>
+          <Button color="inherit" href="/stations">
+            Stations
+          </Button>
           <Button color="inherit" href="/pi">
             Planets
           </Button>

--- a/frontend/packages/components/__tests__/__snapshots__/Navbar.test.tsx.snap
+++ b/frontend/packages/components/__tests__/__snapshots__/Navbar.test.tsx.snap
@@ -97,6 +97,20 @@ exports[`Navbar Component should match snapshot when not authenticated 1`] = `
       </a>
       <a
         class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-plnrbk-MuiButtonBase-root-MuiButton-root"
+        href="/production-plans"
+        tabindex="0"
+      >
+        Plans
+      </a>
+      <a
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-plnrbk-MuiButtonBase-root-MuiButton-root"
+        href="/stations"
+        tabindex="0"
+      >
+        Stations
+      </a>
+      <a
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-plnrbk-MuiButtonBase-root-MuiButton-root"
         href="/pi"
         tabindex="0"
       >

--- a/frontend/packages/components/industry/BatchConfigureTab.tsx
+++ b/frontend/packages/components/industry/BatchConfigureTab.tsx
@@ -1,0 +1,1404 @@
+import { useState, useEffect } from "react";
+import {
+  ProductionPlan,
+  ProductionPlanStep,
+  PlanMaterial,
+  UserStation,
+  HangarsResponse,
+} from "@industry-tool/client/data/models";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import IconButton from "@mui/material/IconButton";
+import Chip from "@mui/material/Chip";
+import TextField from "@mui/material/TextField";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Autocomplete from "@mui/material/Autocomplete";
+import Snackbar from "@mui/material/Snackbar";
+import Alert from "@mui/material/Alert";
+import Divider from "@mui/material/Divider";
+import Tooltip from "@mui/material/Tooltip";
+import CircularProgress from "@mui/material/CircularProgress";
+import EditIcon from "@mui/icons-material/Edit";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import BuildIcon from "@mui/icons-material/Build";
+import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
+
+type Props = {
+  plan: ProductionPlan;
+  planId: number;
+  onUpdate: () => void;
+};
+
+type StepGroup = {
+  productTypeId: number;
+  productName: string;
+  activity: string;
+  steps: ProductionPlanStep[];
+  stepIds: number[];
+  meLevel: number | "mixed";
+  teLevel: number | "mixed";
+  structure: string | "mixed";
+  rig: string | "mixed";
+  security: string | "mixed";
+  stationName: string | null | "mixed";
+  userStationId: number | null | "mixed";
+  inputLocation: string | null | "mixed";
+  outputLocation: string | null | "mixed";
+};
+
+function groupSteps(steps: ProductionPlanStep[]): StepGroup[] {
+  const groupMap = new Map<string, ProductionPlanStep[]>();
+
+  for (const step of steps) {
+    const key = `${step.productTypeId}:${step.activity}`;
+    const existing = groupMap.get(key) || [];
+    existing.push(step);
+    groupMap.set(key, existing);
+  }
+
+  const groups: StepGroup[] = [];
+  for (const [, stepsInGroup] of groupMap) {
+    const first = stepsInGroup[0];
+
+    const uniform = <T,>(getter: (s: ProductionPlanStep) => T): T | "mixed" => {
+      const first = getter(stepsInGroup[0]);
+      return stepsInGroup.every((s) => getter(s) === first) ? first : "mixed";
+    };
+
+    groups.push({
+      productTypeId: first.productTypeId,
+      productName: first.productName || `Type ${first.productTypeId}`,
+      activity: first.activity,
+      steps: stepsInGroup,
+      stepIds: stepsInGroup.map((s) => s.id),
+      meLevel: uniform((s) => s.meLevel),
+      teLevel: uniform((s) => s.teLevel),
+      structure: uniform((s) => s.structure),
+      rig: uniform((s) => s.rig),
+      security: uniform((s) => s.security),
+      stationName: uniform((s) => s.stationName || null),
+      userStationId: uniform((s) => s.userStationId || null),
+      inputLocation: uniform((s) => {
+        if (!s.sourceOwnerName) return null;
+        let loc = s.sourceOwnerName;
+        if (s.sourceDivisionName) loc += ` / ${s.sourceDivisionName}`;
+        if (s.sourceContainerName) loc += ` / ${s.sourceContainerName}`;
+        return loc;
+      }),
+      outputLocation: uniform((s) => {
+        if (!s.outputOwnerName) return null;
+        let loc = s.outputOwnerName;
+        if (s.outputDivisionName) loc += ` / ${s.outputDivisionName}`;
+        if (s.outputContainerName) loc += ` / ${s.outputContainerName}`;
+        return loc;
+      }),
+    });
+  }
+
+  groups.sort((a, b) => a.productName.localeCompare(b.productName));
+  return groups;
+}
+
+type MaterialStatus = "all" | "none" | "mixed";
+
+type GroupMaterial = PlanMaterial & {
+  produceStatus: MaterialStatus;
+};
+
+export default function BatchConfigureTab({ plan, planId, onUpdate }: Props) {
+  const [editGroup, setEditGroup] = useState<StepGroup | null>(null);
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [groupMaterials, setGroupMaterials] = useState<Record<string, GroupMaterial[]>>({});
+  const [loadingMaterials, setLoadingMaterials] = useState<Set<string>>(new Set());
+  const [togglingMaterial, setTogglingMaterial] = useState<string | null>(null);
+  const [togglingAllGroup, setTogglingAllGroup] = useState<string | null>(null);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: "success" | "error";
+  }>({ open: false, message: "", severity: "success" });
+
+  const steps = plan.steps || [];
+  const groups = groupSteps(steps);
+
+  const groupKey = (g: StepGroup) => `${g.productTypeId}:${g.activity}`;
+
+  // Compute produce status for a material across all steps in a group
+  const computeProduceStatus = (group: StepGroup, materialTypeId: number): MaterialStatus => {
+    let hasProduced = false;
+    let hasMissing = false;
+    for (const step of group.steps) {
+      const hasChild = steps.some(
+        (s) => s.parentStepId === step.id && s.productTypeId === materialTypeId,
+      );
+      if (hasChild) hasProduced = true;
+      else hasMissing = true;
+    }
+    if (hasProduced && !hasMissing) return "all";
+    if (!hasProduced && hasMissing) return "none";
+    return "mixed";
+  };
+
+  const fetchMaterialsForGroup = async (group: StepGroup) => {
+    const key = groupKey(group);
+    const firstStep = group.steps[0];
+    setLoadingMaterials((prev) => new Set([...prev, key]));
+    try {
+      const res = await fetch(
+        `/api/industry/plans/${planId}/steps/${firstStep.id}/materials`,
+      );
+      if (res.ok) {
+        const data: PlanMaterial[] = await res.json();
+        const enriched: GroupMaterial[] = (data || []).map((mat) => ({
+          ...mat,
+          produceStatus: computeProduceStatus(group, mat.typeId),
+        }));
+        setGroupMaterials((prev) => ({ ...prev, [key]: enriched }));
+      }
+    } catch (err) {
+      console.error("Failed to fetch group materials:", err);
+    } finally {
+      setLoadingMaterials((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+    }
+  };
+
+  const toggleExpand = (group: StepGroup) => {
+    const key = groupKey(group);
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+        if (!groupMaterials[key]) {
+          fetchMaterialsForGroup(group);
+        }
+      }
+      return next;
+    });
+  };
+
+  // Eagerly fetch materials for all groups, and refresh statuses when plan data changes
+  useEffect(() => {
+    for (const group of groups) {
+      const key = groupKey(group);
+      if (groupMaterials[key]) {
+        // Refresh produce statuses for already-loaded materials
+        setGroupMaterials((prev) => ({
+          ...prev,
+          [key]: prev[key].map((mat) => ({
+            ...mat,
+            produceStatus: computeProduceStatus(group, mat.typeId),
+          })),
+        }));
+      } else if (!loadingMaterials.has(key)) {
+        // Eagerly fetch materials for groups that haven't been loaded yet
+        fetchMaterialsForGroup(group);
+      }
+    }
+  }, [steps.length]);
+
+  const handleToggleProduce = async (group: StepGroup, material: PlanMaterial) => {
+    const matKey = `${groupKey(group)}:${material.typeId}`;
+    setTogglingMaterial(matKey);
+
+    const status = computeProduceStatus(group, material.typeId);
+
+    try {
+      if (status === "all" || status === "mixed") {
+        // Remove: delete child steps for all steps in the group that have one
+        const childSteps = steps.filter(
+          (s) => group.stepIds.includes(s.parentStepId!) && s.productTypeId === material.typeId,
+        );
+        for (const child of childSteps) {
+          await fetch(`/api/industry/plans/${planId}/steps/${child.id}`, {
+            method: "DELETE",
+          });
+        }
+        setSnackbar({
+          open: true,
+          message: `Set ${material.typeName} to Buy across ${group.stepIds.length} step(s)`,
+          severity: "success",
+        });
+      } else {
+        // Create: add child steps for all steps in the group that don't have one
+        for (const step of group.steps) {
+          const hasChild = steps.some(
+            (s) => s.parentStepId === step.id && s.productTypeId === material.typeId,
+          );
+          if (!hasChild) {
+            await fetch(`/api/industry/plans/${planId}/steps`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                parent_step_id: step.id,
+                product_type_id: material.typeId,
+              }),
+            });
+          }
+        }
+        setSnackbar({
+          open: true,
+          message: `Set ${material.typeName} to Produce across ${group.stepIds.length} step(s)`,
+          severity: "success",
+        });
+      }
+      onUpdate();
+    } catch (err) {
+      console.error("Failed to toggle produce:", err);
+      setSnackbar({
+        open: true,
+        message: "Failed to toggle produce/buy",
+        severity: "error",
+      });
+    } finally {
+      setTogglingMaterial(null);
+    }
+  };
+
+  const handleSetAllBuild = async (group: StepGroup) => {
+    const key = groupKey(group);
+    setTogglingAllGroup(key);
+    try {
+      // Ensure materials are loaded
+      let mats = groupMaterials[key];
+      if (!mats) {
+        const firstStep = group.steps[0];
+        const res = await fetch(
+          `/api/industry/plans/${planId}/steps/${firstStep.id}/materials`,
+        );
+        if (!res.ok) throw new Error("Failed to fetch materials");
+        const data: PlanMaterial[] = await res.json();
+        mats = (data || []).map((mat) => ({
+          ...mat,
+          produceStatus: computeProduceStatus(group, mat.typeId),
+        }));
+        setGroupMaterials((prev) => ({ ...prev, [key]: mats! }));
+      }
+
+      // For each material with a blueprint, create child steps where missing
+      const buildableMats = mats.filter((m) => m.hasBlueprint);
+      let created = 0;
+      for (const mat of buildableMats) {
+        for (const step of group.steps) {
+          const hasChild = steps.some(
+            (s) => s.parentStepId === step.id && s.productTypeId === mat.typeId,
+          );
+          if (!hasChild) {
+            await fetch(`/api/industry/plans/${planId}/steps`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                parent_step_id: step.id,
+                product_type_id: mat.typeId,
+              }),
+            });
+            created++;
+          }
+        }
+      }
+      setSnackbar({
+        open: true,
+        message: `Set all to Build: created ${created} step(s) across ${group.stepIds.length} ${group.productName} step(s)`,
+        severity: "success",
+      });
+      onUpdate();
+    } catch (err) {
+      console.error("Failed to set all to build:", err);
+      setSnackbar({ open: true, message: "Failed to set all to build", severity: "error" });
+    } finally {
+      setTogglingAllGroup(null);
+    }
+  };
+
+  const handleSetAllBuy = async (group: StepGroup) => {
+    const key = groupKey(group);
+    setTogglingAllGroup(key);
+    try {
+      // Find all child steps belonging to this group's steps
+      const childSteps = steps.filter(
+        (s) => s.parentStepId && group.stepIds.includes(s.parentStepId),
+      );
+      for (const child of childSteps) {
+        await fetch(`/api/industry/plans/${planId}/steps/${child.id}`, {
+          method: "DELETE",
+        });
+      }
+      setSnackbar({
+        open: true,
+        message: `Set all to Buy: removed ${childSteps.length} step(s) from ${group.stepIds.length} ${group.productName} step(s)`,
+        severity: "success",
+      });
+      onUpdate();
+    } catch (err) {
+      console.error("Failed to set all to buy:", err);
+      setSnackbar({ open: true, message: "Failed to set all to buy", severity: "error" });
+    } finally {
+      setTogglingAllGroup(null);
+    }
+  };
+
+  const handleSave = async (group: StepGroup, updates: Record<string, unknown>) => {
+    try {
+      const res = await fetch(`/api/industry/plans/${planId}/steps/batch`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          step_ids: group.stepIds,
+          ...updates,
+        }),
+      });
+      if (res.ok) {
+        setEditGroup(null);
+        onUpdate();
+        setSnackbar({
+          open: true,
+          message: `Updated ${group.stepIds.length} ${group.productName} step(s)`,
+          severity: "success",
+        });
+      } else {
+        setSnackbar({
+          open: true,
+          message: "Failed to update steps",
+          severity: "error",
+        });
+      }
+    } catch (err) {
+      console.error("Failed to batch update steps:", err);
+      setSnackbar({
+        open: true,
+        message: "Failed to update steps",
+        severity: "error",
+      });
+    }
+  };
+
+  if (steps.length === 0) {
+    return (
+      <Box sx={{ textAlign: "center", py: 4 }}>
+        <Typography sx={{ color: "#64748b" }}>No steps in this plan</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Typography sx={{ color: "#94a3b8", fontSize: 13, mb: 2 }}>
+        Steps producing the same item are grouped together. Edit a group to configure all instances at once. Expand a group to toggle materials between buy and produce.
+      </Typography>
+
+      <TableContainer component={Paper} sx={{ backgroundColor: "#12151f" }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow sx={{ backgroundColor: "#0f1219" }}>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                Product
+              </TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                Activity
+              </TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="center">
+                Count
+              </TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="center">
+                Build / Buy
+              </TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                ME / TE
+              </TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                Structure / Rig / Sec
+              </TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                Station
+              </TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="center">
+                Actions
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {groups.map((group) => {
+              const key = groupKey(group);
+              const isExpanded = expandedGroups.has(key);
+              const materials = groupMaterials[key] || [];
+              const isLoadingMats = loadingMaterials.has(key);
+
+              // Count distinct produced material types across all steps in this group
+              const childTypeIds = new Set<number>();
+              for (const step of group.steps) {
+                for (const s of steps) {
+                  if (s.parentStepId === step.id) {
+                    childTypeIds.add(s.productTypeId);
+                  }
+                }
+              }
+              const buildCount = childTypeIds.size;
+
+              // Buy count: from loaded materials, count buildable materials not being produced
+              const loadedMats = groupMaterials[key];
+              const buyCount = loadedMats
+                ? loadedMats.filter((m) => m.hasBlueprint && !childTypeIds.has(m.typeId)).length
+                : null; // null means materials not yet loaded
+
+              return [
+                <TableRow
+                  key={key}
+                  sx={{
+                    backgroundColor: "#12151f",
+                    "&:hover": { backgroundColor: "#1e2235" },
+                  }}
+                >
+                  <TableCell>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                      <IconButton
+                        size="small"
+                        onClick={() => toggleExpand(group)}
+                        sx={{ color: "#94a3b8" }}
+                      >
+                        {isExpanded ? (
+                          <ExpandMoreIcon fontSize="small" />
+                        ) : (
+                          <ChevronRightIcon fontSize="small" />
+                        )}
+                      </IconButton>
+                      <img
+                        src={`https://images.evetech.net/types/${group.productTypeId}/icon?size=32`}
+                        alt=""
+                        width={24}
+                        height={24}
+                        style={{ borderRadius: 2 }}
+                      />
+                      <Typography sx={{ color: "#e2e8f0", fontSize: 14 }}>
+                        {group.productName}
+                      </Typography>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={group.activity}
+                      size="small"
+                      sx={{
+                        height: 20,
+                        fontSize: 11,
+                        backgroundColor:
+                          group.activity === "manufacturing" ? "#1e3a5f" : "#3a1e5f",
+                        color:
+                          group.activity === "manufacturing" ? "#60a5fa" : "#a78bfa",
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align="center">
+                    <Chip
+                      label={group.stepIds.length}
+                      size="small"
+                      sx={{
+                        height: 20,
+                        fontSize: 11,
+                        backgroundColor: "#1e293b",
+                        color: "#94a3b8",
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align="center">
+                    {togglingAllGroup === key ? (
+                      <CircularProgress size={16} sx={{ color: "#64748b" }} />
+                    ) : (
+                      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5, flexWrap: "wrap" }}>
+                        <Chip
+                          icon={<BuildIcon sx={{ fontSize: "14px !important" }} />}
+                          label={buildCount}
+                          size="small"
+                          sx={{
+                            height: 20,
+                            fontSize: 11,
+                            backgroundColor: buildCount > 0 ? "#1e3a5f" : "#1e293b",
+                            color: buildCount > 0 ? "#60a5fa" : "#475569",
+                            "& .MuiChip-icon": { color: buildCount > 0 ? "#60a5fa" : "#475569" },
+                          }}
+                        />
+                        <Chip
+                          icon={<ShoppingCartIcon sx={{ fontSize: "14px !important" }} />}
+                          label={buyCount ?? "?"}
+                          size="small"
+                          sx={{
+                            height: 20,
+                            fontSize: 11,
+                            backgroundColor: buyCount && buyCount > 0 ? "#1e293b" : "#1e293b",
+                            color: buyCount && buyCount > 0 ? "#94a3b8" : "#475569",
+                            "& .MuiChip-icon": { color: buyCount && buyCount > 0 ? "#94a3b8" : "#475569" },
+                          }}
+                        />
+                        <Tooltip title="Set all materials to Build">
+                          <span>
+                            <IconButton
+                              size="small"
+                              onClick={() => handleSetAllBuild(group)}
+                              disabled={buyCount === 0}
+                              sx={{ color: buyCount && buyCount > 0 ? "#10b981" : "#334155", p: 0.25 }}
+                            >
+                              <BuildIcon sx={{ fontSize: 16 }} />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title="Set all materials to Buy">
+                          <span>
+                            <IconButton
+                              size="small"
+                              onClick={() => handleSetAllBuy(group)}
+                              disabled={buildCount === 0}
+                              sx={{ color: buildCount > 0 ? "#ef4444" : "#334155", p: 0.25 }}
+                            >
+                              <ShoppingCartIcon sx={{ fontSize: 16 }} />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </Box>
+                    )}
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", fontSize: 13 }}>
+                    {group.meLevel === "mixed" ? (
+                      <Chip label="Mixed" size="small" sx={{ height: 18, fontSize: 10, backgroundColor: "#422006", color: "#f59e0b" }} />
+                    ) : (
+                      `ME ${group.meLevel}`
+                    )}
+                    {" / "}
+                    {group.teLevel === "mixed" ? (
+                      <Chip label="Mixed" size="small" sx={{ height: 18, fontSize: 10, backgroundColor: "#422006", color: "#f59e0b" }} />
+                    ) : (
+                      `TE ${group.teLevel}`
+                    )}
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", fontSize: 13 }}>
+                    {group.structure === "mixed" ? (
+                      <Chip label="Mixed" size="small" sx={{ height: 18, fontSize: 10, backgroundColor: "#422006", color: "#f59e0b" }} />
+                    ) : (
+                      group.structure
+                    )}
+                    {" / "}
+                    {group.rig === "mixed" ? (
+                      <Chip label="Mixed" size="small" sx={{ height: 18, fontSize: 10, backgroundColor: "#422006", color: "#f59e0b" }} />
+                    ) : (
+                      group.rig
+                    )}
+                    {" / "}
+                    {group.security === "mixed" ? (
+                      <Chip label="Mixed" size="small" sx={{ height: 18, fontSize: 10, backgroundColor: "#422006", color: "#f59e0b" }} />
+                    ) : (
+                      group.security
+                    )}
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", fontSize: 13 }}>
+                    {group.stationName === "mixed" ? (
+                      <Chip label="Mixed" size="small" sx={{ height: 18, fontSize: 10, backgroundColor: "#422006", color: "#f59e0b" }} />
+                    ) : (
+                      group.stationName || "—"
+                    )}
+                    {group.inputLocation === "mixed" ? (
+                      <Typography component="span" sx={{ color: "#64748b", fontSize: 11, display: "block" }}>
+                        In: <Chip label="Mixed" size="small" sx={{ height: 16, fontSize: 9, backgroundColor: "#422006", color: "#f59e0b" }} />
+                      </Typography>
+                    ) : group.inputLocation ? (
+                      <Typography sx={{ color: "#64748b", fontSize: 11 }}>
+                        In: {group.inputLocation}
+                      </Typography>
+                    ) : null}
+                    {group.outputLocation === "mixed" ? (
+                      <Typography component="span" sx={{ color: "#64748b", fontSize: 11, display: "block" }}>
+                        Out: <Chip label="Mixed" size="small" sx={{ height: 16, fontSize: 9, backgroundColor: "#422006", color: "#f59e0b" }} />
+                      </Typography>
+                    ) : group.outputLocation ? (
+                      <Typography sx={{ color: "#64748b", fontSize: 11 }}>
+                        Out: {group.outputLocation}
+                      </Typography>
+                    ) : null}
+                  </TableCell>
+                  <TableCell align="center">
+                    <IconButton
+                      size="small"
+                      onClick={() => setEditGroup(group)}
+                      sx={{ color: "#3b82f6" }}
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>,
+                // Material rows when expanded
+                ...(isExpanded
+                  ? isLoadingMats
+                    ? [
+                        <TableRow key={`${key}-loading`}>
+                          <TableCell
+                            colSpan={8}
+                            sx={{ color: "#64748b", fontSize: 13, pl: 6 }}
+                          >
+                            Loading materials...
+                          </TableCell>
+                        </TableRow>,
+                      ]
+                    : materials.map((mat) => {
+                        const matToggleKey = `${key}:${mat.typeId}`;
+                        const isToggling = togglingMaterial === matToggleKey;
+                        return (
+                          <TableRow
+                            key={`${key}-mat-${mat.typeId}`}
+                            sx={{
+                              backgroundColor: "#0f1219",
+                              "&:hover": { backgroundColor: "#151825" },
+                            }}
+                          >
+                            <TableCell>
+                              <Box
+                                sx={{
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: 0.5,
+                                  pl: 5,
+                                }}
+                              >
+                                <img
+                                  src={`https://images.evetech.net/types/${mat.typeId}/icon?size=32`}
+                                  alt=""
+                                  width={18}
+                                  height={18}
+                                  style={{ borderRadius: 2 }}
+                                />
+                                <Typography sx={{ color: "#cbd5e1", fontSize: 13 }}>
+                                  {mat.typeName}
+                                </Typography>
+                                <Typography
+                                  sx={{ color: "#64748b", fontSize: 12, ml: 1 }}
+                                >
+                                  x{mat.quantity}
+                                </Typography>
+                                {mat.produceStatus === "all" ? (
+                                  <Chip
+                                    label="Produce"
+                                    size="small"
+                                    sx={{
+                                      ml: 1,
+                                      height: 18,
+                                      fontSize: 10,
+                                      backgroundColor: "#1e3a5f",
+                                      color: "#60a5fa",
+                                    }}
+                                  />
+                                ) : mat.produceStatus === "mixed" ? (
+                                  <Chip
+                                    label="Mixed"
+                                    size="small"
+                                    sx={{
+                                      ml: 1,
+                                      height: 18,
+                                      fontSize: 10,
+                                      backgroundColor: "#422006",
+                                      color: "#f59e0b",
+                                    }}
+                                  />
+                                ) : (
+                                  <Chip
+                                    label="Buy"
+                                    size="small"
+                                    variant="outlined"
+                                    sx={{
+                                      ml: 1,
+                                      height: 18,
+                                      fontSize: 10,
+                                      borderColor: "#334155",
+                                      color: "#64748b",
+                                    }}
+                                  />
+                                )}
+                              </Box>
+                            </TableCell>
+                            <TableCell />
+                            <TableCell />
+                            <TableCell />
+                            <TableCell />
+                            <TableCell />
+                            <TableCell />
+                            <TableCell align="center">
+                              {mat.hasBlueprint && (
+                                <IconButton
+                                  size="small"
+                                  disabled={isToggling}
+                                  onClick={() => handleToggleProduce(group, mat)}
+                                  sx={{
+                                    color:
+                                      mat.produceStatus === "none"
+                                        ? "#10b981"
+                                        : "#ef4444",
+                                  }}
+                                  title={
+                                    mat.produceStatus === "none"
+                                      ? "Switch all to Produce"
+                                      : "Switch all to Buy"
+                                  }
+                                >
+                                  {mat.produceStatus === "none" ? (
+                                    <BuildIcon fontSize="small" />
+                                  ) : (
+                                    <ShoppingCartIcon fontSize="small" />
+                                  )}
+                                </IconButton>
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })
+                  : []),
+              ];
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {editGroup && (
+        <BatchEditStepDialog
+          group={editGroup}
+          open={!!editGroup}
+          onClose={() => setEditGroup(null)}
+          onSave={(updates) => handleSave(editGroup, updates)}
+        />
+      )}
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+      >
+        <Alert severity={snackbar.severity} sx={{ width: "100%" }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}
+
+// --- Batch Edit Step Dialog ---
+
+type OwnerOption = {
+  id: number;
+  name: string;
+  type: "character" | "corporation";
+};
+
+type DivisionOption = {
+  number: number;
+  name: string;
+};
+
+type ContainerOption = {
+  id: number;
+  name: string;
+};
+
+function BatchEditStepDialog({
+  group,
+  open,
+  onClose,
+  onSave,
+}: {
+  group: StepGroup;
+  open: boolean;
+  onClose: () => void;
+  onSave: (updates: Record<string, unknown>) => void;
+}) {
+  const firstStep = group.steps[0];
+
+  const [meLevel, setMeLevel] = useState(
+    group.meLevel === "mixed" ? 10 : group.meLevel,
+  );
+  const [teLevel, setTeLevel] = useState(
+    group.teLevel === "mixed" ? 20 : group.teLevel,
+  );
+  const [industrySkill, setIndustrySkill] = useState(firstStep.industrySkill);
+  const [advIndustrySkill, setAdvIndustrySkill] = useState(firstStep.advIndustrySkill);
+  const [structure, setStructure] = useState(
+    group.structure === "mixed" ? "raitaru" : group.structure,
+  );
+  const [rig, setRig] = useState(
+    group.rig === "mixed" ? "t2" : group.rig,
+  );
+  const [security, setSecurity] = useState(
+    group.security === "mixed" ? "high" : group.security,
+  );
+  const [facilityTax, setFacilityTax] = useState(firstStep.facilityTax);
+  const [stationName, setStationName] = useState(firstStep.stationName || "");
+
+  const [userStations, setUserStations] = useState<UserStation[]>([]);
+  const [selectedUserStation, setSelectedUserStation] = useState<UserStation | null>(null);
+  const [stationsLoaded, setStationsLoaded] = useState(false);
+
+  // Input location state
+  const [hangarsData, setHangarsData] = useState<HangarsResponse | null>(null);
+  const [hangarsLoaded, setHangarsLoaded] = useState(false);
+  const [selectedOwner, setSelectedOwner] = useState<OwnerOption | null>(null);
+  const [selectedDivision, setSelectedDivision] = useState<DivisionOption | null>(null);
+  const [selectedContainer, setSelectedContainer] = useState<ContainerOption | null>(null);
+
+  // Output location state
+  const [selectedOutputOwner, setSelectedOutputOwner] = useState<OwnerOption | null>(null);
+  const [selectedOutputDivision, setSelectedOutputDivision] = useState<DivisionOption | null>(null);
+  const [selectedOutputContainer, setSelectedOutputContainer] = useState<ContainerOption | null>(null);
+
+  useEffect(() => {
+    if (!open || stationsLoaded) return;
+    const fetchStations = async () => {
+      try {
+        const res = await fetch("/api/stations/user-stations");
+        if (res.ok) {
+          const data: UserStation[] = await res.json();
+          setUserStations(data || []);
+          // Pre-select if first step references a station and all steps share the same one
+          if (group.userStationId !== "mixed" && group.userStationId) {
+            const match = (data || []).find((s) => s.id === group.userStationId);
+            if (match) setSelectedUserStation(match);
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch user stations:", err);
+      } finally {
+        setStationsLoaded(true);
+      }
+    };
+    fetchStations();
+  }, [open, stationsLoaded, group]);
+
+  // Fetch hangars when station is selected
+  const stationIdForHangars = selectedUserStation?.id;
+  useEffect(() => {
+    if (!open || !stationIdForHangars) {
+      setHangarsData(null);
+      setHangarsLoaded(false);
+      return;
+    }
+    const fetchHangars = async () => {
+      try {
+        const res = await fetch(
+          `/api/industry/plans/hangars?user_station_id=${stationIdForHangars}`,
+        );
+        if (res.ok) {
+          const data: HangarsResponse = await res.json();
+          setHangarsData(data);
+        }
+      } catch (err) {
+        console.error("Failed to fetch hangars:", err);
+      } finally {
+        setHangarsLoaded(true);
+      }
+    };
+    fetchHangars();
+  }, [open, stationIdForHangars]);
+
+  // Reset loaded state when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setStationsLoaded(false);
+      setSelectedUserStation(null);
+      setHangarsData(null);
+      setHangarsLoaded(false);
+      setSelectedOwner(null);
+      setSelectedDivision(null);
+      setSelectedContainer(null);
+      setSelectedOutputOwner(null);
+      setSelectedOutputDivision(null);
+      setSelectedOutputContainer(null);
+    }
+  }, [open]);
+
+  const handleStationSelect = (station: UserStation | null) => {
+    setSelectedUserStation(station);
+    setSelectedOwner(null);
+    setSelectedDivision(null);
+    setSelectedContainer(null);
+    setSelectedOutputOwner(null);
+    setSelectedOutputDivision(null);
+    setSelectedOutputContainer(null);
+    if (station) {
+      setStructure(station.structure);
+      setFacilityTax(station.facilityTax);
+      setSecurity(station.security || "high");
+      setStationName(station.stationName || "");
+      if (firstStep.rigCategory) {
+        const matchingRig = station.rigs.find(
+          (r) => r.category === firstStep.rigCategory,
+        );
+        setRig(matchingRig ? matchingRig.tier : "none");
+      } else {
+        setRig("none");
+      }
+    }
+  };
+
+  // Build owner options from hangars data
+  const ownerOptions: OwnerOption[] = [];
+  if (hangarsData) {
+    for (const char of hangarsData.characters) {
+      ownerOptions.push({ id: char.id, name: char.name, type: "character" });
+    }
+    for (const corp of hangarsData.corporations) {
+      ownerOptions.push({ id: corp.id, name: corp.name, type: "corporation" });
+    }
+  }
+
+  // Build division options for selected corporation
+  const divisionOptions: DivisionOption[] = [];
+  if (selectedOwner?.type === "corporation" && hangarsData) {
+    const corp = hangarsData.corporations.find((c) => c.id === selectedOwner.id);
+    if (corp) {
+      for (const [num, name] of Object.entries(corp.divisions)) {
+        divisionOptions.push({ number: parseInt(num), name });
+      }
+      divisionOptions.sort((a, b) => a.number - b.number);
+    }
+  }
+
+  // Build container options filtered by selected owner/division
+  const containerOptions: ContainerOption[] = [];
+  if (selectedOwner && hangarsData) {
+    for (const c of hangarsData.containers) {
+      if (c.ownerType !== selectedOwner.type || c.ownerId !== selectedOwner.id) continue;
+      if (selectedOwner.type === "corporation" && selectedDivision) {
+        if (c.divisionNumber !== selectedDivision.number) continue;
+      }
+      containerOptions.push({ id: c.id, name: c.name });
+    }
+  }
+
+  const handleOwnerSelect = (owner: OwnerOption | null) => {
+    setSelectedOwner(owner);
+    setSelectedDivision(null);
+    setSelectedContainer(null);
+  };
+
+  const handleDivisionSelect = (division: DivisionOption | null) => {
+    setSelectedDivision(division);
+    setSelectedContainer(null);
+  };
+
+  // Build output division options
+  const outputDivisionOptions: DivisionOption[] = [];
+  if (selectedOutputOwner?.type === "corporation" && hangarsData) {
+    const corp = hangarsData.corporations.find((c) => c.id === selectedOutputOwner.id);
+    if (corp) {
+      for (const [num, name] of Object.entries(corp.divisions)) {
+        outputDivisionOptions.push({ number: parseInt(num), name });
+      }
+      outputDivisionOptions.sort((a, b) => a.number - b.number);
+    }
+  }
+
+  // Build output container options
+  const outputContainerOptions: ContainerOption[] = [];
+  if (selectedOutputOwner && hangarsData) {
+    for (const c of hangarsData.containers) {
+      if (c.ownerType !== selectedOutputOwner.type || c.ownerId !== selectedOutputOwner.id) continue;
+      if (selectedOutputOwner.type === "corporation" && selectedOutputDivision) {
+        if (c.divisionNumber !== selectedOutputDivision.number) continue;
+      }
+      outputContainerOptions.push({ id: c.id, name: c.name });
+    }
+  }
+
+  const handleOutputOwnerSelect = (owner: OwnerOption | null) => {
+    setSelectedOutputOwner(owner);
+    setSelectedOutputDivision(null);
+    setSelectedOutputContainer(null);
+  };
+
+  const handleOutputDivisionSelect = (division: DivisionOption | null) => {
+    setSelectedOutputDivision(division);
+    setSelectedOutputContainer(null);
+  };
+
+  // Filter stations to show those with matching activity
+  const filteredStations = userStations.filter((s) =>
+    firstStep.activity ? s.activities.includes(firstStep.activity) : true,
+  );
+
+  const hasStation = !!selectedUserStation;
+
+  const resolvedSourceLocationId = selectedUserStation
+    ? selectedUserStation.stationId
+    : null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: { backgroundColor: "#12151f", color: "#e2e8f0" },
+      }}
+    >
+      <DialogTitle>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <img
+            src={`https://images.evetech.net/types/${group.productTypeId}/icon?size=32`}
+            alt=""
+            width={24}
+            height={24}
+            style={{ borderRadius: 2 }}
+          />
+          Batch Edit: {group.productName}
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Alert severity="info" sx={{ mb: 2, mt: 1 }}>
+          Changes will apply to all {group.stepIds.length} {group.productName} ({group.activity}) step(s).
+        </Alert>
+
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {/* Preferred Station Selection */}
+          <Autocomplete
+            value={selectedUserStation}
+            onChange={(_, newValue) => handleStationSelect(newValue)}
+            options={filteredStations}
+            getOptionLabel={(option) =>
+              `${option.stationName || "Unknown"} (${option.solarSystemName || ""})`
+            }
+            isOptionEqualToValue={(option, value) => option.id === value.id}
+            renderOption={(props, option) => (
+              <Box component="li" {...props}>
+                <Box>
+                  <Typography variant="body2">
+                    {option.stationName || "Unknown"}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {option.solarSystemName} &middot; {option.structure} &middot;{" "}
+                    {option.activities.join(", ")}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Preferred Station"
+                placeholder="Select a saved station or leave empty for manual config"
+              />
+            )}
+          />
+
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 2,
+            }}
+          >
+            <TextField
+              type="number"
+              label="ME Level"
+              value={meLevel}
+              onChange={(e) => setMeLevel(parseInt(e.target.value) || 0)}
+              inputProps={{ min: 0, max: 10 }}
+            />
+            <TextField
+              type="number"
+              label="TE Level"
+              value={teLevel}
+              onChange={(e) => setTeLevel(parseInt(e.target.value) || 0)}
+              inputProps={{ min: 0, max: 20 }}
+            />
+            <TextField
+              type="number"
+              label="Industry Skill"
+              value={industrySkill}
+              onChange={(e) => setIndustrySkill(parseInt(e.target.value) || 0)}
+              inputProps={{ min: 0, max: 5 }}
+            />
+            <TextField
+              type="number"
+              label="Adv. Industry Skill"
+              value={advIndustrySkill}
+              onChange={(e) =>
+                setAdvIndustrySkill(parseInt(e.target.value) || 0)
+              }
+              inputProps={{ min: 0, max: 5 }}
+            />
+            <FormControl fullWidth disabled={hasStation}>
+              <InputLabel>Structure</InputLabel>
+              <Select
+                value={structure}
+                label="Structure"
+                onChange={(e) => setStructure(e.target.value)}
+              >
+                <MenuItem value="station">Station</MenuItem>
+                <MenuItem value="raitaru">Raitaru</MenuItem>
+                <MenuItem value="azbel">Azbel</MenuItem>
+                <MenuItem value="sotiyo">Sotiyo</MenuItem>
+                <MenuItem value="athanor">Athanor</MenuItem>
+                <MenuItem value="tatara">Tatara</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl fullWidth disabled={hasStation}>
+              <InputLabel>Rig</InputLabel>
+              <Select
+                value={rig}
+                label="Rig"
+                onChange={(e) => setRig(e.target.value)}
+              >
+                <MenuItem value="none">None</MenuItem>
+                <MenuItem value="t1">T1</MenuItem>
+                <MenuItem value="t2">T2</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl fullWidth disabled={hasStation}>
+              <InputLabel>Security</InputLabel>
+              <Select
+                value={security}
+                label="Security"
+                onChange={(e) => setSecurity(e.target.value)}
+              >
+                <MenuItem value="high">Highsec</MenuItem>
+                <MenuItem value="low">Lowsec</MenuItem>
+                <MenuItem value="null">Nullsec / WH</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              type="number"
+              label="Facility Tax %"
+              value={facilityTax}
+              onChange={(e) => setFacilityTax(parseFloat(e.target.value) || 0)}
+              inputProps={{ min: 0, step: 0.1 }}
+              disabled={hasStation}
+            />
+            <TextField
+              label="Station Name"
+              value={stationName}
+              onChange={(e) => setStationName(e.target.value)}
+              placeholder="e.g. Jita 4-4 or player structure name"
+              sx={{ gridColumn: "1 / -1" }}
+              disabled={hasStation}
+            />
+          </Box>
+
+          {/* Input Location Section */}
+          {hasStation && (
+            <>
+              <Divider sx={{ borderColor: "#1e293b", mt: 1 }} />
+              <Typography sx={{ color: "#94a3b8", fontSize: 14, fontWeight: 600 }}>
+                Input Location
+              </Typography>
+              <Typography sx={{ color: "#64748b", fontSize: 12 }}>
+                Where should materials for these steps be pulled from?
+              </Typography>
+
+              {!hangarsLoaded ? (
+                <Typography sx={{ color: "#64748b", fontSize: 13 }}>
+                  Loading hangars...
+                </Typography>
+              ) : (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                  <Autocomplete
+                    value={selectedOwner}
+                    onChange={(_, newValue) => handleOwnerSelect(newValue)}
+                    options={ownerOptions}
+                    getOptionLabel={(option) =>
+                      `${option.name} (${option.type === "character" ? "Character" : "Corporation"})`
+                    }
+                    isOptionEqualToValue={(option, value) =>
+                      option.id === value.id && option.type === value.type
+                    }
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label="Owner"
+                        placeholder="Select character or corporation"
+                        size="small"
+                      />
+                    )}
+                  />
+
+                  {selectedOwner?.type === "corporation" && divisionOptions.length > 0 && (
+                    <Autocomplete
+                      value={selectedDivision}
+                      onChange={(_, newValue) => handleDivisionSelect(newValue)}
+                      options={divisionOptions}
+                      getOptionLabel={(option) => `${option.number}. ${option.name}`}
+                      isOptionEqualToValue={(option, value) =>
+                        option.number === value.number
+                      }
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="Hangar Division"
+                          placeholder="Select division"
+                          size="small"
+                        />
+                      )}
+                    />
+                  )}
+
+                  {selectedOwner && (
+                    <Autocomplete
+                      value={selectedContainer}
+                      onChange={(_, newValue) => setSelectedContainer(newValue)}
+                      options={containerOptions}
+                      getOptionLabel={(option) => option.name}
+                      isOptionEqualToValue={(option, value) =>
+                        option.id === value.id
+                      }
+                      noOptionsText="No containers at this station"
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="Container (optional)"
+                          placeholder="Select container or leave empty for hangar"
+                          size="small"
+                        />
+                      )}
+                    />
+                  )}
+                </Box>
+              )}
+
+              <Divider sx={{ borderColor: "#1e293b", mt: 1 }} />
+              <Typography sx={{ color: "#94a3b8", fontSize: 14, fontWeight: 600 }}>
+                Output Location
+              </Typography>
+              <Typography sx={{ color: "#64748b", fontSize: 12 }}>
+                Where should completed items from these jobs be delivered?
+              </Typography>
+
+              {!hangarsLoaded ? (
+                <Typography sx={{ color: "#64748b", fontSize: 13 }}>
+                  Loading hangars...
+                </Typography>
+              ) : (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                  <Autocomplete
+                    value={selectedOutputOwner}
+                    onChange={(_, newValue) => handleOutputOwnerSelect(newValue)}
+                    options={ownerOptions}
+                    getOptionLabel={(option) =>
+                      `${option.name} (${option.type === "character" ? "Character" : "Corporation"})`
+                    }
+                    isOptionEqualToValue={(option, value) =>
+                      option.id === value.id && option.type === value.type
+                    }
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label="Owner"
+                        placeholder="Select character or corporation"
+                        size="small"
+                      />
+                    )}
+                  />
+
+                  {selectedOutputOwner?.type === "corporation" && outputDivisionOptions.length > 0 && (
+                    <Autocomplete
+                      value={selectedOutputDivision}
+                      onChange={(_, newValue) => handleOutputDivisionSelect(newValue)}
+                      options={outputDivisionOptions}
+                      getOptionLabel={(option) => `${option.number}. ${option.name}`}
+                      isOptionEqualToValue={(option, value) =>
+                        option.number === value.number
+                      }
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="Hangar Division"
+                          placeholder="Select division"
+                          size="small"
+                        />
+                      )}
+                    />
+                  )}
+
+                  {selectedOutputOwner && (
+                    <Autocomplete
+                      value={selectedOutputContainer}
+                      onChange={(_, newValue) => setSelectedOutputContainer(newValue)}
+                      options={outputContainerOptions}
+                      getOptionLabel={(option) => option.name}
+                      isOptionEqualToValue={(option, value) =>
+                        option.id === value.id
+                      }
+                      noOptionsText="No containers at this station"
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="Container (optional)"
+                          placeholder="Select container or leave empty for hangar"
+                          size="small"
+                        />
+                      )}
+                    />
+                  )}
+                </Box>
+              )}
+            </>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} sx={{ color: "#94a3b8" }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() =>
+            onSave({
+              me_level: meLevel,
+              te_level: teLevel,
+              industry_skill: industrySkill,
+              adv_industry_skill: advIndustrySkill,
+              structure,
+              rig,
+              security,
+              facility_tax: facilityTax,
+              station_name: stationName || null,
+              user_station_id: selectedUserStation?.id || null,
+              source_owner_type: selectedOwner?.type || null,
+              source_owner_id: selectedOwner?.id || null,
+              source_division_number:
+                selectedOwner?.type === "corporation"
+                  ? selectedDivision?.number ?? null
+                  : null,
+              source_container_id: selectedContainer?.id || null,
+              source_location_id: resolvedSourceLocationId,
+              output_owner_type: selectedOutputOwner?.type || null,
+              output_owner_id: selectedOutputOwner?.id || null,
+              output_division_number:
+                selectedOutputOwner?.type === "corporation"
+                  ? selectedOutputDivision?.number ?? null
+                  : null,
+              output_container_id: selectedOutputContainer?.id || null,
+            })
+          }
+          variant="contained"
+          sx={{
+            backgroundColor: "#3b82f6",
+            "&:hover": { backgroundColor: "#2563eb" },
+          }}
+        >
+          Save ({group.stepIds.length} steps)
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/packages/components/industry/ProductionPlanEditor.tsx
+++ b/frontend/packages/components/industry/ProductionPlanEditor.tsx
@@ -1,0 +1,1513 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  ProductionPlan,
+  ProductionPlanStep,
+  PlanMaterial,
+  GenerateJobsResult,
+  UserStation,
+  HangarsResponse,
+} from "@industry-tool/client/data/models";
+import { formatISK } from "@industry-tool/utils/formatting";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import IconButton from "@mui/material/IconButton";
+import Chip from "@mui/material/Chip";
+import TextField from "@mui/material/TextField";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Autocomplete from "@mui/material/Autocomplete";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import Snackbar from "@mui/material/Snackbar";
+import Alert from "@mui/material/Alert";
+import Divider from "@mui/material/Divider";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import BuildIcon from "@mui/icons-material/Build";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
+import Tooltip from "@mui/material/Tooltip";
+import BatchConfigureTab from "./BatchConfigureTab";
+
+type Props = {
+  planId: number;
+};
+
+type StepMaterials = {
+  [stepId: number]: PlanMaterial[];
+};
+
+export default function ProductionPlanEditor({ planId }: Props) {
+  const [plan, setPlan] = useState<ProductionPlan | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set());
+  const [stepMaterials, setStepMaterials] = useState<StepMaterials>({});
+  const [loadingMaterials, setLoadingMaterials] = useState<Set<number>>(
+    new Set(),
+  );
+  const [editStepId, setEditStepId] = useState<number | null>(null);
+  const [generateDialogOpen, setGenerateDialogOpen] = useState(false);
+  const [generateQuantity, setGenerateQuantity] = useState(1);
+  const [generating, setGenerating] = useState(false);
+  const [generateResult, setGenerateResult] =
+    useState<GenerateJobsResult | null>(null);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: "success" | "error";
+  }>({ open: false, message: "", severity: "success" });
+  const [editingName, setEditingName] = useState(false);
+  const [nameValue, setNameValue] = useState("");
+  const [tab, setTab] = useState(0);
+
+  const initialLoadRef = useRef(true);
+
+  const fetchPlan = useCallback(async () => {
+    if (initialLoadRef.current) {
+      setLoading(true);
+    }
+    try {
+      const res = await fetch(`/api/industry/plans/${planId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setPlan(data);
+        // Only auto-expand root step on initial load
+        if (initialLoadRef.current && data.steps?.length > 0) {
+          initialLoadRef.current = false;
+          const rootStep = data.steps.find(
+            (s: ProductionPlanStep) => !s.parentStepId,
+          );
+          if (rootStep) {
+            setExpandedSteps(new Set([rootStep.id]));
+            fetchMaterials(rootStep.id);
+          }
+        }
+      }
+    } catch (err) {
+      console.error("Failed to fetch plan:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [planId]);
+
+  useEffect(() => {
+    fetchPlan();
+  }, [fetchPlan]);
+
+  const fetchMaterials = async (stepId: number) => {
+    setLoadingMaterials((prev) => new Set([...prev, stepId]));
+    try {
+      const res = await fetch(
+        `/api/industry/plans/${planId}/steps/${stepId}/materials`,
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setStepMaterials((prev) => ({ ...prev, [stepId]: data || [] }));
+      }
+    } catch (err) {
+      console.error("Failed to fetch materials:", err);
+    } finally {
+      setLoadingMaterials((prev) => {
+        const next = new Set(prev);
+        next.delete(stepId);
+        return next;
+      });
+    }
+  };
+
+  const toggleExpand = (stepId: number) => {
+    setExpandedSteps((prev) => {
+      const next = new Set(prev);
+      if (next.has(stepId)) {
+        next.delete(stepId);
+      } else {
+        next.add(stepId);
+        if (!stepMaterials[stepId]) {
+          fetchMaterials(stepId);
+        }
+      }
+      return next;
+    });
+  };
+
+  const handleToggleProduce = async (
+    parentStepId: number,
+    material: PlanMaterial,
+  ) => {
+    if (material.isProduced) {
+      // Find the child step and delete it
+      const childStep = plan?.steps?.find(
+        (s) =>
+          s.parentStepId === parentStepId &&
+          s.productTypeId === material.typeId,
+      );
+      if (childStep) {
+        try {
+          await fetch(
+            `/api/industry/plans/${planId}/steps/${childStep.id}`,
+            { method: "DELETE" },
+          );
+          await fetchPlan();
+          // Refresh materials for parent
+          fetchMaterials(parentStepId);
+        } catch (err) {
+          console.error("Failed to remove step:", err);
+        }
+      }
+    } else {
+      // Create a new step for this material
+      try {
+        const res = await fetch(`/api/industry/plans/${planId}/steps`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            parent_step_id: parentStepId,
+            product_type_id: material.typeId,
+          }),
+        });
+        if (res.ok) {
+          const newStep = await res.json();
+          await fetchPlan();
+          fetchMaterials(parentStepId);
+          // Auto-expand the new child step and load its materials
+          if (newStep?.id) {
+            setExpandedSteps((prev) => new Set([...prev, newStep.id]));
+            fetchMaterials(newStep.id);
+          }
+        }
+      } catch (err) {
+        console.error("Failed to create step:", err);
+      }
+    }
+  };
+
+  const handleUpdateStep = async (
+    stepId: number,
+    updates: Partial<ProductionPlanStep>,
+  ) => {
+    try {
+      const res = await fetch(
+        `/api/industry/plans/${planId}/steps/${stepId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(updates),
+        },
+      );
+      if (res.ok) {
+        setEditStepId(null);
+        fetchPlan();
+        setSnackbar({
+          open: true,
+          message: "Step updated",
+          severity: "success",
+        });
+      }
+    } catch (err) {
+      console.error("Failed to update step:", err);
+    }
+  };
+
+  const handleGenerate = async () => {
+    setGenerating(true);
+    try {
+      const res = await fetch(`/api/industry/plans/${planId}/generate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ quantity: generateQuantity }),
+      });
+      if (res.ok) {
+        const result: GenerateJobsResult = await res.json();
+        setGenerateResult(result);
+        setSnackbar({
+          open: true,
+          message: `Created ${result.created.length} job(s), skipped ${result.skipped.length}`,
+          severity: "success",
+        });
+      }
+    } catch (err) {
+      console.error("Failed to generate jobs:", err);
+      setSnackbar({
+        open: true,
+        message: "Failed to generate jobs",
+        severity: "error",
+      });
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleSaveName = async () => {
+    const trimmed = nameValue.trim();
+    if (!trimmed || trimmed === plan?.name) {
+      setEditingName(false);
+      return;
+    }
+    try {
+      const res = await fetch(`/api/industry/plans/${planId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: trimmed }),
+      });
+      if (res.ok) {
+        setEditingName(false);
+        fetchPlan();
+      }
+    } catch (err) {
+      console.error("Failed to update plan name:", err);
+    }
+  };
+
+  if (loading || !plan) {
+    return (
+      <Box sx={{ textAlign: "center", py: 4 }}>
+        <Typography sx={{ color: "#64748b" }}>Loading plan...</Typography>
+      </Box>
+    );
+  }
+
+  // Build step tree structure
+  const stepMap = new Map<number, ProductionPlanStep>();
+  const childrenMap = new Map<number, ProductionPlanStep[]>();
+  let rootStep: ProductionPlanStep | null = null;
+
+  for (const step of plan.steps || []) {
+    stepMap.set(step.id, step);
+    if (!step.parentStepId) {
+      rootStep = step;
+    } else {
+      const children = childrenMap.get(step.parentStepId) || [];
+      children.push(step);
+      childrenMap.set(step.parentStepId, children);
+    }
+  }
+
+  const depthColors = ["#3b82f6", "#10b981", "#f59e0b", "#a78bfa", "#ec4899", "#06b6d4"];
+
+  const renderDepthIndicators = (colorPath: number[]) =>
+    colorPath.map((colorIndex, i) => (
+      <Box
+        key={`depth-bar-${i}`}
+        sx={{
+          position: "absolute",
+          left: `${i * 32 + 8}px`,
+          top: 0,
+          bottom: 0,
+          width: 3,
+          backgroundColor: depthColors[colorIndex % depthColors.length],
+        }}
+      />
+    ));
+
+  const renderStepRow = (step: ProductionPlanStep, depth: number, colorPath: number[], parentStep?: ProductionPlanStep) => {
+    const isExpanded = expandedSteps.has(step.id);
+    const materials = stepMaterials[step.id] || [];
+    const isLoadingMats = loadingMaterials.has(step.id);
+    const children = childrenMap.get(step.id) || [];
+
+    const rows: React.ReactNode[] = [];
+
+    // Step header row
+    rows.push(
+      <TableRow
+        key={`step-${step.id}`}
+        sx={{
+          backgroundColor: depth === 0 ? "#1a1d2e" : "#12151f",
+          "&:hover": { backgroundColor: "#1e2235" },
+        }}
+      >
+        <TableCell sx={{ position: "relative", pl: 0 }}>
+          {renderDepthIndicators(colorPath)}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, pl: `${depth * 32 + 20}px` }}>
+            <IconButton
+              size="small"
+              onClick={() => toggleExpand(step.id)}
+              sx={{ color: "#94a3b8" }}
+            >
+              {isExpanded ? (
+                <ExpandMoreIcon fontSize="small" />
+              ) : (
+                <ChevronRightIcon fontSize="small" />
+              )}
+            </IconButton>
+            <img
+              src={`https://images.evetech.net/types/${step.productTypeId}/icon?size=32`}
+              alt=""
+              width={20}
+              height={20}
+              style={{ borderRadius: 2 }}
+            />
+            <Typography sx={{ color: "#e2e8f0", fontSize: 14, fontWeight: depth === 0 ? 600 : 400 }}>
+              {step.productName || `Type ${step.productTypeId}`}
+            </Typography>
+            <Chip
+              label={step.activity}
+              size="small"
+              sx={{
+                ml: 1,
+                height: 20,
+                fontSize: 11,
+                backgroundColor:
+                  step.activity === "manufacturing" ? "#1e3a5f" : "#3a1e5f",
+                color:
+                  step.activity === "manufacturing" ? "#60a5fa" : "#a78bfa",
+              }}
+            />
+          </Box>
+        </TableCell>
+        <TableCell sx={{ color: "#94a3b8", fontSize: 13 }}>
+          ME {step.meLevel} / TE {step.teLevel}
+        </TableCell>
+        <TableCell sx={{ color: "#94a3b8", fontSize: 13 }}>
+          {step.structure} / {step.rig} / {step.security}
+        </TableCell>
+        <TableCell sx={{ color: "#94a3b8", fontSize: 13 }}>
+          {step.stationName || "—"}
+          {step.sourceOwnerName && (
+            <Typography sx={{ color: "#64748b", fontSize: 11 }}>
+              In: {step.sourceOwnerName}
+              {step.sourceDivisionName ? ` / ${step.sourceDivisionName}` : ""}
+              {step.sourceContainerName ? ` / ${step.sourceContainerName}` : ""}
+            </Typography>
+          )}
+          {step.outputOwnerName ? (
+            <Typography sx={{ color: "#64748b", fontSize: 11 }}>
+              Out: {step.outputOwnerName}
+              {step.outputDivisionName ? ` / ${step.outputDivisionName}` : ""}
+              {step.outputContainerName ? ` / ${step.outputContainerName}` : ""}
+            </Typography>
+          ) : !step.parentStepId ? (
+            <Typography sx={{ color: "#475569", fontSize: 11, fontStyle: "italic" }}>
+              Out: set at build time
+            </Typography>
+          ) : null}
+          {step.parentStepId && parentStep &&
+           step.userStationId && parentStep.userStationId &&
+           step.userStationId !== parentStep.userStationId && (
+            <Tooltip title="Items must be moved between stations">
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.25 }}>
+                <SwapHorizIcon sx={{ fontSize: 14, color: "#f59e0b" }} />
+                <Typography sx={{ color: "#f59e0b", fontSize: 11 }}>Transfer</Typography>
+              </Box>
+            </Tooltip>
+          )}
+        </TableCell>
+        <TableCell align="center">
+          <IconButton
+            size="small"
+            onClick={() => setEditStepId(step.id)}
+            sx={{ color: "#3b82f6" }}
+          >
+            <EditIcon fontSize="small" />
+          </IconButton>
+          {depth > 0 && (
+            <IconButton
+              size="small"
+              onClick={async () => {
+                await fetch(
+                  `/api/industry/plans/${planId}/steps/${step.id}`,
+                  { method: "DELETE" },
+                );
+                fetchPlan();
+                if (step.parentStepId) fetchMaterials(step.parentStepId);
+              }}
+              sx={{ color: "#ef4444" }}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          )}
+        </TableCell>
+      </TableRow>,
+    );
+
+    // Material rows (when expanded)
+    if (isExpanded) {
+      if (isLoadingMats) {
+        rows.push(
+          <TableRow key={`loading-${step.id}`}>
+            <TableCell
+              colSpan={5}
+              sx={{ position: "relative", pl: 0, color: "#64748b", fontSize: 13 }}
+            >
+              {renderDepthIndicators(colorPath)}
+              <Box sx={{ pl: `${(depth + 1) * 32 + 20}px` }}>Loading materials...</Box>
+            </TableCell>
+          </TableRow>,
+        );
+      } else {
+        const sortedMaterials = [...materials].sort((a, b) => {
+          if (a.isProduced !== b.isProduced) return a.isProduced ? -1 : 1;
+          if (a.hasBlueprint !== b.hasBlueprint) return a.hasBlueprint ? -1 : 1;
+          return 0;
+        });
+        let childIndex = 0;
+        for (const mat of sortedMaterials) {
+          // Check if this material has a child step (is produced)
+          const childStep = children.find(
+            (c) => c.productTypeId === mat.typeId,
+          );
+
+          if (childStep) {
+            // Render the child step recursively
+            rows.push(...renderStepRow(childStep, depth + 1, [...colorPath, childIndex], step));
+            childIndex++;
+          } else {
+            // Render as a buy material
+            rows.push(
+              <TableRow
+                key={`mat-${step.id}-${mat.typeId}`}
+                sx={{
+                  backgroundColor: "#0f1219",
+                  "&:hover": { backgroundColor: "#151825" },
+                }}
+              >
+                <TableCell sx={{ position: "relative", pl: 0 }}>
+                  {renderDepthIndicators(colorPath)}
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 0.5,
+                      pl: `${(depth + 1) * 32 + 20}px`,
+                    }}
+                  >
+                    <img
+                      src={`https://images.evetech.net/types/${mat.typeId}/icon?size=32`}
+                      alt=""
+                      width={18}
+                      height={18}
+                      style={{ borderRadius: 2 }}
+                    />
+                    <Typography
+                      sx={{ color: "#cbd5e1", fontSize: 13 }}
+                    >
+                      {mat.typeName}
+                    </Typography>
+                    <Typography
+                      sx={{ color: "#64748b", fontSize: 12, ml: 1 }}
+                    >
+                      x{mat.quantity}
+                    </Typography>
+                    {mat.isProduced ? (
+                      <Chip
+                        label="Produce"
+                        size="small"
+                        sx={{
+                          ml: 1,
+                          height: 18,
+                          fontSize: 10,
+                          backgroundColor: "#1e3a5f",
+                          color: "#60a5fa",
+                        }}
+                      />
+                    ) : (
+                      <Chip
+                        label="Buy"
+                        size="small"
+                        variant="outlined"
+                        sx={{
+                          ml: 1,
+                          height: 18,
+                          fontSize: 10,
+                          borderColor: "#334155",
+                          color: "#64748b",
+                        }}
+                      />
+                    )}
+                  </Box>
+                </TableCell>
+                <TableCell />
+                <TableCell />
+                <TableCell />
+                <TableCell align="center">
+                  {mat.hasBlueprint && (
+                    <IconButton
+                      size="small"
+                      onClick={() => handleToggleProduce(step.id, mat)}
+                      sx={{
+                        color: mat.isProduced ? "#ef4444" : "#10b981",
+                      }}
+                      title={
+                        mat.isProduced
+                          ? "Switch to Buy"
+                          : "Switch to Produce"
+                      }
+                    >
+                      {mat.isProduced ? (
+                        <ShoppingCartIcon fontSize="small" />
+                      ) : (
+                        <BuildIcon fontSize="small" />
+                      )}
+                    </IconButton>
+                  )}
+                </TableCell>
+              </TableRow>,
+            );
+          }
+        }
+      }
+    }
+
+    return rows;
+  };
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 2,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <img
+            src={`https://images.evetech.net/types/${plan.productTypeId}/icon?size=64`}
+            alt=""
+            width={40}
+            height={40}
+            style={{ borderRadius: 4 }}
+          />
+          <Box>
+            {editingName ? (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <TextField
+                  size="small"
+                  value={nameValue}
+                  onChange={(e) => setNameValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSaveName();
+                    if (e.key === "Escape") setEditingName(false);
+                  }}
+                  autoFocus
+                  sx={{ minWidth: 250 }}
+                />
+                <IconButton size="small" onClick={handleSaveName} sx={{ color: "#10b981" }}>
+                  <CheckIcon fontSize="small" />
+                </IconButton>
+                <IconButton size="small" onClick={() => setEditingName(false)} sx={{ color: "#94a3b8" }}>
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            ) : (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <Typography
+                  variant="h5"
+                  sx={{ color: "#e2e8f0", fontWeight: 600 }}
+                >
+                  {plan.name}
+                </Typography>
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    setNameValue(plan.name);
+                    setEditingName(true);
+                  }}
+                  sx={{ color: "#64748b", "&:hover": { color: "#3b82f6" } }}
+                >
+                  <EditIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            )}
+            <Typography sx={{ color: "#64748b", fontSize: 13 }}>
+              {plan.steps?.length || 0} production step(s)
+            </Typography>
+          </Box>
+        </Box>
+        <Button
+          variant="contained"
+          startIcon={<PlayArrowIcon />}
+          onClick={() => setGenerateDialogOpen(true)}
+          sx={{
+            backgroundColor: "#10b981",
+            "&:hover": { backgroundColor: "#059669" },
+          }}
+        >
+          Generate Jobs
+        </Button>
+      </Box>
+
+      <Box sx={{ borderBottom: 1, borderColor: "rgba(148, 163, 184, 0.15)", mb: 2 }}>
+        <Tabs
+          value={tab}
+          onChange={(_, newValue) => setTab(newValue)}
+          sx={{
+            "& .MuiTab-root": { color: "#64748b", textTransform: "none", fontWeight: 500 },
+            "& .Mui-selected": { color: "#3b82f6" },
+            "& .MuiTabs-indicator": { backgroundColor: "#3b82f6" },
+          }}
+        >
+          <Tab label="Step Tree" />
+          <Tab label="Batch Configure" />
+        </Tabs>
+      </Box>
+
+      {tab === 0 && (
+        <TableContainer component={Paper} sx={{ backgroundColor: "#12151f" }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow sx={{ backgroundColor: "#0f1219" }}>
+                <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                  Item / Material
+                </TableCell>
+                <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                  ME / TE
+                </TableCell>
+                <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                  Structure / Rig / Sec
+                </TableCell>
+                <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                  Station
+                </TableCell>
+                <TableCell
+                  sx={{ color: "#94a3b8", fontWeight: 600 }}
+                  align="center"
+                >
+                  Actions
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rootStep ? (
+                renderStepRow(rootStep, 0, [0])
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={5} sx={{ textAlign: "center" }}>
+                    <Typography sx={{ color: "#64748b" }}>
+                      No steps in this plan
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {tab === 1 && (
+        <BatchConfigureTab plan={plan} planId={planId} onUpdate={fetchPlan} />
+      )}
+
+      {/* Edit Step Dialog */}
+      {editStepId && (
+        <EditStepDialog
+          step={
+            plan.steps?.find((s) => s.id === editStepId) || null
+          }
+          open={!!editStepId}
+          onClose={() => setEditStepId(null)}
+          onSave={(updates) => handleUpdateStep(editStepId, updates)}
+        />
+      )}
+
+      {/* Generate Jobs Dialog */}
+      <Dialog
+        open={generateDialogOpen}
+        onClose={() => {
+          setGenerateDialogOpen(false);
+          setGenerateResult(null);
+        }}
+        maxWidth="sm"
+        fullWidth
+        PaperProps={{
+          sx: { backgroundColor: "#12151f", color: "#e2e8f0" },
+        }}
+      >
+        <DialogTitle>Generate Production Jobs</DialogTitle>
+        <DialogContent>
+          {generateResult ? (
+            <Box>
+              <Typography sx={{ color: "#10b981", mb: 1 }}>
+                Created {generateResult.created.length} job(s)
+              </Typography>
+              {generateResult.created.map((job) => (
+                <Typography
+                  key={job.id}
+                  sx={{ color: "#cbd5e1", fontSize: 13, ml: 2 }}
+                >
+                  {job.blueprintName || `BP ${job.blueprintTypeId}`} &mdash;{" "}
+                  {job.runs} runs
+                  {job.estimatedCost
+                    ? ` (${formatISK(job.estimatedCost)})`
+                    : ""}
+                </Typography>
+              ))}
+              {generateResult.skipped.length > 0 && (
+                <>
+                  <Typography sx={{ color: "#f59e0b", mt: 2, mb: 1 }}>
+                    Skipped {generateResult.skipped.length} item(s)
+                  </Typography>
+                  {generateResult.skipped.map((skip, i) => (
+                    <Typography
+                      key={i}
+                      sx={{ color: "#94a3b8", fontSize: 13, ml: 2 }}
+                    >
+                      {skip.typeName} &mdash; {skip.reason}
+                    </Typography>
+                  ))}
+                </>
+              )}
+            </Box>
+          ) : (
+            <Box sx={{ mt: 1 }}>
+              <Typography sx={{ color: "#94a3b8", mb: 2 }}>
+                How many {plan.productName || "units"} do you want to produce?
+                Job queue entries will be created for each step in the
+                production chain.
+              </Typography>
+              <TextField
+                type="number"
+                label="Quantity"
+                value={generateQuantity}
+                onChange={(e) =>
+                  setGenerateQuantity(Math.max(1, parseInt(e.target.value) || 1))
+                }
+                fullWidth
+                inputProps={{ min: 1 }}
+              />
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          {generateResult ? (
+            <Button
+              onClick={() => {
+                setGenerateDialogOpen(false);
+                setGenerateResult(null);
+              }}
+              variant="contained"
+              sx={{
+                backgroundColor: "#3b82f6",
+                "&:hover": { backgroundColor: "#2563eb" },
+              }}
+            >
+              Done
+            </Button>
+          ) : (
+            <>
+              <Button
+                onClick={() => setGenerateDialogOpen(false)}
+                sx={{ color: "#94a3b8" }}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleGenerate}
+                disabled={generating}
+                variant="contained"
+                sx={{
+                  backgroundColor: "#10b981",
+                  "&:hover": { backgroundColor: "#059669" },
+                }}
+              >
+                {generating ? "Generating..." : "Generate"}
+              </Button>
+            </>
+          )}
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+      >
+        <Alert severity={snackbar.severity} sx={{ width: "100%" }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}
+
+// --- Edit Step Dialog ---
+
+type OwnerOption = {
+  id: number;
+  name: string;
+  type: "character" | "corporation";
+};
+
+type DivisionOption = {
+  number: number;
+  name: string;
+};
+
+type ContainerOption = {
+  id: number;
+  name: string;
+};
+
+function EditStepDialog({
+  step,
+  open,
+  onClose,
+  onSave,
+}: {
+  step: ProductionPlanStep | null;
+  open: boolean;
+  onClose: () => void;
+  onSave: (updates: Partial<ProductionPlanStep>) => void;
+}) {
+  const [meLevel, setMeLevel] = useState(step?.meLevel || 10);
+  const [teLevel, setTeLevel] = useState(step?.teLevel || 20);
+  const [industrySkill, setIndustrySkill] = useState(
+    step?.industrySkill || 5,
+  );
+  const [advIndustrySkill, setAdvIndustrySkill] = useState(
+    step?.advIndustrySkill || 5,
+  );
+  const [structure, setStructure] = useState(step?.structure || "raitaru");
+  const [rig, setRig] = useState(step?.rig || "t2");
+  const [security, setSecurity] = useState(step?.security || "high");
+  const [facilityTax, setFacilityTax] = useState(step?.facilityTax || 1.0);
+  const [stationName, setStationName] = useState(step?.stationName || "");
+
+  const [userStations, setUserStations] = useState<UserStation[]>([]);
+  const [selectedUserStation, setSelectedUserStation] = useState<UserStation | null>(null);
+  const [stationsLoaded, setStationsLoaded] = useState(false);
+
+  // Input location state
+  const [hangarsData, setHangarsData] = useState<HangarsResponse | null>(null);
+  const [hangarsLoaded, setHangarsLoaded] = useState(false);
+  const [selectedOwner, setSelectedOwner] = useState<OwnerOption | null>(null);
+  const [selectedDivision, setSelectedDivision] = useState<DivisionOption | null>(null);
+  const [selectedContainer, setSelectedContainer] = useState<ContainerOption | null>(null);
+
+  // Output location state
+  const [selectedOutputOwner, setSelectedOutputOwner] = useState<OwnerOption | null>(null);
+  const [selectedOutputDivision, setSelectedOutputDivision] = useState<DivisionOption | null>(null);
+  const [selectedOutputContainer, setSelectedOutputContainer] = useState<ContainerOption | null>(null);
+
+  useEffect(() => {
+    if (step) {
+      setMeLevel(step.meLevel);
+      setTeLevel(step.teLevel);
+      setIndustrySkill(step.industrySkill);
+      setAdvIndustrySkill(step.advIndustrySkill);
+      setStructure(step.structure);
+      setRig(step.rig);
+      setSecurity(step.security);
+      setFacilityTax(step.facilityTax);
+      setStationName(step.stationName || "");
+    }
+  }, [step]);
+
+  useEffect(() => {
+    if (!open || stationsLoaded) return;
+    const fetchStations = async () => {
+      try {
+        const res = await fetch("/api/stations/user-stations");
+        if (res.ok) {
+          const data: UserStation[] = await res.json();
+          setUserStations(data || []);
+          // Pre-select if step already references a station
+          if (step?.userStationId) {
+            const match = (data || []).find((s) => s.id === step.userStationId);
+            if (match) setSelectedUserStation(match);
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch user stations:", err);
+      } finally {
+        setStationsLoaded(true);
+      }
+    };
+    fetchStations();
+  }, [open, stationsLoaded, step]);
+
+  // Fetch hangars when station is selected
+  const stationIdForHangars = selectedUserStation?.id;
+  useEffect(() => {
+    if (!open || !stationIdForHangars) {
+      setHangarsData(null);
+      setHangarsLoaded(false);
+      return;
+    }
+    const fetchHangars = async () => {
+      try {
+        const res = await fetch(
+          `/api/industry/plans/hangars?user_station_id=${stationIdForHangars}`,
+        );
+        if (res.ok) {
+          const data: HangarsResponse = await res.json();
+          setHangarsData(data);
+
+          // Pre-populate from step's existing source fields
+          if (step?.sourceOwnerType && step?.sourceOwnerId) {
+            const ownerMatch = step.sourceOwnerType === "character"
+              ? data.characters.find((c) => c.id === step.sourceOwnerId)
+              : data.corporations.find((c) => c.id === step.sourceOwnerId);
+            if (ownerMatch) {
+              setSelectedOwner({
+                id: ownerMatch.id,
+                name: ownerMatch.name,
+                type: step.sourceOwnerType as "character" | "corporation",
+              });
+
+              // Pre-populate division for corporation
+              if (step.sourceOwnerType === "corporation" && step.sourceDivisionNumber != null) {
+                const corp = data.corporations.find((c) => c.id === step.sourceOwnerId);
+                if (corp) {
+                  const divName = corp.divisions[String(step.sourceDivisionNumber)] || `Division ${step.sourceDivisionNumber}`;
+                  setSelectedDivision({ number: step.sourceDivisionNumber, name: divName });
+                }
+              }
+
+              // Pre-populate container
+              if (step.sourceContainerId) {
+                const container = data.containers.find((c) => c.id === step.sourceContainerId);
+                if (container) {
+                  setSelectedContainer({ id: container.id, name: container.name });
+                }
+              }
+            }
+          }
+
+          // Pre-populate output location
+          if (step?.outputOwnerType && step?.outputOwnerId) {
+            const outOwnerMatch = step.outputOwnerType === "character"
+              ? data.characters.find((c) => c.id === step.outputOwnerId)
+              : data.corporations.find((c) => c.id === step.outputOwnerId);
+            if (outOwnerMatch) {
+              setSelectedOutputOwner({
+                id: outOwnerMatch.id,
+                name: outOwnerMatch.name,
+                type: step.outputOwnerType as "character" | "corporation",
+              });
+
+              if (step.outputOwnerType === "corporation" && step.outputDivisionNumber != null) {
+                const corp = data.corporations.find((c) => c.id === step.outputOwnerId);
+                if (corp) {
+                  const divName = corp.divisions[String(step.outputDivisionNumber)] || `Division ${step.outputDivisionNumber}`;
+                  setSelectedOutputDivision({ number: step.outputDivisionNumber, name: divName });
+                }
+              }
+
+              if (step.outputContainerId) {
+                const container = data.containers.find((c) => c.id === step.outputContainerId);
+                if (container) {
+                  setSelectedOutputContainer({ id: container.id, name: container.name });
+                }
+              }
+            }
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch hangars:", err);
+      } finally {
+        setHangarsLoaded(true);
+      }
+    };
+    fetchHangars();
+  }, [open, stationIdForHangars, step]);
+
+  // Reset loaded state when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setStationsLoaded(false);
+      setSelectedUserStation(null);
+      setHangarsData(null);
+      setHangarsLoaded(false);
+      setSelectedOwner(null);
+      setSelectedDivision(null);
+      setSelectedContainer(null);
+      setSelectedOutputOwner(null);
+      setSelectedOutputDivision(null);
+      setSelectedOutputContainer(null);
+    }
+  }, [open]);
+
+  const handleStationSelect = (station: UserStation | null) => {
+    setSelectedUserStation(station);
+    // Reset input/output location when station changes
+    setSelectedOwner(null);
+    setSelectedDivision(null);
+    setSelectedContainer(null);
+    setSelectedOutputOwner(null);
+    setSelectedOutputDivision(null);
+    setSelectedOutputContainer(null);
+    if (station) {
+      setStructure(station.structure);
+      setFacilityTax(station.facilityTax);
+      setSecurity(station.security || "high");
+      setStationName(station.stationName || "");
+      // Auto-select rig based on rigCategory
+      if (step?.rigCategory) {
+        const matchingRig = station.rigs.find(
+          (r) => r.category === step.rigCategory,
+        );
+        setRig(matchingRig ? matchingRig.tier : "none");
+      } else {
+        setRig("none");
+      }
+    }
+  };
+
+  // Build owner options from hangars data
+  const ownerOptions: OwnerOption[] = [];
+  if (hangarsData) {
+    for (const char of hangarsData.characters) {
+      ownerOptions.push({ id: char.id, name: char.name, type: "character" });
+    }
+    for (const corp of hangarsData.corporations) {
+      ownerOptions.push({ id: corp.id, name: corp.name, type: "corporation" });
+    }
+  }
+
+  // Build division options for selected corporation
+  const divisionOptions: DivisionOption[] = [];
+  if (selectedOwner?.type === "corporation" && hangarsData) {
+    const corp = hangarsData.corporations.find((c) => c.id === selectedOwner.id);
+    if (corp) {
+      for (const [num, name] of Object.entries(corp.divisions)) {
+        divisionOptions.push({ number: parseInt(num), name });
+      }
+      divisionOptions.sort((a, b) => a.number - b.number);
+    }
+  }
+
+  // Build container options filtered by selected owner/division
+  const containerOptions: ContainerOption[] = [];
+  if (selectedOwner && hangarsData) {
+    for (const c of hangarsData.containers) {
+      if (c.ownerType !== selectedOwner.type || c.ownerId !== selectedOwner.id) continue;
+      if (selectedOwner.type === "corporation" && selectedDivision) {
+        if (c.divisionNumber !== selectedDivision.number) continue;
+      }
+      containerOptions.push({ id: c.id, name: c.name });
+    }
+  }
+
+  const handleOwnerSelect = (owner: OwnerOption | null) => {
+    setSelectedOwner(owner);
+    setSelectedDivision(null);
+    setSelectedContainer(null);
+  };
+
+  const handleDivisionSelect = (division: DivisionOption | null) => {
+    setSelectedDivision(division);
+    setSelectedContainer(null);
+  };
+
+  // Build output division options for selected output corporation
+  const outputDivisionOptions: DivisionOption[] = [];
+  if (selectedOutputOwner?.type === "corporation" && hangarsData) {
+    const corp = hangarsData.corporations.find((c) => c.id === selectedOutputOwner.id);
+    if (corp) {
+      for (const [num, name] of Object.entries(corp.divisions)) {
+        outputDivisionOptions.push({ number: parseInt(num), name });
+      }
+      outputDivisionOptions.sort((a, b) => a.number - b.number);
+    }
+  }
+
+  // Build output container options filtered by selected output owner/division
+  const outputContainerOptions: ContainerOption[] = [];
+  if (selectedOutputOwner && hangarsData) {
+    for (const c of hangarsData.containers) {
+      if (c.ownerType !== selectedOutputOwner.type || c.ownerId !== selectedOutputOwner.id) continue;
+      if (selectedOutputOwner.type === "corporation" && selectedOutputDivision) {
+        if (c.divisionNumber !== selectedOutputDivision.number) continue;
+      }
+      outputContainerOptions.push({ id: c.id, name: c.name });
+    }
+  }
+
+  const handleOutputOwnerSelect = (owner: OwnerOption | null) => {
+    setSelectedOutputOwner(owner);
+    setSelectedOutputDivision(null);
+    setSelectedOutputContainer(null);
+  };
+
+  const handleOutputDivisionSelect = (division: DivisionOption | null) => {
+    setSelectedOutputDivision(division);
+    setSelectedOutputContainer(null);
+  };
+
+  // Filter stations to only show those with matching activity
+  const filteredStations = userStations.filter((s) =>
+    step?.activity ? s.activities.includes(step.activity) : true,
+  );
+
+  const hasStation = !!selectedUserStation;
+
+  // Resolve source_location_id from selected station
+  const resolvedSourceLocationId = selectedUserStation
+    ? selectedUserStation.stationId
+    : null;
+
+  if (!step) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: { backgroundColor: "#12151f", color: "#e2e8f0" },
+      }}
+    >
+      <DialogTitle>
+        Edit Step: {step.productName || `Type ${step.productTypeId}`}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+          {/* Preferred Station Selection */}
+          <Autocomplete
+            value={selectedUserStation}
+            onChange={(_, newValue) => handleStationSelect(newValue)}
+            options={filteredStations}
+            getOptionLabel={(option) =>
+              `${option.stationName || "Unknown"} (${option.solarSystemName || ""})`
+            }
+            isOptionEqualToValue={(option, value) => option.id === value.id}
+            renderOption={(props, option) => (
+              <Box component="li" {...props}>
+                <Box>
+                  <Typography variant="body2">
+                    {option.stationName || "Unknown"}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {option.solarSystemName} &middot; {option.structure} &middot;{" "}
+                    {option.activities.join(", ")}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Preferred Station"
+                placeholder="Select a saved station or leave empty for manual config"
+              />
+            )}
+          />
+
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 2,
+            }}
+          >
+            <TextField
+              type="number"
+              label="ME Level"
+              value={meLevel}
+              onChange={(e) => setMeLevel(parseInt(e.target.value) || 0)}
+              inputProps={{ min: 0, max: 10 }}
+            />
+            <TextField
+              type="number"
+              label="TE Level"
+              value={teLevel}
+              onChange={(e) => setTeLevel(parseInt(e.target.value) || 0)}
+              inputProps={{ min: 0, max: 20 }}
+            />
+            <TextField
+              type="number"
+              label="Industry Skill"
+              value={industrySkill}
+              onChange={(e) => setIndustrySkill(parseInt(e.target.value) || 0)}
+              inputProps={{ min: 0, max: 5 }}
+            />
+            <TextField
+              type="number"
+              label="Adv. Industry Skill"
+              value={advIndustrySkill}
+              onChange={(e) =>
+                setAdvIndustrySkill(parseInt(e.target.value) || 0)
+              }
+              inputProps={{ min: 0, max: 5 }}
+            />
+            <FormControl fullWidth disabled={hasStation}>
+              <InputLabel>Structure</InputLabel>
+              <Select
+                value={structure}
+                label="Structure"
+                onChange={(e) => setStructure(e.target.value)}
+              >
+                <MenuItem value="station">Station</MenuItem>
+                <MenuItem value="raitaru">Raitaru</MenuItem>
+                <MenuItem value="azbel">Azbel</MenuItem>
+                <MenuItem value="sotiyo">Sotiyo</MenuItem>
+                <MenuItem value="athanor">Athanor</MenuItem>
+                <MenuItem value="tatara">Tatara</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl fullWidth disabled={hasStation}>
+              <InputLabel>Rig</InputLabel>
+              <Select
+                value={rig}
+                label="Rig"
+                onChange={(e) => setRig(e.target.value)}
+              >
+                <MenuItem value="none">None</MenuItem>
+                <MenuItem value="t1">T1</MenuItem>
+                <MenuItem value="t2">T2</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl fullWidth disabled={hasStation}>
+              <InputLabel>Security</InputLabel>
+              <Select
+                value={security}
+                label="Security"
+                onChange={(e) => setSecurity(e.target.value)}
+              >
+                <MenuItem value="high">Highsec</MenuItem>
+                <MenuItem value="low">Lowsec</MenuItem>
+                <MenuItem value="null">Nullsec / WH</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              type="number"
+              label="Facility Tax %"
+              value={facilityTax}
+              onChange={(e) => setFacilityTax(parseFloat(e.target.value) || 0)}
+              inputProps={{ min: 0, step: 0.1 }}
+              disabled={hasStation}
+            />
+            <TextField
+              label="Station Name"
+              value={stationName}
+              onChange={(e) => setStationName(e.target.value)}
+              placeholder="e.g. Jita 4-4 or player structure name"
+              sx={{ gridColumn: "1 / -1" }}
+              disabled={hasStation}
+            />
+          </Box>
+
+          {/* Input Location Section */}
+          {hasStation && (
+            <>
+              <Divider sx={{ borderColor: "#1e293b", mt: 1 }} />
+              <Typography sx={{ color: "#94a3b8", fontSize: 14, fontWeight: 600 }}>
+                Input Location
+              </Typography>
+              <Typography sx={{ color: "#64748b", fontSize: 12 }}>
+                Where should materials for this step be pulled from?
+              </Typography>
+
+              {!hangarsLoaded ? (
+                <Typography sx={{ color: "#64748b", fontSize: 13 }}>
+                  Loading hangars...
+                </Typography>
+              ) : (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                  {/* Owner Selection */}
+                  <Autocomplete
+                    value={selectedOwner}
+                    onChange={(_, newValue) => handleOwnerSelect(newValue)}
+                    options={ownerOptions}
+                    getOptionLabel={(option) =>
+                      `${option.name} (${option.type === "character" ? "Character" : "Corporation"})`
+                    }
+                    isOptionEqualToValue={(option, value) =>
+                      option.id === value.id && option.type === value.type
+                    }
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label="Owner"
+                        placeholder="Select character or corporation"
+                        size="small"
+                      />
+                    )}
+                  />
+
+                  {/* Division Selection (corporation only) */}
+                  {selectedOwner?.type === "corporation" && divisionOptions.length > 0 && (
+                    <Autocomplete
+                      value={selectedDivision}
+                      onChange={(_, newValue) => handleDivisionSelect(newValue)}
+                      options={divisionOptions}
+                      getOptionLabel={(option) => `${option.number}. ${option.name}`}
+                      isOptionEqualToValue={(option, value) =>
+                        option.number === value.number
+                      }
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="Hangar Division"
+                          placeholder="Select division"
+                          size="small"
+                        />
+                      )}
+                    />
+                  )}
+
+                  {/* Container Selection (optional) */}
+                  {selectedOwner && (
+                    <Autocomplete
+                      value={selectedContainer}
+                      onChange={(_, newValue) => setSelectedContainer(newValue)}
+                      options={containerOptions}
+                      getOptionLabel={(option) => option.name}
+                      isOptionEqualToValue={(option, value) =>
+                        option.id === value.id
+                      }
+                      noOptionsText="No containers at this station"
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="Container (optional)"
+                          placeholder="Select container or leave empty for hangar"
+                          size="small"
+                        />
+                      )}
+                    />
+                  )}
+                </Box>
+              )}
+
+              <Divider sx={{ borderColor: "#1e293b", mt: 1 }} />
+              <Typography sx={{ color: "#94a3b8", fontSize: 14, fontWeight: 600 }}>
+                Output Location
+              </Typography>
+              <Typography sx={{ color: "#64748b", fontSize: 12 }}>
+                Where should completed items from this job be delivered?
+              </Typography>
+
+              {!hangarsLoaded ? (
+                <Typography sx={{ color: "#64748b", fontSize: 13 }}>
+                  Loading hangars...
+                </Typography>
+              ) : (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                  {/* Output Owner Selection */}
+                  <Autocomplete
+                    value={selectedOutputOwner}
+                    onChange={(_, newValue) => handleOutputOwnerSelect(newValue)}
+                    options={ownerOptions}
+                    getOptionLabel={(option) =>
+                      `${option.name} (${option.type === "character" ? "Character" : "Corporation"})`
+                    }
+                    isOptionEqualToValue={(option, value) =>
+                      option.id === value.id && option.type === value.type
+                    }
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label="Owner"
+                        placeholder="Select character or corporation"
+                        size="small"
+                      />
+                    )}
+                  />
+
+                  {/* Output Division Selection (corporation only) */}
+                  {selectedOutputOwner?.type === "corporation" && outputDivisionOptions.length > 0 && (
+                    <Autocomplete
+                      value={selectedOutputDivision}
+                      onChange={(_, newValue) => handleOutputDivisionSelect(newValue)}
+                      options={outputDivisionOptions}
+                      getOptionLabel={(option) => `${option.number}. ${option.name}`}
+                      isOptionEqualToValue={(option, value) =>
+                        option.number === value.number
+                      }
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="Hangar Division"
+                          placeholder="Select division"
+                          size="small"
+                        />
+                      )}
+                    />
+                  )}
+
+                  {/* Output Container Selection (optional) */}
+                  {selectedOutputOwner && (
+                    <Autocomplete
+                      value={selectedOutputContainer}
+                      onChange={(_, newValue) => setSelectedOutputContainer(newValue)}
+                      options={outputContainerOptions}
+                      getOptionLabel={(option) => option.name}
+                      isOptionEqualToValue={(option, value) =>
+                        option.id === value.id
+                      }
+                      noOptionsText="No containers at this station"
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label="Container (optional)"
+                          placeholder="Select container or leave empty for hangar"
+                          size="small"
+                        />
+                      )}
+                    />
+                  )}
+                </Box>
+              )}
+            </>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} sx={{ color: "#94a3b8" }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() =>
+            onSave({
+              me_level: meLevel,
+              te_level: teLevel,
+              industry_skill: industrySkill,
+              adv_industry_skill: advIndustrySkill,
+              structure,
+              rig,
+              security,
+              facility_tax: facilityTax,
+              station_name: stationName || null,
+              user_station_id: selectedUserStation?.id || null,
+              source_owner_type: selectedOwner?.type || null,
+              source_owner_id: selectedOwner?.id || null,
+              source_division_number:
+                selectedOwner?.type === "corporation"
+                  ? selectedDivision?.number ?? null
+                  : null,
+              source_container_id: selectedContainer?.id || null,
+              source_location_id: resolvedSourceLocationId,
+              output_owner_type: selectedOutputOwner?.type || null,
+              output_owner_id: selectedOutputOwner?.id || null,
+              output_division_number:
+                selectedOutputOwner?.type === "corporation"
+                  ? selectedOutputDivision?.number ?? null
+                  : null,
+              output_container_id: selectedOutputContainer?.id || null,
+            } as unknown as Partial<ProductionPlanStep>)
+          }
+          variant="contained"
+          sx={{
+            backgroundColor: "#3b82f6",
+            "&:hover": { backgroundColor: "#2563eb" },
+          }}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/packages/components/industry/ProductionPlansList.tsx
+++ b/frontend/packages/components/industry/ProductionPlansList.tsx
@@ -1,0 +1,512 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import {
+  ProductionPlan,
+  BlueprintSearchResult,
+  UserStation,
+} from "@industry-tool/client/data/models";
+import Navbar from "@industry-tool/components/Navbar";
+import Loading from "@industry-tool/components/loading";
+import ProductionPlanEditor from "./ProductionPlanEditor";
+import Container from "@mui/material/Container";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import IconButton from "@mui/material/IconButton";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import AddIcon from "@mui/icons-material/Add";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import TextField from "@mui/material/TextField";
+import Autocomplete from "@mui/material/Autocomplete";
+import CircularProgress from "@mui/material/CircularProgress";
+
+export default function ProductionPlansList() {
+  const { data: session } = useSession();
+  const [plans, setPlans] = useState<ProductionPlan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedPlanId, setSelectedPlanId] = useState<number | null>(null);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const hasFetchedRef = useRef(false);
+
+  const fetchPlans = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/industry/plans");
+      if (res.ok) {
+        const data = await res.json();
+        setPlans(data || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch plans:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (session && !hasFetchedRef.current) {
+      hasFetchedRef.current = true;
+      fetchPlans();
+    }
+  }, [session, fetchPlans]);
+
+  const handleDelete = async (id: number) => {
+    try {
+      const res = await fetch(`/api/industry/plans/${id}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        fetchPlans();
+      }
+    } catch (err) {
+      console.error("Failed to delete plan:", err);
+    }
+  };
+
+  const handlePlanCreated = (plan: ProductionPlan) => {
+    setCreateDialogOpen(false);
+    fetchPlans();
+    setSelectedPlanId(plan.id);
+  };
+
+  const handleBack = () => {
+    setSelectedPlanId(null);
+    fetchPlans();
+  };
+
+  // Show plan editor if a plan is selected
+  if (selectedPlanId !== null) {
+    return (
+      <>
+        <Navbar />
+        <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
+          <Button
+            startIcon={<ArrowBackIcon />}
+            onClick={handleBack}
+            sx={{ color: "#94a3b8", mb: 2 }}
+          >
+            Back to Plans
+          </Button>
+          <ProductionPlanEditor planId={selectedPlanId} />
+        </Container>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            mb: 2,
+          }}
+        >
+          <Typography
+            variant="h5"
+            sx={{ color: "#e2e8f0", fontWeight: 600 }}
+          >
+            Production Plans
+          </Typography>
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={() => setCreateDialogOpen(true)}
+            sx={{
+              backgroundColor: "#3b82f6",
+              "&:hover": { backgroundColor: "#2563eb" },
+            }}
+          >
+            New Plan
+          </Button>
+        </Box>
+
+        {loading ? (
+          <Loading />
+        ) : plans.length === 0 ? (
+          <Paper
+            sx={{
+              backgroundColor: "#12151f",
+              p: 4,
+              textAlign: "center",
+            }}
+          >
+            <Typography sx={{ color: "#64748b" }}>
+              No production plans yet. Create one to define how items should be
+              produced.
+            </Typography>
+          </Paper>
+        ) : (
+          <TableContainer
+            component={Paper}
+            sx={{ backgroundColor: "#12151f" }}
+          >
+            <Table size="small">
+              <TableHead>
+                <TableRow sx={{ backgroundColor: "#0f1219" }}>
+                  <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                    Product
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                    Plan Name
+                  </TableCell>
+                  <TableCell
+                    sx={{ color: "#94a3b8", fontWeight: 600 }}
+                    align="right"
+                  >
+                    Steps
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                    Created
+                  </TableCell>
+                  <TableCell
+                    sx={{ color: "#94a3b8", fontWeight: 600 }}
+                    align="center"
+                  >
+                    Actions
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {plans.map((plan, idx) => (
+                  <TableRow
+                    key={plan.id}
+                    sx={{
+                      backgroundColor:
+                        idx % 2 === 0 ? "#12151f" : "#0f1219",
+                      "&:hover": { backgroundColor: "#1a1d2e" },
+                      cursor: "pointer",
+                    }}
+                    onClick={() => setSelectedPlanId(plan.id)}
+                  >
+                    <TableCell>
+                      <Box
+                        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                      >
+                        <img
+                          src={`https://images.evetech.net/types/${plan.productTypeId}/icon?size=32`}
+                          alt=""
+                          width={24}
+                          height={24}
+                          style={{ borderRadius: 2 }}
+                        />
+                        <Typography sx={{ color: "#e2e8f0", fontSize: 14 }}>
+                          {plan.productName || `Type ${plan.productTypeId}`}
+                        </Typography>
+                      </Box>
+                    </TableCell>
+                    <TableCell sx={{ color: "#cbd5e1", fontSize: 14 }}>
+                      {plan.name}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{ color: "#cbd5e1", fontSize: 14 }}
+                    >
+                      {plan.steps?.length || 0}
+                    </TableCell>
+                    <TableCell sx={{ color: "#64748b", fontSize: 13 }}>
+                      {new Date(plan.createdAt).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell align="center">
+                      <IconButton
+                        size="small"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedPlanId(plan.id);
+                        }}
+                        sx={{ color: "#3b82f6" }}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(plan.id);
+                        }}
+                        sx={{ color: "#ef4444" }}
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+
+        <CreatePlanDialog
+          open={createDialogOpen}
+          onClose={() => setCreateDialogOpen(false)}
+          onCreated={handlePlanCreated}
+        />
+      </Container>
+    </>
+  );
+}
+
+// --- Create Plan Dialog ---
+
+function CreatePlanDialog({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (plan: ProductionPlan) => void;
+}) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<BlueprintSearchResult[]>(
+    [],
+  );
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [selectedBlueprint, setSelectedBlueprint] =
+    useState<BlueprintSearchResult | null>(null);
+  const [creating, setCreating] = useState(false);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [userStations, setUserStations] = useState<UserStation[]>([]);
+  const [defaultManufacturingStation, setDefaultManufacturingStation] =
+    useState<UserStation | null>(null);
+  const [defaultReactionStation, setDefaultReactionStation] =
+    useState<UserStation | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setDefaultManufacturingStation(null);
+      setDefaultReactionStation(null);
+      return;
+    }
+    const fetchStations = async () => {
+      try {
+        const res = await fetch("/api/stations/user-stations");
+        if (res.ok) {
+          const data: UserStation[] = await res.json();
+          setUserStations(data || []);
+        }
+      } catch (err) {
+        console.error("Failed to fetch user stations:", err);
+      }
+    };
+    fetchStations();
+  }, [open]);
+
+  const manufacturingStations = userStations.filter((s) =>
+    s.activities.includes("manufacturing"),
+  );
+  const reactionStations = userStations.filter((s) =>
+    s.activities.includes("reaction"),
+  );
+
+  const handleSearch = (query: string) => {
+    setSearchQuery(query);
+    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+    if (query.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+    searchTimeoutRef.current = setTimeout(async () => {
+      setSearchLoading(true);
+      try {
+        const res = await fetch(
+          `/api/industry/blueprints?q=${encodeURIComponent(query)}&limit=20`,
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setSearchResults(data || []);
+        }
+      } catch (err) {
+        console.error("Blueprint search failed:", err);
+      } finally {
+        setSearchLoading(false);
+      }
+    }, 300);
+  };
+
+  const handleCreate = async () => {
+    if (!selectedBlueprint) return;
+    setCreating(true);
+    try {
+      const res = await fetch("/api/industry/plans", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          product_type_id: selectedBlueprint.ProductTypeID,
+          default_manufacturing_station_id:
+            defaultManufacturingStation?.id || null,
+          default_reaction_station_id: defaultReactionStation?.id || null,
+        }),
+      });
+      if (res.ok) {
+        const plan = await res.json();
+        setSelectedBlueprint(null);
+        setSearchQuery("");
+        onCreated(plan);
+      }
+    } catch (err) {
+      console.error("Failed to create plan:", err);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{ sx: { backgroundColor: "#12151f", color: "#e2e8f0" } }}
+    >
+      <DialogTitle>Create Production Plan</DialogTitle>
+      <DialogContent>
+        <Autocomplete
+          sx={{ mt: 1 }}
+          options={searchResults}
+          getOptionLabel={(option) =>
+            `${option.ProductName} (${option.Activity})`
+          }
+          renderOption={(props, option) => (
+            <Box
+              component="li"
+              {...props}
+              key={`${option.BlueprintTypeID}-${option.Activity}`}
+              sx={{ display: "flex", alignItems: "center", gap: 1 }}
+            >
+              <img
+                src={`https://images.evetech.net/types/${option.ProductTypeID}/icon?size=32`}
+                alt=""
+                width={24}
+                height={24}
+              />
+              <Box>
+                <Typography sx={{ fontSize: 14 }}>
+                  {option.ProductName}
+                </Typography>
+                <Typography sx={{ fontSize: 12, color: "#64748b" }}>
+                  {option.BlueprintName} &middot; {option.Activity}
+                </Typography>
+              </Box>
+            </Box>
+          )}
+          loading={searchLoading}
+          onInputChange={(_, value) => handleSearch(value)}
+          onChange={(_, value) => setSelectedBlueprint(value)}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Search for a product"
+              placeholder="e.g. Rifter, Damage Control II..."
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {searchLoading ? (
+                      <CircularProgress color="inherit" size={20} />
+                    ) : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+            />
+          )}
+          noOptionsText={
+            searchQuery.length < 2
+              ? "Type to search..."
+              : "No blueprints found"
+          }
+        />
+        <Autocomplete
+          sx={{ mt: 2 }}
+          value={defaultManufacturingStation}
+          onChange={(_, newValue) => setDefaultManufacturingStation(newValue)}
+          options={manufacturingStations}
+          getOptionLabel={(option) =>
+            `${option.stationName || "Unknown"} (${option.solarSystemName || ""})`
+          }
+          isOptionEqualToValue={(option, value) => option.id === value.id}
+          renderOption={(props, option) => (
+            <Box component="li" {...props} key={option.id}>
+              <Box>
+                <Typography variant="body2">
+                  {option.stationName || "Unknown"}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {option.solarSystemName} &middot; {option.structure}
+                </Typography>
+              </Box>
+            </Box>
+          )}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Default Manufacturing Station"
+              placeholder="Optional"
+            />
+          )}
+        />
+        <Autocomplete
+          sx={{ mt: 2 }}
+          value={defaultReactionStation}
+          onChange={(_, newValue) => setDefaultReactionStation(newValue)}
+          options={reactionStations}
+          getOptionLabel={(option) =>
+            `${option.stationName || "Unknown"} (${option.solarSystemName || ""})`
+          }
+          isOptionEqualToValue={(option, value) => option.id === value.id}
+          renderOption={(props, option) => (
+            <Box component="li" {...props} key={option.id}>
+              <Box>
+                <Typography variant="body2">
+                  {option.stationName || "Unknown"}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {option.solarSystemName} &middot; {option.structure}
+                </Typography>
+              </Box>
+            </Box>
+          )}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Default Reaction Station"
+              placeholder="Optional"
+            />
+          )}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} sx={{ color: "#94a3b8" }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleCreate}
+          disabled={!selectedBlueprint || creating}
+          variant="contained"
+          sx={{
+            backgroundColor: "#3b82f6",
+            "&:hover": { backgroundColor: "#2563eb" },
+          }}
+        >
+          {creating ? "Creating..." : "Create Plan"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/packages/components/industry/__tests__/BatchConfigureTab.test.tsx
+++ b/frontend/packages/components/industry/__tests__/BatchConfigureTab.test.tsx
@@ -1,0 +1,586 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import BatchConfigureTab from '../BatchConfigureTab';
+import { ProductionPlan, ProductionPlanStep } from '@industry-tool/client/data/models';
+
+jest.mock('@industry-tool/utils/formatting', () => ({
+  formatISK: (val: number) => `${val.toLocaleString()} ISK`,
+  formatNumber: (val: number) => val.toLocaleString(),
+  formatCompact: (val: number) => val.toLocaleString(),
+}));
+
+const mockRootStep: ProductionPlanStep = {
+  id: 10,
+  planId: 1,
+  productTypeId: 587,
+  blueprintTypeId: 787,
+  activity: 'manufacturing',
+  meLevel: 10,
+  teLevel: 20,
+  industrySkill: 5,
+  advIndustrySkill: 5,
+  structure: 'raitaru',
+  rig: 't2',
+  security: 'high',
+  facilityTax: 1.0,
+  productName: 'Rifter',
+  blueprintName: 'Rifter Blueprint',
+};
+
+const mockFuelStep1: ProductionPlanStep = {
+  id: 20,
+  planId: 1,
+  parentStepId: 10,
+  productTypeId: 4247,
+  blueprintTypeId: 4248,
+  activity: 'manufacturing',
+  meLevel: 10,
+  teLevel: 20,
+  industrySkill: 5,
+  advIndustrySkill: 5,
+  structure: 'raitaru',
+  rig: 't2',
+  security: 'high',
+  facilityTax: 1.0,
+  productName: 'Nitrogen Fuel Block',
+  blueprintName: 'Nitrogen Fuel Block Blueprint',
+};
+
+const mockFuelStep2: ProductionPlanStep = {
+  id: 21,
+  planId: 1,
+  parentStepId: 10,
+  productTypeId: 4247,
+  blueprintTypeId: 4248,
+  activity: 'manufacturing',
+  meLevel: 10,
+  teLevel: 20,
+  industrySkill: 5,
+  advIndustrySkill: 5,
+  structure: 'raitaru',
+  rig: 't2',
+  security: 'high',
+  facilityTax: 1.0,
+  productName: 'Nitrogen Fuel Block',
+  blueprintName: 'Nitrogen Fuel Block Blueprint',
+};
+
+const mockReactionStep: ProductionPlanStep = {
+  id: 30,
+  planId: 1,
+  parentStepId: 10,
+  productTypeId: 16634,
+  blueprintTypeId: 16635,
+  activity: 'reaction',
+  meLevel: 0,
+  teLevel: 0,
+  industrySkill: 5,
+  advIndustrySkill: 5,
+  structure: 'tatara',
+  rig: 't1',
+  security: 'low',
+  facilityTax: 0.25,
+  productName: 'Chromium',
+  blueprintName: 'Chromium Reaction Formula',
+};
+
+const mockPlan: ProductionPlan = {
+  id: 1,
+  userId: 100,
+  productTypeId: 587,
+  name: 'Rifter Production',
+  createdAt: '2026-02-22T00:00:00Z',
+  updatedAt: '2026-02-22T00:00:00Z',
+  productName: 'Rifter',
+  steps: [mockRootStep, mockFuelStep1, mockFuelStep2, mockReactionStep],
+};
+
+const emptyPlan: ProductionPlan = {
+  id: 2,
+  userId: 100,
+  productTypeId: 587,
+  name: 'Empty Plan',
+  createdAt: '2026-02-22T00:00:00Z',
+  updatedAt: '2026-02-22T00:00:00Z',
+  productName: 'Rifter',
+  steps: [],
+};
+
+const mockMaterials = [
+  {
+    typeId: 34,
+    typeName: 'Tritanium',
+    quantity: 2000,
+    volume: 0.01,
+    hasBlueprint: false,
+    isProduced: false,
+  },
+  {
+    typeId: 35,
+    typeName: 'Pyerite',
+    quantity: 1000,
+    volume: 0.01,
+    hasBlueprint: true,
+    blueprintTypeId: 135,
+    activity: 'manufacturing',
+    isProduced: false,
+  },
+];
+
+describe('BatchConfigureTab Component', () => {
+  const mockOnUpdate = jest.fn();
+
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+    mockOnUpdate.mockClear();
+  });
+
+  it('should match snapshot with grouped steps', () => {
+    const { container } = render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should show empty state when no steps', () => {
+    render(
+      <BatchConfigureTab plan={emptyPlan} planId={2} onUpdate={mockOnUpdate} />,
+    );
+    expect(screen.getByText('No steps in this plan')).toBeInTheDocument();
+  });
+
+  it('should match snapshot with empty plan', () => {
+    const { container } = render(
+      <BatchConfigureTab plan={emptyPlan} planId={2} onUpdate={mockOnUpdate} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should group steps by product type and activity', () => {
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Should show 3 groups: Chromium (1), Nitrogen Fuel Block (2), Rifter (1)
+    expect(screen.getByText('Chromium')).toBeInTheDocument();
+    expect(screen.getByText('Nitrogen Fuel Block')).toBeInTheDocument();
+    expect(screen.getByText('Rifter')).toBeInTheDocument();
+  });
+
+  it('should show correct count for grouped steps', () => {
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Fuel block group has 2 steps
+    const chips = screen.getAllByText('2');
+    expect(chips.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should show activity chips', () => {
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    const mfgChips = screen.getAllByText('manufacturing');
+    expect(mfgChips.length).toBe(2); // Rifter and Fuel blocks
+    expect(screen.getByText('reaction')).toBeInTheDocument();
+  });
+
+  it('should open edit dialog when edit button is clicked', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    const editButtons = screen.getAllByTestId('EditIcon');
+    await act(async () => {
+      fireEvent.click(editButtons[0].closest('button')!);
+    });
+
+    expect(screen.getByText(/Batch Edit:/)).toBeInTheDocument();
+  });
+
+  it('should show warning in edit dialog about number of steps', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Click edit on the fuel block group (which has 2 steps)
+    const editButtons = screen.getAllByTestId('EditIcon');
+    // Groups are sorted alphabetically: Chromium, Nitrogen Fuel Block, Rifter
+    await act(async () => {
+      fireEvent.click(editButtons[1].closest('button')!); // Nitrogen Fuel Block
+    });
+
+    expect(screen.getByText(/Changes will apply to all 2/)).toBeInTheDocument();
+  });
+
+  it('should display Mixed chip when steps have different ME levels', () => {
+    const mixedPlan: ProductionPlan = {
+      ...mockPlan,
+      steps: [
+        mockRootStep,
+        mockFuelStep1,
+        { ...mockFuelStep2, meLevel: 5 },
+        mockReactionStep,
+      ],
+    };
+
+    render(
+      <BatchConfigureTab plan={mixedPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    const mixedChips = screen.getAllByText('Mixed');
+    expect(mixedChips.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should display description text', () => {
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    expect(
+      screen.getByText(/Steps producing the same item are grouped together/),
+    ).toBeInTheDocument();
+  });
+
+  it('should show expand/collapse icons on each group row', () => {
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // All groups should show ChevronRight (collapsed) by default
+    const chevrons = screen.getAllByTestId('ChevronRightIcon');
+    expect(chevrons.length).toBe(3); // 3 groups
+  });
+
+  it('should expand group and fetch materials on click', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockMaterials,
+    });
+
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Click expand on first group (Chromium)
+    const chevrons = screen.getAllByTestId('ChevronRightIcon');
+    await act(async () => {
+      fireEvent.click(chevrons[0].closest('button')!);
+    });
+
+    // Should have fetched materials
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/industry/plans/1/steps/30/materials',
+    );
+
+    // Should show material names
+    await waitFor(() => {
+      expect(screen.getByText('Tritanium')).toBeInTheDocument();
+      expect(screen.getByText('Pyerite')).toBeInTheDocument();
+    });
+  });
+
+  it('should show Buy chip for materials not produced', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockMaterials,
+    });
+
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Expand Chromium group
+    const chevrons = screen.getAllByTestId('ChevronRightIcon');
+    await act(async () => {
+      fireEvent.click(chevrons[0].closest('button')!);
+    });
+
+    await waitFor(() => {
+      const buyChips = screen.getAllByText('Buy');
+      expect(buyChips.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('should show toggle button only for materials with blueprints', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockMaterials,
+    });
+
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Expand Chromium group
+    const chevrons = screen.getAllByTestId('ChevronRightIcon');
+    await act(async () => {
+      fireEvent.click(chevrons[0].closest('button')!);
+    });
+
+    await waitFor(() => {
+      // Pyerite has hasBlueprint=true, so its row should have a BuildIcon toggle button
+      // BuildIcon also appears in the build count chip, so check for the toggle button specifically
+      const buildIcons = screen.getAllByTestId('BuildIcon');
+      const toggleButton = buildIcons.find(
+        (icon) => icon.closest('button[title="Switch all to Produce"]'),
+      );
+      expect(toggleButton).toBeTruthy();
+    });
+  });
+
+  it('should collapse expanded group on second click', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockMaterials,
+    });
+
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Expand first group
+    const chevrons = screen.getAllByTestId('ChevronRightIcon');
+    await act(async () => {
+      fireEvent.click(chevrons[0].closest('button')!);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Tritanium')).toBeInTheDocument();
+    });
+
+    // Collapse it - the ExpandMore icon should now be visible
+    const expandIcon = screen.getByTestId('ExpandMoreIcon');
+    await act(async () => {
+      fireEvent.click(expandIcon.closest('button')!);
+    });
+
+    // Materials should be hidden
+    expect(screen.queryByText('Tritanium')).not.toBeInTheDocument();
+  });
+
+  it('should show Produce chip for materials with child steps', async () => {
+    // Create a plan where fuel step 1 has a child for material typeId 35
+    const planWithChild: ProductionPlan = {
+      ...mockPlan,
+      steps: [
+        mockRootStep,
+        mockFuelStep1,
+        mockFuelStep2,
+        mockReactionStep,
+        // Child step of fuelStep1 producing Pyerite
+        {
+          id: 40,
+          planId: 1,
+          parentStepId: 20,
+          productTypeId: 35,
+          blueprintTypeId: 135,
+          activity: 'manufacturing',
+          meLevel: 10,
+          teLevel: 20,
+          industrySkill: 5,
+          advIndustrySkill: 5,
+          structure: 'raitaru',
+          rig: 't2',
+          security: 'high',
+          facilityTax: 1.0,
+          productName: 'Pyerite',
+          blueprintName: 'Pyerite Blueprint',
+        },
+        // Child step of fuelStep2 producing Pyerite
+        {
+          id: 41,
+          planId: 1,
+          parentStepId: 21,
+          productTypeId: 35,
+          blueprintTypeId: 135,
+          activity: 'manufacturing',
+          meLevel: 10,
+          teLevel: 20,
+          industrySkill: 5,
+          advIndustrySkill: 5,
+          structure: 'raitaru',
+          rig: 't2',
+          security: 'high',
+          facilityTax: 1.0,
+          productName: 'Pyerite',
+          blueprintName: 'Pyerite Blueprint',
+        },
+      ],
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockMaterials,
+    });
+
+    render(
+      <BatchConfigureTab plan={planWithChild} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Expand fuel block group (index 1 alphabetically: Nitrogen Fuel Block)
+    const chevrons = screen.getAllByTestId('ChevronRightIcon');
+    await act(async () => {
+      // Groups: Chromium, Nitrogen Fuel Block, Pyerite, Rifter
+      fireEvent.click(chevrons[1].closest('button')!);
+    });
+
+    await waitFor(() => {
+      // Pyerite should show "Produce" chip since both fuel steps have child steps for it
+      expect(screen.getByText('Produce')).toBeInTheDocument();
+    });
+  });
+
+  it('should show input/output location when configured', () => {
+    const planWithLocations: ProductionPlan = {
+      ...mockPlan,
+      steps: [
+        mockRootStep,
+        {
+          ...mockFuelStep1,
+          sourceOwnerName: 'My Corp',
+          sourceDivisionName: 'Hangar 1',
+          sourceContainerName: 'Materials',
+          outputOwnerName: 'My Corp',
+          outputDivisionName: 'Hangar 2',
+        },
+        {
+          ...mockFuelStep2,
+          sourceOwnerName: 'My Corp',
+          sourceDivisionName: 'Hangar 1',
+          sourceContainerName: 'Materials',
+          outputOwnerName: 'My Corp',
+          outputDivisionName: 'Hangar 2',
+        },
+        mockReactionStep,
+      ],
+    };
+
+    render(
+      <BatchConfigureTab plan={planWithLocations} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    expect(screen.getByText('In: My Corp / Hangar 1 / Materials')).toBeInTheDocument();
+    expect(screen.getByText('Out: My Corp / Hangar 2')).toBeInTheDocument();
+  });
+
+  it('should show Mixed chip for input location when steps differ', () => {
+    const planWithMixedLocations: ProductionPlan = {
+      ...mockPlan,
+      steps: [
+        mockRootStep,
+        {
+          ...mockFuelStep1,
+          sourceOwnerName: 'Corp A',
+        },
+        {
+          ...mockFuelStep2,
+          sourceOwnerName: 'Corp B',
+        },
+        mockReactionStep,
+      ],
+    };
+
+    render(
+      <BatchConfigureTab plan={planWithMixedLocations} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // The fuel block group should show "In: Mixed"
+    const inTexts = screen.getAllByText(/^In:/);
+    expect(inTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should show set-all-build and set-all-buy buttons on each group row', () => {
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Each group row has a build button for "Set all to Build"
+    // 3 groups = 3 build buttons + 1 chip icon (Rifter group has children) = 4 total BuildIcons
+    const allBuildIcons = screen.getAllByTestId('BuildIcon');
+    const buildButtons = allBuildIcons.filter(
+      (icon) => icon.closest('button[class*="IconButton"]'),
+    );
+    expect(buildButtons.length).toBeGreaterThanOrEqual(3);
+
+    // Each group row has a buy chip + a "Set all to Buy" button = 2 per group = 6 total
+    const allCartIcons = screen.getAllByTestId('ShoppingCartIcon');
+    expect(allCartIcons.length).toBe(6);
+  });
+
+  it('should call onUpdate after set all to buy removes child steps', async () => {
+    // Plan with child steps under fuel steps
+    const planWithChildren: ProductionPlan = {
+      ...mockPlan,
+      steps: [
+        mockRootStep,
+        mockFuelStep1,
+        mockFuelStep2,
+        mockReactionStep,
+        {
+          id: 40,
+          planId: 1,
+          parentStepId: 20,
+          productTypeId: 35,
+          blueprintTypeId: 135,
+          activity: 'manufacturing',
+          meLevel: 10,
+          teLevel: 20,
+          industrySkill: 5,
+          advIndustrySkill: 5,
+          structure: 'raitaru',
+          rig: 't2',
+          security: 'high',
+          facilityTax: 1.0,
+          productName: 'Pyerite',
+          blueprintName: 'Pyerite Blueprint',
+        },
+      ],
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    render(
+      <BatchConfigureTab plan={planWithChildren} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    // Find "Set all to Buy" buttons — these are IconButtons containing ShoppingCartIcon
+    // (distinct from the Chip icons which are not inside IconButtons)
+    const cartButtons = screen.getAllByTestId('ShoppingCartIcon')
+      .filter((icon) => icon.closest('button.MuiIconButton-root'))
+      .map((icon) => icon.closest('button')!);
+    // Groups alphabetically: Chromium (0), Nitrogen Fuel Block (1), Pyerite (2), Rifter (3)
+    await act(async () => {
+      fireEvent.click(cartButtons[1]);
+    });
+
+    // Should have called DELETE for the child step
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/industry/plans/1/steps/40',
+      { method: 'DELETE' },
+    );
+    expect(mockOnUpdate).toHaveBeenCalled();
+  });
+
+  it('should mention expand feature in description text', () => {
+    render(
+      <BatchConfigureTab plan={mockPlan} planId={1} onUpdate={mockOnUpdate} />,
+    );
+
+    expect(
+      screen.getByText(/Expand a group to toggle materials between buy and produce/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/components/industry/__tests__/ProductionPlanEditor.test.tsx
+++ b/frontend/packages/components/industry/__tests__/ProductionPlanEditor.test.tsx
@@ -1,0 +1,387 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ProductionPlanEditor from '../ProductionPlanEditor';
+import { ProductionPlan, ProductionPlanStep, PlanMaterial } from '@industry-tool/client/data/models';
+
+// Mock formatISK to avoid import issues
+jest.mock('@industry-tool/utils/formatting', () => ({
+  formatISK: (val: number) => `${val.toLocaleString()} ISK`,
+  formatNumber: (val: number) => val.toLocaleString(),
+  formatCompact: (val: number) => val.toLocaleString(),
+}));
+
+const mockRootStep: ProductionPlanStep = {
+  id: 10,
+  planId: 1,
+  productTypeId: 587,
+  blueprintTypeId: 787,
+  activity: 'manufacturing',
+  meLevel: 10,
+  teLevel: 20,
+  industrySkill: 5,
+  advIndustrySkill: 5,
+  structure: 'raitaru',
+  rig: 't2',
+  security: 'high',
+  facilityTax: 1.0,
+  productName: 'Rifter',
+  blueprintName: 'Rifter Blueprint',
+};
+
+const mockPlan: ProductionPlan = {
+  id: 1,
+  userId: 100,
+  productTypeId: 587,
+  name: 'Rifter Production',
+  createdAt: '2026-02-22T00:00:00Z',
+  updatedAt: '2026-02-22T00:00:00Z',
+  productName: 'Rifter',
+  steps: [mockRootStep],
+};
+
+const mockMaterials: PlanMaterial[] = [
+  {
+    typeId: 34,
+    typeName: 'Tritanium',
+    quantity: 22222,
+    volume: 0.01,
+    hasBlueprint: false,
+    isProduced: false,
+  },
+  {
+    typeId: 35,
+    typeName: 'Pyerite',
+    quantity: 5555,
+    volume: 0.01,
+    hasBlueprint: false,
+    isProduced: false,
+  },
+  {
+    typeId: 11399,
+    typeName: 'Morphite',
+    quantity: 10,
+    volume: 0.01,
+    hasBlueprint: true,
+    blueprintTypeId: 99999,
+    activity: 'reaction',
+    isProduced: false,
+  },
+];
+
+describe('ProductionPlanEditor Component', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it('should match snapshot while loading', () => {
+    (global.fetch as jest.Mock).mockImplementation(
+      () => new Promise(() => {}), // never resolves
+    );
+
+    const { container } = render(<ProductionPlanEditor planId={1} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display loading text initially', () => {
+    (global.fetch as jest.Mock).mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    render(<ProductionPlanEditor planId={1} />);
+    expect(screen.getByText('Loading plan...')).toBeInTheDocument();
+  });
+
+  it('should match snapshot with loaded plan', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    let container: HTMLElement;
+    await act(async () => {
+      const result = render(<ProductionPlanEditor planId={1} />);
+      container = result.container;
+    });
+
+    expect(container!).toMatchSnapshot();
+  });
+
+  it('should display plan name and product info', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    expect(screen.getByText('Rifter Production')).toBeInTheDocument();
+    expect(screen.getByText('1 production step(s)')).toBeInTheDocument();
+  });
+
+  it('should display root step with details', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    expect(screen.getByText('Rifter')).toBeInTheDocument();
+    expect(screen.getByText('manufacturing')).toBeInTheDocument();
+    expect(screen.getByText('ME 10 / TE 20')).toBeInTheDocument();
+    expect(screen.getByText('raitaru / t2 / high')).toBeInTheDocument();
+  });
+
+  it('should display materials when root step is auto-expanded', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    expect(screen.getByText('Tritanium')).toBeInTheDocument();
+    expect(screen.getByText('Pyerite')).toBeInTheDocument();
+    expect(screen.getByText('Morphite')).toBeInTheDocument();
+  });
+
+  it('should show produce toggle for materials with blueprints', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    // Morphite has hasBlueprint=true, so it should have a toggle button
+    expect(screen.getByTitle('Switch to Produce')).toBeInTheDocument();
+  });
+
+  it('should show Buy chip for non-produced materials', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    const buyChips = screen.getAllByText('Buy');
+    expect(buyChips.length).toBe(3);
+  });
+
+  it('should have Generate Jobs button', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    expect(screen.getByText('Generate Jobs')).toBeInTheDocument();
+  });
+
+  it('should open generate dialog when Generate Jobs is clicked', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    fireEvent.click(screen.getByText('Generate Jobs'));
+    expect(screen.getByText('Generate Production Jobs')).toBeInTheDocument();
+    expect(screen.getByText(/How many Rifter do you want to produce/)).toBeInTheDocument();
+  });
+
+  it('should open edit dialog when edit button is clicked', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    const editButtons = screen.getAllByTestId('EditIcon');
+    // First EditIcon is plan name edit, second is the step edit button
+    fireEvent.click(editButtons[1].closest('button')!);
+
+    expect(screen.getByText('Edit Step: Rifter')).toBeInTheDocument();
+  });
+
+  it('should display "No steps" message for plan without steps', async () => {
+    const emptyPlan: ProductionPlan = {
+      ...mockPlan,
+      steps: [],
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => emptyPlan,
+    });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    expect(screen.getByText('No steps in this plan')).toBeInTheDocument();
+  });
+
+  it('should match snapshot with multi-step plan', async () => {
+    const childStep: ProductionPlanStep = {
+      id: 11,
+      planId: 1,
+      parentStepId: 10,
+      productTypeId: 11399,
+      blueprintTypeId: 99999,
+      activity: 'reaction',
+      meLevel: 0,
+      teLevel: 0,
+      industrySkill: 5,
+      advIndustrySkill: 5,
+      structure: 'raitaru',
+      rig: 't2',
+      security: 'low',
+      facilityTax: 0.25,
+      productName: 'Morphite',
+      blueprintName: 'Morphite Reaction Formula',
+    };
+
+    const multiStepPlan: ProductionPlan = {
+      ...mockPlan,
+      steps: [mockRootStep, childStep],
+    };
+
+    const materialsWithProduced: PlanMaterial[] = [
+      ...mockMaterials.slice(0, 2),
+      { ...mockMaterials[2], isProduced: true },
+    ];
+
+    const childMaterials: PlanMaterial[] = [
+      {
+        typeId: 16634,
+        typeName: 'Chromium',
+        quantity: 100,
+        volume: 0.16,
+        hasBlueprint: false,
+        isProduced: false,
+      },
+    ];
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => multiStepPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => materialsWithProduced,
+      });
+
+    let container: HTMLElement;
+    await act(async () => {
+      const result = render(<ProductionPlanEditor planId={1} />);
+      container = result.container;
+    });
+
+    expect(container!).toMatchSnapshot();
+  });
+
+  it('should fetch plan on mount', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/industry/plans/1');
+  });
+
+  it('should fetch materials for root step on load', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPlan,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMaterials,
+      });
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/industry/plans/1/steps/10/materials',
+    );
+  });
+});

--- a/frontend/packages/components/industry/__tests__/ProductionPlansList.test.tsx
+++ b/frontend/packages/components/industry/__tests__/ProductionPlansList.test.tsx
@@ -1,0 +1,346 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { useSession } from 'next-auth/react';
+import ProductionPlansList from '../ProductionPlansList';
+import { ProductionPlan } from '@industry-tool/client/data/models';
+
+jest.mock('next-auth/react');
+jest.mock('../../Navbar', () => {
+  return function MockNavbar() {
+    return <div data-testid="navbar">Navbar</div>;
+  };
+});
+jest.mock('../../loading', () => {
+  return function MockLoading() {
+    return <div data-testid="loading">Loading...</div>;
+  };
+});
+jest.mock('../ProductionPlanEditor', () => {
+  return function MockEditor({ planId }: { planId: number }) {
+    return <div data-testid="plan-editor">Editor for plan {planId}</div>;
+  };
+});
+
+const mockUseSession = useSession as jest.MockedFunction<typeof useSession>;
+
+const mockSession = {
+  data: {
+    providerAccountId: '1001',
+    expires: '2099-01-01',
+  },
+  status: 'authenticated' as const,
+  update: jest.fn(),
+};
+
+describe('ProductionPlansList Component', () => {
+  beforeEach(() => {
+    mockUseSession.mockReturnValue(mockSession);
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it('should match snapshot while loading', async () => {
+    (global.fetch as jest.Mock).mockImplementation(
+      () => new Promise(() => {}), // never resolves
+    );
+
+    const { container } = render(<ProductionPlansList />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should match snapshot with empty plans', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    let container: HTMLElement;
+    await act(async () => {
+      const result = render(<ProductionPlansList />);
+      container = result.container;
+    });
+
+    expect(container!).toMatchSnapshot();
+  });
+
+  it('should display empty message when no plans', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    await act(async () => {
+      render(<ProductionPlansList />);
+    });
+
+    expect(
+      screen.getByText(/No production plans yet/),
+    ).toBeInTheDocument();
+  });
+
+  it('should match snapshot with plans', async () => {
+    const plans: ProductionPlan[] = [
+      {
+        id: 1,
+        userId: 100,
+        productTypeId: 587,
+        name: 'Rifter Production',
+        createdAt: '2026-02-22T12:00:00Z',
+        updatedAt: '2026-02-22T12:00:00Z',
+        productName: 'Rifter',
+        steps: [
+          {
+            id: 10,
+            planId: 1,
+            productTypeId: 587,
+            blueprintTypeId: 787,
+            activity: 'manufacturing',
+            meLevel: 10,
+            teLevel: 20,
+            industrySkill: 5,
+            advIndustrySkill: 5,
+            structure: 'raitaru',
+            rig: 't2',
+            security: 'high',
+            facilityTax: 1.0,
+            productName: 'Rifter',
+            blueprintName: 'Rifter Blueprint',
+          },
+        ],
+      },
+      {
+        id: 2,
+        userId: 100,
+        productTypeId: 11379,
+        name: 'Muninn Production',
+        createdAt: '2026-02-22T12:00:00Z',
+        updatedAt: '2026-02-22T12:00:00Z',
+        productName: 'Muninn',
+        steps: [
+          {
+            id: 20,
+            planId: 2,
+            productTypeId: 11379,
+            blueprintTypeId: 11380,
+            activity: 'manufacturing',
+            meLevel: 10,
+            teLevel: 20,
+            industrySkill: 5,
+            advIndustrySkill: 5,
+            structure: 'raitaru',
+            rig: 't2',
+            security: 'low',
+            facilityTax: 1.0,
+            productName: 'Muninn',
+            blueprintName: 'Muninn Blueprint',
+          },
+          {
+            id: 21,
+            planId: 2,
+            parentStepId: 20,
+            productTypeId: 11370,
+            blueprintTypeId: 11371,
+            activity: 'manufacturing',
+            meLevel: 10,
+            teLevel: 20,
+            industrySkill: 5,
+            advIndustrySkill: 5,
+            structure: 'raitaru',
+            rig: 't2',
+            security: 'low',
+            facilityTax: 1.0,
+            productName: 'Rupture',
+            blueprintName: 'Rupture Blueprint',
+          },
+        ],
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => plans,
+    });
+
+    let container: HTMLElement;
+    await act(async () => {
+      const result = render(<ProductionPlansList />);
+      container = result.container;
+    });
+
+    expect(container!).toMatchSnapshot();
+  });
+
+  it('should display plan details in table', async () => {
+    const plans: ProductionPlan[] = [
+      {
+        id: 1,
+        userId: 100,
+        productTypeId: 587,
+        name: 'Rifter Production',
+        createdAt: '2026-02-22T12:00:00Z',
+        updatedAt: '2026-02-22T12:00:00Z',
+        productName: 'Rifter',
+        steps: [
+          {
+            id: 10,
+            planId: 1,
+            productTypeId: 587,
+            blueprintTypeId: 787,
+            activity: 'manufacturing',
+            meLevel: 10,
+            teLevel: 20,
+            industrySkill: 5,
+            advIndustrySkill: 5,
+            structure: 'raitaru',
+            rig: 't2',
+            security: 'high',
+            facilityTax: 1.0,
+          },
+        ],
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => plans,
+    });
+
+    await act(async () => {
+      render(<ProductionPlansList />);
+    });
+
+    expect(screen.getByText('Rifter')).toBeInTheDocument();
+    expect(screen.getByText('Rifter Production')).toBeInTheDocument();
+  });
+
+  it('should navigate to editor when plan row is clicked', async () => {
+    const plans: ProductionPlan[] = [
+      {
+        id: 42,
+        userId: 100,
+        productTypeId: 587,
+        name: 'Rifter Production',
+        createdAt: '2026-02-22T12:00:00Z',
+        updatedAt: '2026-02-22T12:00:00Z',
+        productName: 'Rifter',
+        steps: [],
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => plans,
+    });
+
+    await act(async () => {
+      render(<ProductionPlansList />);
+    });
+
+    // Click the plan row
+    fireEvent.click(screen.getByText('Rifter'));
+
+    expect(screen.getByTestId('plan-editor')).toBeInTheDocument();
+    expect(screen.getByText('Editor for plan 42')).toBeInTheDocument();
+  });
+
+  it('should show back button when viewing editor', async () => {
+    const plans: ProductionPlan[] = [
+      {
+        id: 42,
+        userId: 100,
+        productTypeId: 587,
+        name: 'Rifter Production',
+        createdAt: '2026-02-22T12:00:00Z',
+        updatedAt: '2026-02-22T12:00:00Z',
+        productName: 'Rifter',
+        steps: [],
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => plans,
+    });
+
+    await act(async () => {
+      render(<ProductionPlansList />);
+    });
+
+    fireEvent.click(screen.getByText('Rifter'));
+    expect(screen.getByText('Back to Plans')).toBeInTheDocument();
+  });
+
+  it('should call delete API when delete button is clicked', async () => {
+    const plans: ProductionPlan[] = [
+      {
+        id: 5,
+        userId: 100,
+        productTypeId: 587,
+        name: 'Rifter Production',
+        createdAt: '2026-02-22T12:00:00Z',
+        updatedAt: '2026-02-22T12:00:00Z',
+        productName: 'Rifter',
+        steps: [],
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => plans,
+    });
+
+    await act(async () => {
+      render(<ProductionPlansList />);
+    });
+
+    // Mock for delete + refetch
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    // Find the delete button (second icon button in actions cell)
+    const deleteButtons = screen.getAllByTestId('DeleteIcon');
+    await act(async () => {
+      fireEvent.click(deleteButtons[0].closest('button')!);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/industry/plans/5', {
+      method: 'DELETE',
+    });
+  });
+
+  it('should not fetch plans when not authenticated', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+      update: jest.fn(),
+    });
+
+    render(<ProductionPlansList />);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should open create dialog when New Plan button is clicked', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    await act(async () => {
+      render(<ProductionPlansList />);
+    });
+
+    // Mock the stations fetch that fires when dialog opens
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('New Plan'));
+    });
+
+    expect(screen.getByText('Create Production Plan')).toBeInTheDocument();
+    expect(screen.getByLabelText('Default Manufacturing Station')).toBeInTheDocument();
+    expect(screen.getByLabelText('Default Reaction Station')).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/components/industry/__tests__/__snapshots__/BatchConfigureTab.test.tsx.snap
+++ b/frontend/packages/components/industry/__tests__/__snapshots__/BatchConfigureTab.test.tsx.snap
@@ -1,0 +1,709 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`BatchConfigureTab Component should match snapshot with empty plan 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-8ptgxe"
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body1 css-1p2qead-MuiTypography-root"
+    >
+      No steps in this plan
+    </p>
+  </div>
+</div>
+`;
+
+exports[`BatchConfigureTab Component should match snapshot with grouped steps 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-0"
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body1 css-bk90tm-MuiTypography-root"
+    >
+      Steps producing the same item are grouped together. Edit a group to configure all instances at once. Expand a group to toggle materials between buy and produce.
+    </p>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root css-s09dh4-MuiPaper-root-MuiTableContainer-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <table
+        class="MuiTable-root css-1xwxv7r-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+        >
+          <tr
+            class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Product
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Activity
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+              scope="col"
+            >
+              Count
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+              scope="col"
+            >
+              Build / Buy
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              ME / TE
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Structure / Rig / Sec
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Station
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+              scope="col"
+            >
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root css-1xcq121-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-q4vm8z-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="ChevronRightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                    />
+                  </svg>
+                </button>
+                <img
+                  alt=""
+                  height="24"
+                  src="https://images.evetech.net/types/16634/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="24"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-28s2xz-MuiTypography-root"
+                >
+                  Chromium
+                </p>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1fjfhd2-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  reaction
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1sz2u09-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  1
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-vg81k4"
+              >
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1816kef-MuiChip-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconSmall MuiChip-iconColorDefault css-g5bvlu-MuiSvgIcon-root"
+                    data-testid="BuildIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m22.7 19-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4"
+                    />
+                  </svg>
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    0
+                  </span>
+                </div>
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1816kef-MuiChip-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconSmall MuiChip-iconColorDefault css-g5bvlu-MuiSvgIcon-root"
+                    data-testid="ShoppingCartIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2M1 2v2h2l3.6 7.59-1.35 2.45c-.16.28-.25.61-.25.96 0 1.1.9 2 2 2h12v-2H7.42c-.14 0-.25-.11-.25-.25l.03-.12.9-1.63h7.45c.75 0 1.41-.41 1.75-1.03l3.58-6.49c.08-.14.12-.31.12-.48 0-.55-.45-1-1-1H5.21l-.94-2zm16 16c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2"
+                    />
+                  </svg>
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    ?
+                  </span>
+                </div>
+                <span
+                  aria-label="Set all materials to Build"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lvvih5-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                      data-testid="BuildIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m22.7 19-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4"
+                      />
+                    </svg>
+                  </button>
+                </span>
+                <span
+                  aria-label="Set all materials to Buy"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-lvvih5-MuiButtonBase-root-MuiIconButton-root"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                      data-testid="ShoppingCartIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2M1 2v2h2l3.6 7.59-1.35 2.45c-.16.28-.25.61-.25.96 0 1.1.9 2 2 2h12v-2H7.42c-.14 0-.25-.11-.25-.25l.03-.12.9-1.63h7.45c.75 0 1.41-.41 1.75-1.03l3.58-6.49c.08-.14.12-.31.12-.48 0-.55-.45-1-1-1H5.21l-.94-2zm16 16c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              ME 0
+               / 
+              TE 0
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              tatara
+               / 
+              t1
+               / 
+              low
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              —
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="EditIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-1xcq121-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-q4vm8z-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="ChevronRightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                    />
+                  </svg>
+                </button>
+                <img
+                  alt=""
+                  height="24"
+                  src="https://images.evetech.net/types/4247/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="24"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-28s2xz-MuiTypography-root"
+                >
+                  Nitrogen Fuel Block
+                </p>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1wbc4rh-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  manufacturing
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1sz2u09-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  2
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-vg81k4"
+              >
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1816kef-MuiChip-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconSmall MuiChip-iconColorDefault css-g5bvlu-MuiSvgIcon-root"
+                    data-testid="BuildIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m22.7 19-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4"
+                    />
+                  </svg>
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    0
+                  </span>
+                </div>
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1816kef-MuiChip-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconSmall MuiChip-iconColorDefault css-g5bvlu-MuiSvgIcon-root"
+                    data-testid="ShoppingCartIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2M1 2v2h2l3.6 7.59-1.35 2.45c-.16.28-.25.61-.25.96 0 1.1.9 2 2 2h12v-2H7.42c-.14 0-.25-.11-.25-.25l.03-.12.9-1.63h7.45c.75 0 1.41-.41 1.75-1.03l3.58-6.49c.08-.14.12-.31.12-.48 0-.55-.45-1-1-1H5.21l-.94-2zm16 16c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2"
+                    />
+                  </svg>
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    ?
+                  </span>
+                </div>
+                <span
+                  aria-label="Set all materials to Build"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lvvih5-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                      data-testid="BuildIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m22.7 19-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4"
+                      />
+                    </svg>
+                  </button>
+                </span>
+                <span
+                  aria-label="Set all materials to Buy"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-lvvih5-MuiButtonBase-root-MuiIconButton-root"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                      data-testid="ShoppingCartIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2M1 2v2h2l3.6 7.59-1.35 2.45c-.16.28-.25.61-.25.96 0 1.1.9 2 2 2h12v-2H7.42c-.14 0-.25-.11-.25-.25l.03-.12.9-1.63h7.45c.75 0 1.41-.41 1.75-1.03l3.58-6.49c.08-.14.12-.31.12-.48 0-.55-.45-1-1-1H5.21l-.94-2zm16 16c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              ME 10
+               / 
+              TE 20
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              raitaru
+               / 
+              t2
+               / 
+              high
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              —
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="EditIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-1xcq121-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-q4vm8z-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="ChevronRightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                    />
+                  </svg>
+                </button>
+                <img
+                  alt=""
+                  height="24"
+                  src="https://images.evetech.net/types/587/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="24"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-28s2xz-MuiTypography-root"
+                >
+                  Rifter
+                </p>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1wbc4rh-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  manufacturing
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1sz2u09-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  1
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-vg81k4"
+              >
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-ngzb2m-MuiChip-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconSmall MuiChip-iconColorDefault css-g5bvlu-MuiSvgIcon-root"
+                    data-testid="BuildIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m22.7 19-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4"
+                    />
+                  </svg>
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    2
+                  </span>
+                </div>
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1816kef-MuiChip-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconSmall MuiChip-iconColorDefault css-g5bvlu-MuiSvgIcon-root"
+                    data-testid="ShoppingCartIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2M1 2v2h2l3.6 7.59-1.35 2.45c-.16.28-.25.61-.25.96 0 1.1.9 2 2 2h12v-2H7.42c-.14 0-.25-.11-.25-.25l.03-.12.9-1.63h7.45c.75 0 1.41-.41 1.75-1.03l3.58-6.49c.08-.14.12-.31.12-.48 0-.55-.45-1-1-1H5.21l-.94-2zm16 16c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2"
+                    />
+                  </svg>
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    ?
+                  </span>
+                </div>
+                <span
+                  aria-label="Set all materials to Build"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lvvih5-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                      data-testid="BuildIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m22.7 19-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4"
+                      />
+                    </svg>
+                  </button>
+                </span>
+                <span
+                  aria-label="Set all materials to Buy"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13y1t3b-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                      data-testid="ShoppingCartIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2M1 2v2h2l3.6 7.59-1.35 2.45c-.16.28-.25.61-.25.96 0 1.1.9 2 2 2h12v-2H7.42c-.14 0-.25-.11-.25-.25l.03-.12.9-1.63h7.45c.75 0 1.41-.41 1.75-1.03l3.58-6.49c.08-.14.12-.31.12-.48 0-.55-.45-1-1-1H5.21l-.94-2zm16 16c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              ME 10
+               / 
+              TE 20
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              raitaru
+               / 
+              t2
+               / 
+              high
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              —
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="EditIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/packages/components/industry/__tests__/__snapshots__/ProductionPlanEditor.test.tsx.snap
+++ b/frontend/packages/components/industry/__tests__/__snapshots__/ProductionPlanEditor.test.tsx.snap
@@ -1,0 +1,968 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ProductionPlanEditor Component should match snapshot while loading 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-8ptgxe"
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body1 css-1p2qead-MuiTypography-root"
+    >
+      Loading plan...
+    </p>
+  </div>
+</div>
+`;
+
+exports[`ProductionPlanEditor Component should match snapshot with loaded plan 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-0"
+  >
+    <div
+      class="MuiBox-root css-1kw3y0a"
+    >
+      <div
+        class="MuiBox-root css-axw7ok"
+      >
+        <img
+          alt=""
+          height="40"
+          src="https://images.evetech.net/types/587/icon?size=64"
+          style="border-radius: 4px;"
+          width="40"
+        />
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            class="MuiBox-root css-171onha"
+          >
+            <h5
+              class="MuiTypography-root MuiTypography-h5 css-119faas-MuiTypography-root"
+            >
+              Rifter Production
+            </h5>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-aqiitb-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="EditIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                />
+              </svg>
+            </button>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-su980v-MuiTypography-root"
+          >
+            1
+             production step(s)
+          </p>
+        </div>
+      </div>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-7mo8ij-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </span>
+        Generate Jobs
+      </button>
+    </div>
+    <div
+      class="MuiBox-root css-14ddptj"
+    >
+      <div
+        class="MuiTabs-root css-1mjdata-MuiTabs-root"
+      >
+        <div
+          class="MuiTabs-scroller MuiTabs-fixed css-s2t35c-MuiTabs-scroller"
+          style="overflow: hidden; margin-bottom: 0px;"
+        >
+          <div
+            class="MuiTabs-list MuiTabs-flexContainer css-hzcega-MuiTabs-list"
+            role="tablist"
+          >
+            <button
+              aria-selected="true"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-1usuzwp-MuiButtonBase-root-MuiTab-root"
+              role="tab"
+              tabindex="0"
+              type="button"
+            >
+              Step Tree
+            </button>
+            <button
+              aria-selected="false"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1usuzwp-MuiButtonBase-root-MuiTab-root"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              Batch Configure
+            </button>
+          </div>
+          <span
+            class="MuiTabs-indicator css-1qltlow-MuiTabs-indicator"
+            style="left: 0px; width: 0px;"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root css-s09dh4-MuiPaper-root-MuiTableContainer-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <table
+        class="MuiTable-root css-1xwxv7r-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+        >
+          <tr
+            class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Item / Material
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              ME / TE
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Structure / Rig / Sec
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Station
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+              scope="col"
+            >
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root css-5e6sxz-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-11tgup3-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-hhy3b5"
+              />
+              <div
+                class="MuiBox-root css-s4z0eu"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-q4vm8z-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="ExpandMoreIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                    />
+                  </svg>
+                </button>
+                <img
+                  alt=""
+                  height="20"
+                  src="https://images.evetech.net/types/587/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="20"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-zi49lp-MuiTypography-root"
+                >
+                  Rifter
+                </p>
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-rpub5i-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    manufacturing
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              ME 
+              10
+               / TE 
+              20
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              raitaru
+               / 
+              t2
+               / 
+              high
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              —
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-1fsnhek-MuiTypography-root"
+              >
+                Out: set at build time
+              </p>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="EditIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-blpnon-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-11tgup3-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-hhy3b5"
+              />
+              <div
+                class="MuiBox-root css-en4xye"
+              >
+                <img
+                  alt=""
+                  height="18"
+                  src="https://images.evetech.net/types/11399/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="18"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-eyjz4m-MuiTypography-root"
+                >
+                  Morphite
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-112eisb-MuiTypography-root"
+                >
+                  x
+                  10
+                </p>
+                <div
+                  class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorDefault MuiChip-outlinedDefault css-1443fb0-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+                  >
+                    Buy
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9xp16b-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                title="Switch to Produce"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="BuildIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m22.7 19-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-blpnon-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-11tgup3-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-hhy3b5"
+              />
+              <div
+                class="MuiBox-root css-en4xye"
+              >
+                <img
+                  alt=""
+                  height="18"
+                  src="https://images.evetech.net/types/34/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="18"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-eyjz4m-MuiTypography-root"
+                >
+                  Tritanium
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-112eisb-MuiTypography-root"
+                >
+                  x
+                  22222
+                </p>
+                <div
+                  class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorDefault MuiChip-outlinedDefault css-1443fb0-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+                  >
+                    Buy
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            />
+          </tr>
+          <tr
+            class="MuiTableRow-root css-blpnon-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-11tgup3-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-hhy3b5"
+              />
+              <div
+                class="MuiBox-root css-en4xye"
+              >
+                <img
+                  alt=""
+                  height="18"
+                  src="https://images.evetech.net/types/35/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="18"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-eyjz4m-MuiTypography-root"
+                >
+                  Pyerite
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-112eisb-MuiTypography-root"
+                >
+                  x
+                  5555
+                </p>
+                <div
+                  class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorDefault MuiChip-outlinedDefault css-1443fb0-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+                  >
+                    Buy
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ProductionPlanEditor Component should match snapshot with multi-step plan 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-0"
+  >
+    <div
+      class="MuiBox-root css-1kw3y0a"
+    >
+      <div
+        class="MuiBox-root css-axw7ok"
+      >
+        <img
+          alt=""
+          height="40"
+          src="https://images.evetech.net/types/587/icon?size=64"
+          style="border-radius: 4px;"
+          width="40"
+        />
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            class="MuiBox-root css-171onha"
+          >
+            <h5
+              class="MuiTypography-root MuiTypography-h5 css-119faas-MuiTypography-root"
+            >
+              Rifter Production
+            </h5>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-aqiitb-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="EditIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                />
+              </svg>
+            </button>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-su980v-MuiTypography-root"
+          >
+            2
+             production step(s)
+          </p>
+        </div>
+      </div>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-7mo8ij-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </span>
+        Generate Jobs
+      </button>
+    </div>
+    <div
+      class="MuiBox-root css-14ddptj"
+    >
+      <div
+        class="MuiTabs-root css-1mjdata-MuiTabs-root"
+      >
+        <div
+          class="MuiTabs-scroller MuiTabs-fixed css-s2t35c-MuiTabs-scroller"
+          style="overflow: hidden; margin-bottom: 0px;"
+        >
+          <div
+            class="MuiTabs-list MuiTabs-flexContainer css-hzcega-MuiTabs-list"
+            role="tablist"
+          >
+            <button
+              aria-selected="true"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-1usuzwp-MuiButtonBase-root-MuiTab-root"
+              role="tab"
+              tabindex="0"
+              type="button"
+            >
+              Step Tree
+            </button>
+            <button
+              aria-selected="false"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1usuzwp-MuiButtonBase-root-MuiTab-root"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              Batch Configure
+            </button>
+          </div>
+          <span
+            class="MuiTabs-indicator css-1qltlow-MuiTabs-indicator"
+            style="left: 0px; width: 0px;"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root css-s09dh4-MuiPaper-root-MuiTableContainer-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <table
+        class="MuiTable-root css-1xwxv7r-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+        >
+          <tr
+            class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Item / Material
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              ME / TE
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Structure / Rig / Sec
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Station
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+              scope="col"
+            >
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root css-5e6sxz-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-11tgup3-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-hhy3b5"
+              />
+              <div
+                class="MuiBox-root css-s4z0eu"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-q4vm8z-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="ExpandMoreIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                    />
+                  </svg>
+                </button>
+                <img
+                  alt=""
+                  height="20"
+                  src="https://images.evetech.net/types/587/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="20"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-zi49lp-MuiTypography-root"
+                >
+                  Rifter
+                </p>
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-rpub5i-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    manufacturing
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              ME 
+              10
+               / TE 
+              20
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              raitaru
+               / 
+              t2
+               / 
+              high
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              —
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-1fsnhek-MuiTypography-root"
+              >
+                Out: set at build time
+              </p>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="EditIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-1xcq121-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-11tgup3-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-hhy3b5"
+              />
+              <div
+                class="MuiBox-root css-1yjp461"
+              />
+              <div
+                class="MuiBox-root css-en4xye"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-q4vm8z-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="ChevronRightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                    />
+                  </svg>
+                </button>
+                <img
+                  alt=""
+                  height="20"
+                  src="https://images.evetech.net/types/11399/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="20"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-oo4rfn-MuiTypography-root"
+                >
+                  Morphite
+                </p>
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-16abibo-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    reaction
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              ME 
+              0
+               / TE 
+              0
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              raitaru
+               / 
+              t2
+               / 
+              low
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              —
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="EditIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                  />
+                </svg>
+              </button>
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="DeleteIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-blpnon-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-11tgup3-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-hhy3b5"
+              />
+              <div
+                class="MuiBox-root css-en4xye"
+              >
+                <img
+                  alt=""
+                  height="18"
+                  src="https://images.evetech.net/types/34/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="18"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-eyjz4m-MuiTypography-root"
+                >
+                  Tritanium
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-112eisb-MuiTypography-root"
+                >
+                  x
+                  22222
+                </p>
+                <div
+                  class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorDefault MuiChip-outlinedDefault css-1443fb0-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+                  >
+                    Buy
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            />
+          </tr>
+          <tr
+            class="MuiTableRow-root css-blpnon-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-11tgup3-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-hhy3b5"
+              />
+              <div
+                class="MuiBox-root css-en4xye"
+              >
+                <img
+                  alt=""
+                  height="18"
+                  src="https://images.evetech.net/types/35/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="18"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-eyjz4m-MuiTypography-root"
+                >
+                  Pyerite
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-112eisb-MuiTypography-root"
+                >
+                  x
+                  5555
+                </p>
+                <div
+                  class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorDefault MuiChip-outlinedDefault css-1443fb0-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+                  >
+                    Buy
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            />
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/packages/components/industry/__tests__/__snapshots__/ProductionPlansList.test.tsx.snap
+++ b/frontend/packages/components/industry/__tests__/__snapshots__/ProductionPlansList.test.tsx.snap
@@ -1,0 +1,356 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ProductionPlansList Component should match snapshot while loading 1`] = `
+<div>
+  <div
+    data-testid="navbar"
+  >
+    Navbar
+  </div>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthXl css-lkiw04-MuiContainer-root"
+  >
+    <div
+      class="MuiBox-root css-1kw3y0a"
+    >
+      <h5
+        class="MuiTypography-root MuiTypography-h5 css-119faas-MuiTypography-root"
+      >
+        Production Plans
+      </h5>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1nttctm-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="AddIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+            />
+          </svg>
+        </span>
+        New Plan
+      </button>
+    </div>
+    <div
+      data-testid="loading"
+    >
+      Loading...
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ProductionPlansList Component should match snapshot with empty plans 1`] = `
+<div>
+  <div
+    data-testid="navbar"
+  >
+    Navbar
+  </div>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthXl css-lkiw04-MuiContainer-root"
+  >
+    <div
+      class="MuiBox-root css-1kw3y0a"
+    >
+      <h5
+        class="MuiTypography-root MuiTypography-h5 css-119faas-MuiTypography-root"
+      >
+        Production Plans
+      </h5>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1nttctm-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="AddIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+            />
+          </svg>
+        </span>
+        New Plan
+      </button>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-57it44-MuiPaper-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1 css-1p2qead-MuiTypography-root"
+      >
+        No production plans yet. Create one to define how items should be produced.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ProductionPlansList Component should match snapshot with plans 1`] = `
+<div>
+  <div
+    data-testid="navbar"
+  >
+    Navbar
+  </div>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthXl css-lkiw04-MuiContainer-root"
+  >
+    <div
+      class="MuiBox-root css-1kw3y0a"
+    >
+      <h5
+        class="MuiTypography-root MuiTypography-h5 css-119faas-MuiTypography-root"
+      >
+        Production Plans
+      </h5>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1nttctm-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="AddIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+            />
+          </svg>
+        </span>
+        New Plan
+      </button>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root css-s09dh4-MuiPaper-root-MuiTableContainer-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <table
+        class="MuiTable-root css-1xwxv7r-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+        >
+          <tr
+            class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Product
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Plan Name
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+              scope="col"
+            >
+              Steps
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Created
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+              scope="col"
+            >
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root css-13pprm5-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-axw7ok"
+              >
+                <img
+                  alt=""
+                  height="24"
+                  src="https://images.evetech.net/types/587/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="24"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-28s2xz-MuiTypography-root"
+                >
+                  Rifter
+                </p>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1akr5kn-MuiTableCell-root"
+            >
+              Rifter Production
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-1aqdq1-MuiTableCell-root"
+            >
+              1
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-hfnm0i-MuiTableCell-root"
+            >
+              2/22/2026
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="EditIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                  />
+                </svg>
+              </button>
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="DeleteIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-e5f821-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-axw7ok"
+              >
+                <img
+                  alt=""
+                  height="24"
+                  src="https://images.evetech.net/types/11379/icon?size=32"
+                  style="border-radius: 2px;"
+                  width="24"
+                />
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-28s2xz-MuiTypography-root"
+                >
+                  Muninn
+                </p>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1akr5kn-MuiTableCell-root"
+            >
+              Muninn Production
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-1aqdq1-MuiTableCell-root"
+            >
+              2
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-hfnm0i-MuiTableCell-root"
+            >
+              2/22/2026
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="EditIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                  />
+                </svg>
+              </button>
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="DeleteIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/packages/components/stations/StationDialog.tsx
+++ b/frontend/packages/components/stations/StationDialog.tsx
@@ -1,0 +1,494 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  UserStation,
+  UserStationRig,
+  UserStationService,
+  ScanResult,
+} from "@industry-tool/client/data/models";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Autocomplete from "@mui/material/Autocomplete";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AddIcon from "@mui/icons-material/Add";
+
+type StationOption = {
+  stationId: number;
+  name: string;
+  solarSystemName: string;
+};
+
+interface Props {
+  open: boolean;
+  station: UserStation | null;
+  onClose: (saved: boolean) => void;
+}
+
+const rigCategories = ["ship", "component", "equipment", "ammo", "drone", "reaction", "reprocessing"];
+const rigTiers = ["t1", "t2"];
+
+const getCategoryColor = (category: string) => {
+  switch (category) {
+    case "ship": return "#3b82f6";
+    case "component": return "#8b5cf6";
+    case "equipment": return "#10b981";
+    case "ammo": return "#f59e0b";
+    case "drone": return "#06b6d4";
+    case "reaction": return "#ec4899";
+    case "reprocessing": return "#f97316";
+    default: return "#94a3b8";
+  }
+};
+
+export default function StationDialog({ open, station, onClose }: Props) {
+  const isEdit = !!station;
+
+  const [stationOptions, setStationOptions] = useState<StationOption[]>([]);
+  const [stationSearchLoading, setStationSearchLoading] = useState(false);
+  const [selectedStation, setSelectedStation] = useState<StationOption | null>(null);
+
+  const [structure, setStructure] = useState("raitaru");
+  const [facilityTax, setFacilityTax] = useState(1.0);
+  const [rigs, setRigs] = useState<{ rigName: string; category: string; tier: string }[]>([]);
+  const [services, setServices] = useState<{ serviceName: string; activity: string }[]>([]);
+
+  const [scanText, setScanText] = useState("");
+  const [scanParsing, setScanParsing] = useState(false);
+
+  const [saving, setSaving] = useState(false);
+
+  const stationSearchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (station) {
+      setSelectedStation({
+        stationId: station.stationId,
+        name: station.stationName || "",
+        solarSystemName: station.solarSystemName || "",
+      });
+      setStructure(station.structure);
+      setFacilityTax(station.facilityTax);
+      setRigs(
+        station.rigs.map((r) => ({
+          rigName: r.rigName,
+          category: r.category,
+          tier: r.tier,
+        })),
+      );
+      setServices(
+        station.services.map((s) => ({
+          serviceName: s.serviceName,
+          activity: s.activity,
+        })),
+      );
+    } else {
+      setSelectedStation(null);
+      setStructure("raitaru");
+      setFacilityTax(1.0);
+      setRigs([]);
+      setServices([]);
+      setScanText("");
+    }
+    setStationOptions([]);
+  }, [station, open]);
+
+  const searchStations = useCallback(async (query: string) => {
+    if (!query || query.length < 2) {
+      setStationOptions([]);
+      return;
+    }
+
+    setStationSearchLoading(true);
+    try {
+      const res = await fetch(`/api/stations/search?q=${encodeURIComponent(query)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setStationOptions(data || []);
+      }
+    } catch (err) {
+      console.error("Failed to search stations:", err);
+      setStationOptions([]);
+    } finally {
+      setStationSearchLoading(false);
+    }
+  }, []);
+
+  const handleStationSearch = (value: string) => {
+    if (stationSearchTimeoutRef.current) {
+      clearTimeout(stationSearchTimeoutRef.current);
+    }
+    stationSearchTimeoutRef.current = setTimeout(() => {
+      searchStations(value);
+    }, 300);
+  };
+
+  const handleParseScan = async () => {
+    if (!scanText.trim()) return;
+
+    setScanParsing(true);
+    try {
+      const res = await fetch("/api/stations/parse-scan", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scanText: scanText.trim() }),
+      });
+
+      if (res.ok) {
+        const data: ScanResult = await res.json();
+        if (data.structure) {
+          setStructure(data.structure);
+        }
+        if (data.rigs?.length > 0) {
+          setRigs(
+            data.rigs.map((r) => ({
+              rigName: r.name,
+              category: r.category,
+              tier: r.tier,
+            })),
+          );
+        }
+        if (data.services?.length > 0) {
+          setServices(
+            data.services.map((s) => ({
+              serviceName: s.name,
+              activity: s.activity,
+            })),
+          );
+        }
+      }
+    } catch (err) {
+      console.error("Failed to parse scan:", err);
+    } finally {
+      setScanParsing(false);
+    }
+  };
+
+  const handleAddRig = () => {
+    setRigs([...rigs, { rigName: "", category: "ship", tier: "t1" }]);
+  };
+
+  const handleRemoveRig = (index: number) => {
+    setRigs(rigs.filter((_, i) => i !== index));
+  };
+
+  const handleRigChange = (index: number, field: string, value: string) => {
+    const updated = [...rigs];
+    updated[index] = { ...updated[index], [field]: value };
+    setRigs(updated);
+  };
+
+  const handleSave = async () => {
+    if (!selectedStation) return;
+
+    setSaving(true);
+    try {
+      const payload = {
+        stationId: selectedStation.stationId,
+        structure,
+        facilityTax,
+        rigs: rigs.map((r) => ({
+          rigName: r.rigName,
+          category: r.category,
+          tier: r.tier,
+        })),
+        services: services.map((s) => ({
+          serviceName: s.serviceName,
+          activity: s.activity,
+        })),
+      };
+
+      const url = isEdit
+        ? `/api/stations/user-stations/${station!.id}`
+        : "/api/stations/user-stations";
+      const method = isEdit ? "PUT" : "POST";
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (res.ok) {
+        onClose(true);
+      }
+    } catch (err) {
+      console.error("Failed to save station:", err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => onClose(false)}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: { backgroundColor: "#12151f", color: "#e2e8f0" },
+      }}
+    >
+      <DialogTitle>{isEdit ? "Edit Station" : "Add Station"}</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+          {/* Station Search */}
+          <Autocomplete
+            value={selectedStation}
+            onChange={(_, newValue) => setSelectedStation(newValue)}
+            onInputChange={(_, value) => handleStationSearch(value)}
+            options={stationOptions}
+            getOptionLabel={(option) => option.name}
+            isOptionEqualToValue={(option, value) =>
+              option.stationId === value.stationId
+            }
+            loading={stationSearchLoading}
+            disabled={isEdit}
+            filterOptions={(x) => x}
+            renderOption={(props, option) => (
+              <Box component="li" {...props}>
+                <Box>
+                  <Typography variant="body2">{option.name}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {option.solarSystemName}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Station"
+                placeholder="Search for a station..."
+                InputProps={{
+                  ...params.InputProps,
+                  endAdornment: (
+                    <>
+                      {stationSearchLoading ? (
+                        <CircularProgress color="inherit" size={20} />
+                      ) : null}
+                      {params.InputProps.endAdornment}
+                    </>
+                  ),
+                }}
+              />
+            )}
+          />
+
+          {/* Scan Input */}
+          <TextField
+            label="Structure Fitting Scan"
+            multiline
+            rows={4}
+            value={scanText}
+            onChange={(e) => setScanText(e.target.value)}
+            placeholder="Paste structure fitting scan here..."
+            sx={{ "& .MuiInputBase-input": { fontSize: 13 } }}
+          />
+          <Button
+            variant="outlined"
+            onClick={handleParseScan}
+            disabled={!scanText.trim() || scanParsing}
+            sx={{ alignSelf: "flex-start" }}
+          >
+            {scanParsing ? "Parsing..." : "Parse Scan"}
+          </Button>
+
+          {/* Structure */}
+          <FormControl fullWidth>
+            <InputLabel>Structure</InputLabel>
+            <Select
+              value={structure}
+              label="Structure"
+              onChange={(e) => setStructure(e.target.value)}
+            >
+              <MenuItem value="raitaru">Raitaru</MenuItem>
+              <MenuItem value="azbel">Azbel</MenuItem>
+              <MenuItem value="sotiyo">Sotiyo</MenuItem>
+              <MenuItem value="athanor">Athanor</MenuItem>
+              <MenuItem value="tatara">Tatara</MenuItem>
+            </Select>
+          </FormControl>
+
+          {/* Facility Tax */}
+          <TextField
+            type="number"
+            label="Facility Tax %"
+            value={facilityTax}
+            onChange={(e) => setFacilityTax(parseFloat(e.target.value) || 0)}
+            inputProps={{ min: 0, step: 0.1 }}
+          />
+
+          {/* Services */}
+          {services.length > 0 && (
+            <Box>
+              <Typography
+                variant="subtitle2"
+                sx={{ color: "#94a3b8", mb: 0.5 }}
+              >
+                Services
+              </Typography>
+              <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+                {services.map((svc, i) => (
+                  <Chip
+                    key={i}
+                    label={svc.serviceName}
+                    size="small"
+                    sx={{
+                      backgroundColor:
+                        svc.activity === "manufacturing"
+                          ? "#3b82f620"
+                          : "#ec489920",
+                      color:
+                        svc.activity === "manufacturing"
+                          ? "#3b82f6"
+                          : "#ec4899",
+                      fontSize: "0.75rem",
+                    }}
+                  />
+                ))}
+              </Box>
+            </Box>
+          )}
+
+          {/* Rigs */}
+          <Box>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                mb: 1,
+              }}
+            >
+              <Typography
+                variant="subtitle2"
+                sx={{ color: "#94a3b8" }}
+              >
+                Rigs
+              </Typography>
+              <Button
+                size="small"
+                startIcon={<AddIcon />}
+                onClick={handleAddRig}
+              >
+                Add Rig
+              </Button>
+            </Box>
+
+            {rigs.length === 0 && (
+              <Typography sx={{ color: "#64748b", fontSize: 13 }}>
+                No rigs. Paste a scan or add manually.
+              </Typography>
+            )}
+
+            {rigs.map((rig, index) => (
+              <Box
+                key={index}
+                sx={{
+                  display: "flex",
+                  gap: 1,
+                  mb: 1,
+                  alignItems: "center",
+                }}
+              >
+                <FormControl size="small" sx={{ minWidth: 140 }}>
+                  <InputLabel>Category</InputLabel>
+                  <Select
+                    value={rig.category}
+                    label="Category"
+                    onChange={(e) =>
+                      handleRigChange(index, "category", e.target.value)
+                    }
+                  >
+                    {rigCategories.map((cat) => (
+                      <MenuItem key={cat} value={cat}>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                          <Box
+                            sx={{
+                              width: 8,
+                              height: 8,
+                              borderRadius: "50%",
+                              backgroundColor: getCategoryColor(cat),
+                            }}
+                          />
+                          <span style={{ textTransform: "capitalize" }}>{cat}</span>
+                        </Box>
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <FormControl size="small" sx={{ minWidth: 80 }}>
+                  <InputLabel>Tier</InputLabel>
+                  <Select
+                    value={rig.tier}
+                    label="Tier"
+                    onChange={(e) =>
+                      handleRigChange(index, "tier", e.target.value)
+                    }
+                  >
+                    {rigTiers.map((t) => (
+                      <MenuItem key={t} value={t}>
+                        {t.toUpperCase()}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <Typography
+                  sx={{
+                    color: "#64748b",
+                    fontSize: 12,
+                    flex: 1,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                  title={rig.rigName}
+                >
+                  {rig.rigName || "Manual"}
+                </Typography>
+
+                <IconButton
+                  size="small"
+                  onClick={() => handleRemoveRig(index)}
+                  sx={{ color: "#ef4444" }}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => onClose(false)} sx={{ color: "#94a3b8" }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          disabled={!selectedStation || saving}
+          variant="contained"
+          sx={{
+            backgroundColor: "#3b82f6",
+            "&:hover": { backgroundColor: "#2563eb" },
+          }}
+        >
+          {saving ? "Saving..." : isEdit ? "Update" : "Add"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/packages/components/stations/StationsList.tsx
+++ b/frontend/packages/components/stations/StationsList.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import { UserStation } from "@industry-tool/client/data/models";
+import StationDialog from "./StationDialog";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AddIcon from "@mui/icons-material/Add";
+
+interface Props {
+  stations: UserStation[];
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+const getSecurityColor = (security: string) => {
+  switch (security) {
+    case "high": return "#10b981";
+    case "low": return "#f59e0b";
+    case "null": return "#ef4444";
+    default: return "#94a3b8";
+  }
+};
+
+const getCategoryColor = (category: string) => {
+  switch (category) {
+    case "ship": return "#3b82f6";
+    case "component": return "#8b5cf6";
+    case "equipment": return "#10b981";
+    case "ammo": return "#f59e0b";
+    case "drone": return "#06b6d4";
+    case "reaction": return "#ec4899";
+    case "reprocessing": return "#f97316";
+    default: return "#94a3b8";
+  }
+};
+
+export default function StationsList({ stations, loading, onRefresh }: Props) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editStation, setEditStation] = useState<UserStation | null>(null);
+
+  const handleAdd = () => {
+    setEditStation(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (station: UserStation) => {
+    setEditStation(station);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = async (station: UserStation) => {
+    if (!confirm(`Delete station "${station.stationName}"?`)) return;
+
+    try {
+      const res = await fetch(`/api/stations/user-stations/${station.id}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        onRefresh();
+      }
+    } catch (err) {
+      console.error("Failed to delete station:", err);
+    }
+  };
+
+  const handleDialogClose = (saved: boolean) => {
+    setDialogOpen(false);
+    setEditStation(null);
+    if (saved) {
+      onRefresh();
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <Box sx={{ mb: 2 }}>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleAdd}>
+          Add Station
+        </Button>
+      </Box>
+
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow sx={{ backgroundColor: "#0f1219" }}>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Station</TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>System</TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Security</TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Structure</TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Activities</TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Rigs</TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Tax</TableCell>
+              <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {stations.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} align="center" sx={{ color: "#64748b", py: 4 }}>
+                  No preferred stations configured. Click &quot;Add Station&quot; to get started.
+                </TableCell>
+              </TableRow>
+            ) : (
+              stations.map((station) => (
+                <TableRow key={station.id} sx={{ "&:hover": { backgroundColor: "rgba(59, 130, 246, 0.05)" } }}>
+                  <TableCell sx={{ color: "#e2e8f0" }}>{station.stationName}</TableCell>
+                  <TableCell sx={{ color: "#94a3b8" }}>{station.solarSystemName}</TableCell>
+                  <TableCell>
+                    <Chip
+                      label={station.security}
+                      size="small"
+                      sx={{
+                        backgroundColor: `${getSecurityColor(station.security || "")}20`,
+                        color: getSecurityColor(station.security || ""),
+                        fontWeight: 600,
+                        textTransform: "capitalize",
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", textTransform: "capitalize" }}>
+                    {station.structure}
+                  </TableCell>
+                  <TableCell>
+                    <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+                      {station.activities.map((activity) => (
+                        <Chip
+                          key={activity}
+                          label={activity}
+                          size="small"
+                          sx={{
+                            backgroundColor: activity === "manufacturing" ? "#3b82f620" : "#ec489920",
+                            color: activity === "manufacturing" ? "#3b82f6" : "#ec4899",
+                            textTransform: "capitalize",
+                            fontSize: "0.7rem",
+                          }}
+                        />
+                      ))}
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+                      {station.rigs.map((rig) => (
+                        <Chip
+                          key={rig.id}
+                          label={`${rig.category} ${rig.tier.toUpperCase()}`}
+                          size="small"
+                          sx={{
+                            backgroundColor: `${getCategoryColor(rig.category)}20`,
+                            color: getCategoryColor(rig.category),
+                            fontSize: "0.7rem",
+                          }}
+                        />
+                      ))}
+                      {station.rigs.length === 0 && (
+                        <span style={{ color: "#64748b", fontSize: "0.8rem" }}>None</span>
+                      )}
+                    </Box>
+                  </TableCell>
+                  <TableCell align="right" sx={{ color: "#94a3b8" }}>
+                    {station.facilityTax}%
+                  </TableCell>
+                  <TableCell align="right">
+                    <IconButton size="small" onClick={() => handleEdit(station)} sx={{ color: "#3b82f6" }}>
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" onClick={() => handleDelete(station)} sx={{ color: "#ef4444" }}>
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <StationDialog
+        open={dialogOpen}
+        station={editStation}
+        onClose={handleDialogClose}
+      />
+    </>
+  );
+}

--- a/frontend/packages/components/stations/__tests__/StationDialog.test.tsx
+++ b/frontend/packages/components/stations/__tests__/StationDialog.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import StationDialog from '../StationDialog';
+import { UserStation } from '@industry-tool/client/data/models';
+
+const mockStation: UserStation = {
+  id: 1,
+  userId: 100,
+  stationId: 60003760,
+  structure: 'sotiyo',
+  facilityTax: 1.0,
+  createdAt: '2026-02-22T12:00:00Z',
+  updatedAt: '2026-02-22T12:00:00Z',
+  stationName: 'Test Sotiyo',
+  solarSystemName: 'Jita',
+  securityStatus: 0.9,
+  security: 'high',
+  rigs: [
+    { id: 1, userStationId: 1, rigName: 'Standup XL-Set Ship Manufacturing Efficiency I', category: 'ship', tier: 't1' },
+    { id: 2, userStationId: 1, rigName: 'Standup XL-Set Structure and Component Manufacturing Efficiency I', category: 'component', tier: 't1' },
+  ],
+  services: [
+    { id: 1, userStationId: 1, serviceName: 'Standup Manufacturing Plant I', activity: 'manufacturing' },
+  ],
+  activities: ['manufacturing'],
+};
+
+describe('StationDialog Component', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it('should match snapshot when closed', () => {
+    const { container } = render(
+      <StationDialog open={false} station={null} onClose={jest.fn()} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should match snapshot when open for adding', () => {
+    const { baseElement } = render(
+      <StationDialog open={true} station={null} onClose={jest.fn()} />,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should match snapshot when open for editing', () => {
+    const { baseElement } = render(
+      <StationDialog open={true} station={mockStation} onClose={jest.fn()} />,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should display Add Station title when creating', () => {
+    render(
+      <StationDialog open={true} station={null} onClose={jest.fn()} />,
+    );
+    expect(screen.getByText('Add Station')).toBeInTheDocument();
+  });
+
+  it('should display Edit Station title when editing', () => {
+    render(
+      <StationDialog open={true} station={mockStation} onClose={jest.fn()} />,
+    );
+    expect(screen.getByText('Edit Station')).toBeInTheDocument();
+  });
+
+  it('should populate fields when editing', () => {
+    render(
+      <StationDialog open={true} station={mockStation} onClose={jest.fn()} />,
+    );
+
+    // Structure should be pre-filled
+    expect(screen.getByText('Sotiyo')).toBeInTheDocument();
+
+    // Rig names should be shown as title attributes on rig rows
+    expect(screen.getByTitle('Standup XL-Set Ship Manufacturing Efficiency I')).toBeInTheDocument();
+    expect(screen.getByTitle('Standup XL-Set Structure and Component Manufacturing Efficiency I')).toBeInTheDocument();
+
+    // Services should be displayed
+    expect(screen.getByText('Standup Manufacturing Plant I')).toBeInTheDocument();
+  });
+
+  it('should disable station search when editing', () => {
+    render(
+      <StationDialog open={true} station={mockStation} onClose={jest.fn()} />,
+    );
+
+    const stationInput = screen.getByLabelText('Station');
+    expect(stationInput).toBeDisabled();
+  });
+
+  it('should call onClose(false) when Cancel is clicked', () => {
+    const onClose = jest.fn();
+    render(
+      <StationDialog open={true} station={null} onClose={onClose} />,
+    );
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+
+  it('should disable Add button when no station is selected', () => {
+    render(
+      <StationDialog open={true} station={null} onClose={jest.fn()} />,
+    );
+
+    const addButton = screen.getByText('Add');
+    expect(addButton.closest('button')).toBeDisabled();
+  });
+
+  it('should parse scan when Parse Scan button is clicked', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        structure: 'sotiyo',
+        rigs: [
+          { name: 'Standup XL-Set Ship Manufacturing Efficiency I', category: 'ship', tier: 't1' },
+        ],
+        services: [
+          { name: 'Standup Manufacturing Plant I', activity: 'manufacturing' },
+        ],
+      }),
+    });
+
+    render(
+      <StationDialog open={true} station={null} onClose={jest.fn()} />,
+    );
+
+    const scanInput = screen.getByLabelText('Structure Fitting Scan');
+    fireEvent.change(scanInput, {
+      target: { value: 'Rig Slots\nStandup XL-Set Ship Manufacturing Efficiency I\nService Slots\nStandup Manufacturing Plant I' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Parse Scan'));
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/stations/parse-scan',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  it('should disable Parse Scan button when scan text is empty', () => {
+    render(
+      <StationDialog open={true} station={null} onClose={jest.fn()} />,
+    );
+
+    const parseButton = screen.getByText('Parse Scan');
+    expect(parseButton.closest('button')).toBeDisabled();
+  });
+
+  it('should add manual rig when Add Rig is clicked', () => {
+    render(
+      <StationDialog open={true} station={null} onClose={jest.fn()} />,
+    );
+
+    expect(screen.getByText('No rigs. Paste a scan or add manually.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Add Rig'));
+
+    // Should now have a rig row with category and tier selects
+    expect(screen.queryByText('No rigs. Paste a scan or add manually.')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/packages/components/stations/__tests__/StationsList.test.tsx
+++ b/frontend/packages/components/stations/__tests__/StationsList.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import StationsList from '../StationsList';
+import { UserStation } from '@industry-tool/client/data/models';
+
+jest.mock('../StationDialog', () => {
+  return function MockStationDialog({ open, station, onClose }: any) {
+    if (!open) return null;
+    return (
+      <div data-testid="station-dialog">
+        <span>{station ? 'Edit' : 'Add'} Station Dialog</span>
+        <button onClick={() => onClose(false)}>Close</button>
+      </div>
+    );
+  };
+});
+
+const mockStations: UserStation[] = [
+  {
+    id: 1,
+    userId: 100,
+    stationId: 60003760,
+    structure: 'sotiyo',
+    facilityTax: 1.0,
+    createdAt: '2026-02-22T12:00:00Z',
+    updatedAt: '2026-02-22T12:00:00Z',
+    stationName: 'Test Sotiyo',
+    solarSystemName: 'Jita',
+    securityStatus: 0.9,
+    security: 'high',
+    rigs: [
+      { id: 1, userStationId: 1, rigName: 'Standup XL-Set Ship Manufacturing Efficiency I', category: 'ship', tier: 't1' },
+      { id: 2, userStationId: 1, rigName: 'Standup XL-Set Structure and Component Manufacturing Efficiency I', category: 'component', tier: 't1' },
+    ],
+    services: [
+      { id: 1, userStationId: 1, serviceName: 'Standup Manufacturing Plant I', activity: 'manufacturing' },
+    ],
+    activities: ['manufacturing'],
+  },
+  {
+    id: 2,
+    userId: 100,
+    stationId: 60003761,
+    structure: 'tatara',
+    facilityTax: 2.5,
+    createdAt: '2026-02-22T12:00:00Z',
+    updatedAt: '2026-02-22T12:00:00Z',
+    stationName: 'Test Tatara',
+    solarSystemName: 'Perimeter',
+    securityStatus: 0.3,
+    security: 'low',
+    rigs: [
+      { id: 3, userStationId: 2, rigName: 'Standup L-Set Biochemical Reactor Efficiency II', category: 'reaction', tier: 't2' },
+    ],
+    services: [
+      { id: 2, userStationId: 2, serviceName: 'Standup Biochemical Reactor I', activity: 'reaction' },
+    ],
+    activities: ['reaction'],
+  },
+];
+
+describe('StationsList Component', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it('should match snapshot while loading', () => {
+    const { container } = render(
+      <StationsList stations={[]} loading={true} onRefresh={jest.fn()} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should match snapshot with empty stations', () => {
+    const { container } = render(
+      <StationsList stations={[]} loading={false} onRefresh={jest.fn()} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should match snapshot with stations', () => {
+    const { container } = render(
+      <StationsList stations={mockStations} loading={false} onRefresh={jest.fn()} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display empty message when no stations', () => {
+    render(
+      <StationsList stations={[]} loading={false} onRefresh={jest.fn()} />,
+    );
+    expect(screen.getByText(/No preferred stations configured/)).toBeInTheDocument();
+  });
+
+  it('should display station details', () => {
+    render(
+      <StationsList stations={mockStations} loading={false} onRefresh={jest.fn()} />,
+    );
+
+    expect(screen.getByText('Test Sotiyo')).toBeInTheDocument();
+    expect(screen.getByText('Jita')).toBeInTheDocument();
+    expect(screen.getByText('high')).toBeInTheDocument();
+    expect(screen.getByText('sotiyo')).toBeInTheDocument();
+
+    expect(screen.getByText('Test Tatara')).toBeInTheDocument();
+    expect(screen.getByText('Perimeter')).toBeInTheDocument();
+    expect(screen.getByText('low')).toBeInTheDocument();
+  });
+
+  it('should display rig chips', () => {
+    render(
+      <StationsList stations={mockStations} loading={false} onRefresh={jest.fn()} />,
+    );
+
+    expect(screen.getByText('ship T1')).toBeInTheDocument();
+    expect(screen.getByText('component T1')).toBeInTheDocument();
+    expect(screen.getByText('reaction T2')).toBeInTheDocument();
+  });
+
+  it('should display activity chips', () => {
+    render(
+      <StationsList stations={mockStations} loading={false} onRefresh={jest.fn()} />,
+    );
+
+    expect(screen.getAllByText('manufacturing')).toHaveLength(1);
+    expect(screen.getAllByText('reaction')).toHaveLength(1);
+  });
+
+  it('should open add dialog when Add Station is clicked', () => {
+    render(
+      <StationsList stations={mockStations} loading={false} onRefresh={jest.fn()} />,
+    );
+
+    fireEvent.click(screen.getByText('Add Station'));
+    expect(screen.getByTestId('station-dialog')).toBeInTheDocument();
+    expect(screen.getByText('Add Station Dialog')).toBeInTheDocument();
+  });
+
+  it('should open edit dialog when edit button is clicked', () => {
+    render(
+      <StationsList stations={mockStations} loading={false} onRefresh={jest.fn()} />,
+    );
+
+    const editButtons = screen.getAllByTestId('EditIcon');
+    fireEvent.click(editButtons[0].closest('button')!);
+    expect(screen.getByTestId('station-dialog')).toBeInTheDocument();
+    expect(screen.getByText('Edit Station Dialog')).toBeInTheDocument();
+  });
+
+  it('should display facility tax', () => {
+    render(
+      <StationsList stations={mockStations} loading={false} onRefresh={jest.fn()} />,
+    );
+
+    expect(screen.getByText('1%')).toBeInTheDocument();
+    expect(screen.getByText('2.5%')).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/components/stations/__tests__/__snapshots__/StationDialog.test.tsx.snap
+++ b/frontend/packages/components/stations/__tests__/__snapshots__/StationDialog.test.tsx.snap
@@ -1,0 +1,961 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`StationDialog Component should match snapshot when closed 1`] = `<div />`;
+
+exports[`StationDialog Component should match snapshot when open for adding 1`] = `
+<body
+  style="padding-right: 1024px; overflow: hidden;"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-1424xw8-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop MuiDialog-backdrop css-1cennmq-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-19do60a-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby="_r_1_"
+        aria-modal="true"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-1kdu84s-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+        style="--Paper-shadow: 0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12);"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-rvoa5x-MuiTypography-root-MuiDialogTitle-root"
+          id="_r_1_"
+        >
+          Add Station
+        </h2>
+        <div
+          class="MuiDialogContent-root css-kw13he-MuiDialogContent-root"
+        >
+          <div
+            class="MuiBox-root css-hiv0t3"
+          >
+            <div
+              class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1tlcqt-MuiAutocomplete-root"
+            >
+              <div
+                class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+                  data-shrink="false"
+                  for="_r_2_"
+                  id="_r_2_-label"
+                >
+                  Station
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1n04w30-MuiInputBase-root-MuiOutlinedInput-root"
+                >
+                  <input
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    aria-invalid="false"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
+                    id="_r_2_"
+                    placeholder="Search for a station..."
+                    role="combobox"
+                    spellcheck="false"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    class="MuiAutocomplete-endAdornment css-1uhhrmm-MuiAutocomplete-endAdornment"
+                  >
+                    <button
+                      aria-label="Open"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-2y136s-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                      tabindex="-1"
+                      title="Open"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                        data-testid="ArrowDropDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <fieldset
+                    aria-hidden="true"
+                    class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="css-1n64csd-MuiNotchedOutlined-root"
+                    >
+                      <span>
+                        Station
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiFormControl-root MuiTextField-root css-1bb3vlc-MuiFormControl-root-MuiTextField-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="false"
+                for="_r_5_"
+                id="_r_5_-label"
+              >
+                Structure Fitting Scan
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-xrmkj5-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <textarea
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="_r_5_"
+                  placeholder="Paste structure fitting scan here..."
+                  rows="4"
+                  style="height: 0px; overflow: hidden;"
+                />
+                <textarea
+                  aria-hidden="true"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
+                  readonly=""
+                  style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
+                  tabindex="-1"
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-1n64csd-MuiNotchedOutlined-root"
+                  >
+                    <span>
+                      Structure Fitting Scan
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-xmgucx-MuiButtonBase-root-MuiButton-root"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              Parse Scan
+            </button>
+            <div
+              class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="true"
+              >
+                Structure
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+              >
+                <div
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-18jp67o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                  role="combobox"
+                  tabindex="0"
+                >
+                  Raitaru
+                </div>
+                <input
+                  aria-hidden="true"
+                  aria-invalid="false"
+                  class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value="raitaru"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                  data-testid="ArrowDropDownIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
+                  >
+                    <span>
+                      Structure
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <div
+              class="MuiFormControl-root MuiTextField-root css-1xp5r68-MuiFormControl-root-MuiTextField-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="true"
+                for="_r_8_"
+                id="_r_8_-label"
+              >
+                Facility Tax %
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="_r_8_"
+                  min="0"
+                  step="0.1"
+                  type="number"
+                  value="1"
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
+                  >
+                    <span>
+                      Facility Tax %
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            >
+              <div
+                class="MuiBox-root css-pcqfzb"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle2 css-1jey8w-MuiTypography-root"
+                >
+                  Rigs
+                </h6>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1ccsd5i-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-d8i980-MuiButton-startIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                      data-testid="AddIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                      />
+                    </svg>
+                  </span>
+                  Add Rig
+                </button>
+              </div>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-su980v-MuiTypography-root"
+              >
+                No rigs. Paste a scan or add manually.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-15fu35s-MuiDialogActions-root"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-2uta4f-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1nttctm-MuiButtonBase-root-MuiButton-root"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`StationDialog Component should match snapshot when open for editing 1`] = `
+<body
+  style="padding-right: 1024px; overflow: hidden;"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-1424xw8-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop MuiDialog-backdrop css-1cennmq-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-19do60a-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby="_r_c_"
+        aria-modal="true"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-1kdu84s-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+        style="--Paper-shadow: 0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12);"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-rvoa5x-MuiTypography-root-MuiDialogTitle-root"
+          id="_r_c_"
+        >
+          Edit Station
+        </h2>
+        <div
+          class="MuiDialogContent-root css-kw13he-MuiDialogContent-root"
+        >
+          <div
+            class="MuiBox-root css-hiv0t3"
+          >
+            <div
+              class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1tlcqt-MuiAutocomplete-root"
+            >
+              <div
+                class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+                  data-shrink="true"
+                  for="_r_d_"
+                  id="_r_d_-label"
+                >
+                  Station
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1n04w30-MuiInputBase-root-MuiOutlinedInput-root"
+                >
+                  <input
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    aria-invalid="false"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
+                    disabled=""
+                    id="_r_d_"
+                    placeholder="Search for a station..."
+                    role="combobox"
+                    spellcheck="false"
+                    type="text"
+                    value="Test Sotiyo"
+                  />
+                  <div
+                    class="MuiAutocomplete-endAdornment css-1uhhrmm-MuiAutocomplete-endAdornment"
+                  >
+                    <button
+                      aria-label="Open"
+                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-2y136s-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                      disabled=""
+                      tabindex="-1"
+                      title="Open"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                        data-testid="ArrowDropDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <fieldset
+                    aria-hidden="true"
+                    class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="css-ex8a5f-MuiNotchedOutlined-root"
+                    >
+                      <span>
+                        Station
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiFormControl-root MuiTextField-root css-1bb3vlc-MuiFormControl-root-MuiTextField-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="false"
+                for="_r_g_"
+                id="_r_g_-label"
+              >
+                Structure Fitting Scan
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-xrmkj5-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <textarea
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="_r_g_"
+                  placeholder="Paste structure fitting scan here..."
+                  rows="4"
+                  style="height: 0px; overflow: hidden;"
+                />
+                <textarea
+                  aria-hidden="true"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
+                  readonly=""
+                  style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
+                  tabindex="-1"
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-1n64csd-MuiNotchedOutlined-root"
+                  >
+                    <span>
+                      Structure Fitting Scan
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-xmgucx-MuiButtonBase-root-MuiButton-root"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              Parse Scan
+            </button>
+            <div
+              class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="true"
+              >
+                Structure
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+              >
+                <div
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-18jp67o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                  role="combobox"
+                  tabindex="0"
+                >
+                  Sotiyo
+                </div>
+                <input
+                  aria-hidden="true"
+                  aria-invalid="false"
+                  class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value="sotiyo"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                  data-testid="ArrowDropDownIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
+                  >
+                    <span>
+                      Structure
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <div
+              class="MuiFormControl-root MuiTextField-root css-1xp5r68-MuiFormControl-root-MuiTextField-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="true"
+                for="_r_j_"
+                id="_r_j_-label"
+              >
+                Facility Tax %
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="_r_j_"
+                  min="0"
+                  step="0.1"
+                  type="number"
+                  value="1"
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
+                  >
+                    <span>
+                      Facility Tax %
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            >
+              <h6
+                class="MuiTypography-root MuiTypography-subtitle2 css-1q6s3f6-MuiTypography-root"
+              >
+                Services
+              </h6>
+              <div
+                class="MuiBox-root css-1ttbi7w"
+              >
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-72lu9j-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    Standup Manufacturing Plant I
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            >
+              <div
+                class="MuiBox-root css-pcqfzb"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle2 css-1jey8w-MuiTypography-root"
+                >
+                  Rigs
+                </h6>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1ccsd5i-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-d8i980-MuiButton-startIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                      data-testid="AddIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                      />
+                    </svg>
+                  </span>
+                  Add Rig
+                </button>
+              </div>
+              <div
+                class="MuiBox-root css-1mc0gyh"
+              >
+                <div
+                  class="MuiFormControl-root css-zctqko-MuiFormControl-root"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="true"
+                  >
+                    Category
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-trm6af-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                      role="combobox"
+                      tabindex="0"
+                    >
+                      <div
+                        class="MuiBox-root css-axw7ok"
+                      >
+                        <div
+                          class="MuiBox-root css-1o56k58"
+                        />
+                        <span
+                          style="text-transform: capitalize;"
+                        >
+                          ship
+                        </span>
+                      </div>
+                    </div>
+                    <input
+                      aria-hidden="true"
+                      aria-invalid="false"
+                      class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                      tabindex="-1"
+                      value="ship"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                      data-testid="ArrowDropDownIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-ex8a5f-MuiNotchedOutlined-root"
+                      >
+                        <span>
+                          Category
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+                <div
+                  class="MuiFormControl-root css-1ciitze-MuiFormControl-root"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="true"
+                  >
+                    Tier
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-trm6af-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                      role="combobox"
+                      tabindex="0"
+                    >
+                      T1
+                    </div>
+                    <input
+                      aria-hidden="true"
+                      aria-invalid="false"
+                      class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                      tabindex="-1"
+                      value="t1"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                      data-testid="ArrowDropDownIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-ex8a5f-MuiNotchedOutlined-root"
+                      >
+                        <span>
+                          Tier
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-nu6x2k-MuiTypography-root"
+                  title="Standup XL-Set Ship Manufacturing Efficiency I"
+                >
+                  Standup XL-Set Ship Manufacturing Efficiency I
+                </p>
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="DeleteIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div
+                class="MuiBox-root css-1mc0gyh"
+              >
+                <div
+                  class="MuiFormControl-root css-zctqko-MuiFormControl-root"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="true"
+                  >
+                    Category
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-trm6af-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                      role="combobox"
+                      tabindex="0"
+                    >
+                      <div
+                        class="MuiBox-root css-axw7ok"
+                      >
+                        <div
+                          class="MuiBox-root css-1jwo09m"
+                        />
+                        <span
+                          style="text-transform: capitalize;"
+                        >
+                          component
+                        </span>
+                      </div>
+                    </div>
+                    <input
+                      aria-hidden="true"
+                      aria-invalid="false"
+                      class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                      tabindex="-1"
+                      value="component"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                      data-testid="ArrowDropDownIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-ex8a5f-MuiNotchedOutlined-root"
+                      >
+                        <span>
+                          Category
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+                <div
+                  class="MuiFormControl-root css-1ciitze-MuiFormControl-root"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="true"
+                  >
+                    Tier
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-trm6af-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                      role="combobox"
+                      tabindex="0"
+                    >
+                      T1
+                    </div>
+                    <input
+                      aria-hidden="true"
+                      aria-invalid="false"
+                      class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                      tabindex="-1"
+                      value="t1"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                      data-testid="ArrowDropDownIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-ex8a5f-MuiNotchedOutlined-root"
+                      >
+                        <span>
+                          Tier
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-nu6x2k-MuiTypography-root"
+                  title="Standup XL-Set Structure and Component Manufacturing Efficiency I"
+                >
+                  Standup XL-Set Structure and Component Manufacturing Efficiency I
+                </p>
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="DeleteIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-15fu35s-MuiDialogActions-root"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-2uta4f-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1nttctm-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Update
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;

--- a/frontend/packages/components/stations/__tests__/__snapshots__/StationsList.test.tsx.snap
+++ b/frontend/packages/components/stations/__tests__/__snapshots__/StationsList.test.tsx.snap
@@ -1,0 +1,466 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`StationsList Component should match snapshot while loading 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-zzzt33"
+  >
+    <span
+      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1wxecgq-MuiCircularProgress-root"
+      role="progressbar"
+      style="width: 40px; height: 40px;"
+    >
+      <svg
+        class="MuiCircularProgress-svg css-54pwck-MuiCircularProgress-svg"
+        viewBox="22 22 44 44"
+      >
+        <circle
+          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-19t5dcl-MuiCircularProgress-circle"
+          cx="44"
+          cy="44"
+          fill="none"
+          r="20.2"
+          stroke-width="3.6"
+        />
+      </svg>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`StationsList Component should match snapshot with empty stations 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-1qm1lh"
+  >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-74d805-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          data-testid="AddIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+          />
+        </svg>
+      </span>
+      Add Station
+    </button>
+  </div>
+  <div
+    class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+  >
+    <table
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
+    >
+      <thead
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Station
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            System
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Security
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Structure
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Activities
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Rigs
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Tax
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Actions
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1a1qcai-MuiTableCell-root"
+            colspan="8"
+          >
+            No preferred stations configured. Click "Add Station" to get started.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`StationsList Component should match snapshot with stations 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-1qm1lh"
+  >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-74d805-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          data-testid="AddIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+          />
+        </svg>
+      </span>
+      Add Station
+    </button>
+  </div>
+  <div
+    class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+  >
+    <table
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
+    >
+      <thead
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Station
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            System
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Security
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Structure
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Activities
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Rigs
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Tax
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Actions
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root css-jgrlj7-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-5i58p1-MuiTableCell-root"
+          >
+            Test Sotiyo
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1fair71-MuiTableCell-root"
+          >
+            Jita
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-cow7lq-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+              >
+                high
+              </span>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1r465ak-MuiTableCell-root"
+          >
+            sotiyo
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiBox-root css-1ttbi7w"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-18aao4r-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  manufacturing
+                </span>
+              </div>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiBox-root css-1ttbi7w"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-k8pe1t-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  ship T1
+                </span>
+              </div>
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-19grusu-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  component T1
+                </span>
+              </div>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-twke26-MuiTableCell-root"
+          >
+            1
+            %
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="EditIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                />
+              </svg>
+            </button>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="DeleteIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
+                />
+              </svg>
+            </button>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root css-jgrlj7-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-5i58p1-MuiTableCell-root"
+          >
+            Test Tatara
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1fair71-MuiTableCell-root"
+          >
+            Perimeter
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1yjibm3-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+              >
+                low
+              </span>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1r465ak-MuiTableCell-root"
+          >
+            tatara
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiBox-root css-1ttbi7w"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-6vfr9v-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  reaction
+                </span>
+              </div>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiBox-root css-1ttbi7w"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-bhi5sl-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                >
+                  reaction T2
+                </span>
+              </div>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-twke26-MuiTableCell-root"
+          >
+            2.5
+            %
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lsyoc6-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="EditIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                />
+              </svg>
+            </button>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="DeleteIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
+                />
+              </svg>
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;

--- a/frontend/packages/pages/production-plans.tsx
+++ b/frontend/packages/pages/production-plans.tsx
@@ -1,0 +1,18 @@
+import { useSession } from "next-auth/react";
+import Loading from "@industry-tool/components/loading";
+import Unauthorized from "@industry-tool/components/unauthorized";
+import ProductionPlansList from "@industry-tool/components/industry/ProductionPlansList";
+
+export default function ProductionPlansPage() {
+  const { status } = useSession();
+
+  if (status === "loading") {
+    return <Loading />;
+  }
+
+  if (status !== "authenticated") {
+    return <Unauthorized />;
+  }
+
+  return <ProductionPlansList />;
+}

--- a/frontend/packages/pages/stations.tsx
+++ b/frontend/packages/pages/stations.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { UserStation } from "@industry-tool/client/data/models";
+import Loading from "@industry-tool/components/loading";
+import Unauthorized from "@industry-tool/components/unauthorized";
+import Navbar from "@industry-tool/components/Navbar";
+import StationsList from "@industry-tool/components/stations/StationsList";
+import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
+
+export default function Stations() {
+  const { status } = useSession();
+  const [stations, setStations] = useState<UserStation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchStations = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/stations/user-stations");
+      if (res.ok) {
+        const data = await res.json();
+        setStations(data || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch stations:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      fetchStations();
+    }
+  }, [status, fetchStations]);
+
+  if (status === "loading") {
+    return <Loading />;
+  }
+
+  if (status !== "authenticated") {
+    return <Unauthorized />;
+  }
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
+        <Typography variant="h5" sx={{ color: "#e2e8f0", mb: 2, fontWeight: 600 }}>
+          Preferred Stations
+        </Typography>
+        <StationsList
+          stations={stations}
+          loading={loading}
+          onRefresh={fetchStations}
+        />
+      </Container>
+    </>
+  );
+}

--- a/frontend/pages/api/industry/plans/[id].ts
+++ b/frontend/pages/api/industry/plans/[id].ts
@@ -1,0 +1,73 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (id: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": id,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  try {
+    if (req.method === "GET") {
+      const response = await fetch(`${backend}v1/industry/plans/${id}`, {
+        method: "GET",
+        headers: getHeaders(session.providerAccountId),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else if (req.method === "PUT") {
+      const response = await fetch(`${backend}v1/industry/plans/${id}`, {
+        method: "PUT",
+        headers: getHeaders(session.providerAccountId),
+        body: JSON.stringify(req.body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else if (req.method === "DELETE") {
+      const response = await fetch(`${backend}v1/industry/plans/${id}`, {
+        method: "DELETE",
+        headers: getHeaders(session.providerAccountId),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Production plan API error:", error);
+    return res.status(500).json({ error: "Failed to process plan request" });
+  }
+}

--- a/frontend/pages/api/industry/plans/[id]/generate.ts
+++ b/frontend/pages/api/industry/plans/[id]/generate.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (userId: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": userId,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  try {
+    if (req.method === "POST") {
+      const response = await fetch(
+        `${backend}v1/industry/plans/${id}/generate`,
+        {
+          method: "POST",
+          headers: getHeaders(session.providerAccountId),
+          body: JSON.stringify(req.body),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Generate jobs API error:", error);
+    return res.status(500).json({ error: "Failed to generate jobs" });
+  }
+}

--- a/frontend/pages/api/industry/plans/[id]/runs/[runId].ts
+++ b/frontend/pages/api/industry/plans/[id]/runs/[runId].ts
@@ -1,0 +1,65 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (userId: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": userId,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id, runId } = req.query;
+
+  try {
+    if (req.method === "GET") {
+      const response = await fetch(
+        `${backend}v1/industry/plans/${id}/runs/${runId}`,
+        {
+          method: "GET",
+          headers: getHeaders(session.providerAccountId),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else if (req.method === "DELETE") {
+      const response = await fetch(
+        `${backend}v1/industry/plans/${id}/runs/${runId}`,
+        {
+          method: "DELETE",
+          headers: getHeaders(session.providerAccountId),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Plan run API error:", error);
+    return res.status(500).json({ error: "Failed to process plan run request" });
+  }
+}

--- a/frontend/pages/api/industry/plans/[id]/runs/index.ts
+++ b/frontend/pages/api/industry/plans/[id]/runs/index.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (userId: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": userId,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  try {
+    if (req.method === "GET") {
+      const response = await fetch(
+        `${backend}v1/industry/plans/${id}/runs`,
+        {
+          method: "GET",
+          headers: getHeaders(session.providerAccountId),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Plan runs API error:", error);
+    return res.status(500).json({ error: "Failed to get plan runs" });
+  }
+}

--- a/frontend/pages/api/industry/plans/[id]/steps/[stepId].ts
+++ b/frontend/pages/api/industry/plans/[id]/steps/[stepId].ts
@@ -1,0 +1,66 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (userId: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": userId,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id, stepId } = req.query;
+
+  try {
+    if (req.method === "PUT") {
+      const response = await fetch(
+        `${backend}v1/industry/plans/${id}/steps/${stepId}`,
+        {
+          method: "PUT",
+          headers: getHeaders(session.providerAccountId),
+          body: JSON.stringify(req.body),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else if (req.method === "DELETE") {
+      const response = await fetch(
+        `${backend}v1/industry/plans/${id}/steps/${stepId}`,
+        {
+          method: "DELETE",
+          headers: getHeaders(session.providerAccountId),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Plan step API error:", error);
+    return res.status(500).json({ error: "Failed to process step request" });
+  }
+}

--- a/frontend/pages/api/industry/plans/[id]/steps/[stepId]/materials.ts
+++ b/frontend/pages/api/industry/plans/[id]/steps/[stepId]/materials.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (userId: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": userId,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id, stepId } = req.query;
+
+  try {
+    if (req.method === "GET") {
+      const response = await fetch(
+        `${backend}v1/industry/plans/${id}/steps/${stepId}/materials`,
+        {
+          method: "GET",
+          headers: getHeaders(session.providerAccountId),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Step materials API error:", error);
+    return res
+      .status(500)
+      .json({ error: "Failed to process materials request" });
+  }
+}

--- a/frontend/pages/api/industry/plans/[id]/steps/batch.ts
+++ b/frontend/pages/api/industry/plans/[id]/steps/batch.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (userId: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": userId,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  try {
+    if (req.method === "PUT") {
+      const response = await fetch(
+        `${backend}v1/industry/plans/${id}/steps/batch`,
+        {
+          method: "PUT",
+          headers: getHeaders(session.providerAccountId),
+          body: JSON.stringify(req.body),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Batch update steps API error:", error);
+    return res.status(500).json({ error: "Failed to process batch update request" });
+  }
+}

--- a/frontend/pages/api/industry/plans/[id]/steps/index.ts
+++ b/frontend/pages/api/industry/plans/[id]/steps/index.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (userId: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": userId,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  try {
+    if (req.method === "POST") {
+      const response = await fetch(`${backend}v1/industry/plans/${id}/steps`, {
+        method: "POST",
+        headers: getHeaders(session.providerAccountId),
+        body: JSON.stringify(req.body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Plan steps API error:", error);
+    return res.status(500).json({ error: "Failed to process steps request" });
+  }
+}

--- a/frontend/pages/api/industry/plans/hangars.ts
+++ b/frontend/pages/api/industry/plans/hangars.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (id: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": id,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const userStationId = req.query.user_station_id;
+    if (!userStationId) {
+      return res.status(400).json({ error: "user_station_id is required" });
+    }
+
+    const response = await fetch(
+      `${backend}v1/industry/plans/hangars?user_station_id=${userStationId}`,
+      {
+        method: "GET",
+        headers: getHeaders(session.providerAccountId),
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("Hangars API error:", error);
+    return res.status(500).json({ error: "Failed to fetch hangars" });
+  }
+}

--- a/frontend/pages/api/industry/plans/index.ts
+++ b/frontend/pages/api/industry/plans/index.ts
@@ -1,0 +1,58 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (id: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": id,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    if (req.method === "GET") {
+      const response = await fetch(`${backend}v1/industry/plans`, {
+        method: "GET",
+        headers: getHeaders(session.providerAccountId),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else if (req.method === "POST") {
+      const response = await fetch(`${backend}v1/industry/plans`, {
+        method: "POST",
+        headers: getHeaders(session.providerAccountId),
+        body: JSON.stringify(req.body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Production plans API error:", error);
+    return res.status(500).json({ error: "Failed to process plans request" });
+  }
+}

--- a/frontend/pages/api/stations/parse-scan.ts
+++ b/frontend/pages/api/stations/parse-scan.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (id: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": id,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    if (req.method === "POST") {
+      const response = await fetch(`${backend}v1/user-stations/parse-scan`, {
+        method: "POST",
+        headers: getHeaders(session.providerAccountId),
+        body: JSON.stringify(req.body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Parse scan API error:", error);
+    return res.status(500).json({ error: "Failed to parse scan" });
+  }
+}

--- a/frontend/pages/api/stations/user-stations.ts
+++ b/frontend/pages/api/stations/user-stations.ts
@@ -1,0 +1,58 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (id: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": id,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    if (req.method === "GET") {
+      const response = await fetch(`${backend}v1/user-stations`, {
+        method: "GET",
+        headers: getHeaders(session.providerAccountId),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else if (req.method === "POST") {
+      const response = await fetch(`${backend}v1/user-stations`, {
+        method: "POST",
+        headers: getHeaders(session.providerAccountId),
+        body: JSON.stringify(req.body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("User stations API error:", error);
+    return res.status(500).json({ error: "Failed to process user stations request" });
+  }
+}

--- a/frontend/pages/api/stations/user-stations/[id].ts
+++ b/frontend/pages/api/stations/user-stations/[id].ts
@@ -1,0 +1,60 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (id: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": id,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  try {
+    if (req.method === "PUT") {
+      const response = await fetch(`${backend}v1/user-stations/${id}`, {
+        method: "PUT",
+        headers: getHeaders(session.providerAccountId),
+        body: JSON.stringify(req.body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else if (req.method === "DELETE") {
+      const response = await fetch(`${backend}v1/user-stations/${id}`, {
+        method: "DELETE",
+        headers: getHeaders(session.providerAccountId),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("User station API error:", error);
+    return res.status(500).json({ error: "Failed to process user station request" });
+  }
+}

--- a/frontend/pages/production-plans.tsx
+++ b/frontend/pages/production-plans.tsx
@@ -1,0 +1,3 @@
+import ProductionPlans from "@industry-tool/pages/production-plans";
+
+export default ProductionPlans;

--- a/frontend/pages/stations.tsx
+++ b/frontend/pages/stations.tsx
@@ -1,0 +1,3 @@
+import Stations from "@industry-tool/pages/stations";
+
+export default Stations;

--- a/internal/controllers/productionPlans.go
+++ b/internal/controllers/productionPlans.go
@@ -1,0 +1,907 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/annymsMthd/industry-tool/internal/calculator"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/pkg/errors"
+)
+
+type ProductionPlansRepository interface {
+	Create(ctx context.Context, plan *models.ProductionPlan) (*models.ProductionPlan, error)
+	GetByUser(ctx context.Context, userID int64) ([]*models.ProductionPlan, error)
+	GetByID(ctx context.Context, id, userID int64) (*models.ProductionPlan, error)
+	Update(ctx context.Context, id, userID int64, name string, notes *string, defaultManufacturingStationID *int64, defaultReactionStationID *int64) error
+	Delete(ctx context.Context, id, userID int64) error
+	CreateStep(ctx context.Context, step *models.ProductionPlanStep) (*models.ProductionPlanStep, error)
+	UpdateStep(ctx context.Context, stepID, planID, userID int64, step *models.ProductionPlanStep) error
+	BatchUpdateSteps(ctx context.Context, stepIDs []int64, planID, userID int64, step *models.ProductionPlanStep) (int64, error)
+	DeleteStep(ctx context.Context, stepID, planID, userID int64) error
+	GetStepMaterials(ctx context.Context, stepID, planID, userID int64) ([]*models.PlanMaterial, error)
+	GetContainersAtStation(ctx context.Context, userID, stationID int64) ([]*models.StationContainer, error)
+}
+
+type ProductionPlansCharacterRepository interface {
+	GetNames(ctx context.Context, userID int64) (map[int64]string, error)
+}
+
+type ProductionPlansCorporationRepository interface {
+	Get(ctx context.Context, user int64) ([]repositories.PlayerCorporation, error)
+	GetDivisions(ctx context.Context, corp, user int64) (*models.CorporationDivisions, error)
+}
+
+type ProductionPlansUserStationRepository interface {
+	GetByID(ctx context.Context, id, userID int64) (*models.UserStation, error)
+}
+
+type ProductionPlansSdeRepository interface {
+	GetBlueprintByProduct(ctx context.Context, productTypeID int64) (*repositories.BlueprintProductRow, error)
+	GetManufacturingBlueprint(ctx context.Context, blueprintTypeID int64) (*repositories.ManufacturingBlueprintRow, error)
+	GetManufacturingMaterials(ctx context.Context, blueprintTypeID int64) ([]*repositories.ManufacturingMaterialRow, error)
+}
+
+type ProductionPlansMarketRepository interface {
+	GetAllJitaPrices(ctx context.Context) (map[int64]*models.MarketPrice, error)
+	GetAllAdjustedPrices(ctx context.Context) (map[int64]float64, error)
+}
+
+type ProductionPlansCostIndicesRepository interface {
+	GetCostIndex(ctx context.Context, systemID int64, activity string) (*models.IndustryCostIndex, error)
+}
+
+type ProductionPlansJobQueueRepository interface {
+	Create(ctx context.Context, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error)
+}
+
+type ProductionPlanRunsRepository interface {
+	Create(ctx context.Context, run *models.ProductionPlanRun) (*models.ProductionPlanRun, error)
+	GetByPlan(ctx context.Context, planID, userID int64) ([]*models.ProductionPlanRun, error)
+	GetByID(ctx context.Context, runID, userID int64) (*models.ProductionPlanRun, error)
+	Delete(ctx context.Context, runID, userID int64) error
+}
+
+type ProductionPlans struct {
+	plansRepo       ProductionPlansRepository
+	sdeRepo         ProductionPlansSdeRepository
+	queueRepo       ProductionPlansJobQueueRepository
+	marketRepo      ProductionPlansMarketRepository
+	costIndicesRepo ProductionPlansCostIndicesRepository
+	characterRepo   ProductionPlansCharacterRepository
+	corpRepo        ProductionPlansCorporationRepository
+	stationRepo     ProductionPlansUserStationRepository
+	runsRepo        ProductionPlanRunsRepository
+}
+
+func NewProductionPlans(
+	router Routerer,
+	plansRepo ProductionPlansRepository,
+	sdeRepo ProductionPlansSdeRepository,
+	queueRepo ProductionPlansJobQueueRepository,
+	marketRepo ProductionPlansMarketRepository,
+	costIndicesRepo ProductionPlansCostIndicesRepository,
+	characterRepo ProductionPlansCharacterRepository,
+	corpRepo ProductionPlansCorporationRepository,
+	stationRepo ProductionPlansUserStationRepository,
+	runsRepo ProductionPlanRunsRepository,
+) *ProductionPlans {
+	c := &ProductionPlans{
+		plansRepo:       plansRepo,
+		sdeRepo:         sdeRepo,
+		queueRepo:       queueRepo,
+		marketRepo:      marketRepo,
+		costIndicesRepo: costIndicesRepo,
+		characterRepo:   characterRepo,
+		corpRepo:        corpRepo,
+		stationRepo:     stationRepo,
+		runsRepo:        runsRepo,
+	}
+
+	router.RegisterRestAPIRoute("/v1/industry/plans", web.AuthAccessUser, c.GetPlans, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/plans", web.AuthAccessUser, c.CreatePlan, "POST")
+	router.RegisterRestAPIRoute("/v1/industry/plans/hangars", web.AuthAccessUser, c.GetHangars, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}", web.AuthAccessUser, c.GetPlan, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}", web.AuthAccessUser, c.UpdatePlan, "PUT")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}", web.AuthAccessUser, c.DeletePlan, "DELETE")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}/steps", web.AuthAccessUser, c.CreateStep, "POST")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}/steps/batch", web.AuthAccessUser, c.BatchUpdateSteps, "PUT")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}/steps/{stepId}", web.AuthAccessUser, c.UpdateStep, "PUT")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}/steps/{stepId}", web.AuthAccessUser, c.DeleteStep, "DELETE")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}/steps/{stepId}/materials", web.AuthAccessUser, c.GetStepMaterials, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}/runs", web.AuthAccessUser, c.GetPlanRuns, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}/runs/{runId}", web.AuthAccessUser, c.GetPlanRun, "GET")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}/runs/{runId}", web.AuthAccessUser, c.DeletePlanRun, "DELETE")
+	router.RegisterRestAPIRoute("/v1/industry/plans/{id}/generate", web.AuthAccessUser, c.GenerateJobs, "POST")
+
+	return c
+}
+
+// GetPlans lists all production plans for the user.
+func (c *ProductionPlans) GetPlans(args *web.HandlerArgs) (any, *web.HttpError) {
+	plans, err := c.plansRepo.GetByUser(args.Request.Context(), *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get production plans")}
+	}
+	return plans, nil
+}
+
+type createPlanRequest struct {
+	ProductTypeID                 int64   `json:"product_type_id"`
+	Name                          string  `json:"name"`
+	Notes                         *string `json:"notes"`
+	DefaultManufacturingStationID *int64  `json:"default_manufacturing_station_id"`
+	DefaultReactionStationID      *int64  `json:"default_reaction_station_id"`
+}
+
+// CreatePlan creates a new production plan and auto-creates the root step.
+func (c *ProductionPlans) CreatePlan(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+
+	var req createPlanRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if req.ProductTypeID <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("product_type_id is required")}
+	}
+
+	// Look up the blueprint for this product
+	bp, err := c.sdeRepo.GetBlueprintByProduct(ctx, req.ProductTypeID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to look up blueprint")}
+	}
+	if bp == nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("no manufacturing or reaction blueprint found for this product")}
+	}
+
+	// Get product name for default plan name
+	planName := req.Name
+	if planName == "" {
+		bpInfo, err := c.sdeRepo.GetManufacturingBlueprint(ctx, bp.BlueprintTypeID)
+		if err == nil && bpInfo != nil {
+			planName = bpInfo.ProductName
+		}
+	}
+
+	// Create the plan
+	plan, err := c.plansRepo.Create(ctx, &models.ProductionPlan{
+		UserID:                        *args.User,
+		ProductTypeID:                 req.ProductTypeID,
+		Name:                          planName,
+		Notes:                         req.Notes,
+		DefaultManufacturingStationID: req.DefaultManufacturingStationID,
+		DefaultReactionStationID:      req.DefaultReactionStationID,
+	})
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to create production plan")}
+	}
+
+	// Determine default station for root step based on activity
+	var defaultStationID *int64
+	if bp.Activity == "manufacturing" {
+		defaultStationID = req.DefaultManufacturingStationID
+	} else if bp.Activity == "reaction" {
+		defaultStationID = req.DefaultReactionStationID
+	}
+
+	// Create the root step
+	rootStep := &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ProductTypeID:    req.ProductTypeID,
+		BlueprintTypeID:  bp.BlueprintTypeID,
+		Activity:         bp.Activity,
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+		UserStationID:    defaultStationID,
+	}
+
+	_, err = c.plansRepo.CreateStep(ctx, rootStep)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to create root step")}
+	}
+
+	// Return the full plan with steps
+	fullPlan, err := c.plansRepo.GetByID(ctx, plan.ID, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to fetch created plan")}
+	}
+
+	return fullPlan, nil
+}
+
+// GetPlan returns a single plan with its full step tree.
+func (c *ProductionPlans) GetPlan(args *web.HandlerArgs) (any, *web.HttpError) {
+	id, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+
+	plan, err := c.plansRepo.GetByID(args.Request.Context(), id, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get production plan")}
+	}
+	if plan == nil {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.New("production plan not found")}
+	}
+
+	return plan, nil
+}
+
+type updatePlanRequest struct {
+	Name                          string  `json:"name"`
+	Notes                         *string `json:"notes"`
+	DefaultManufacturingStationID *int64  `json:"default_manufacturing_station_id"`
+	DefaultReactionStationID      *int64  `json:"default_reaction_station_id"`
+}
+
+// UpdatePlan updates plan metadata (name, notes).
+func (c *ProductionPlans) UpdatePlan(args *web.HandlerArgs) (any, *web.HttpError) {
+	id, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+
+	var req updatePlanRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if err := c.plansRepo.Update(args.Request.Context(), id, *args.User, req.Name, req.Notes, req.DefaultManufacturingStationID, req.DefaultReactionStationID); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to update production plan")}
+	}
+
+	return map[string]string{"status": "updated"}, nil
+}
+
+// DeletePlan deletes a plan and all its steps.
+func (c *ProductionPlans) DeletePlan(args *web.HandlerArgs) (any, *web.HttpError) {
+	id, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+
+	if err := c.plansRepo.Delete(args.Request.Context(), id, *args.User); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to delete production plan")}
+	}
+
+	return map[string]string{"status": "deleted"}, nil
+}
+
+type createStepRequest struct {
+	ParentStepID  int64   `json:"parent_step_id"`
+	ProductTypeID int64   `json:"product_type_id"`
+	MELevel       *int    `json:"me_level"`
+	TELevel       *int    `json:"te_level"`
+	Structure     string  `json:"structure"`
+	Rig           string  `json:"rig"`
+	Security      string  `json:"security"`
+	FacilityTax   *float64 `json:"facility_tax"`
+}
+
+// CreateStep adds a production step (toggles a material to "produce").
+func (c *ProductionPlans) CreateStep(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+
+	planID, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+
+	var req createStepRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if req.ParentStepID <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("parent_step_id is required")}
+	}
+	if req.ProductTypeID <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("product_type_id is required")}
+	}
+
+	// Verify the plan exists and belongs to user
+	plan, err := c.plansRepo.GetByID(ctx, planID, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to verify plan")}
+	}
+	if plan == nil {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.New("production plan not found")}
+	}
+
+	// Look up the blueprint for the material
+	bp, err := c.sdeRepo.GetBlueprintByProduct(ctx, req.ProductTypeID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to look up blueprint")}
+	}
+	if bp == nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("no manufacturing or reaction blueprint found for this product")}
+	}
+
+	meLevel := 10
+	if req.MELevel != nil {
+		meLevel = *req.MELevel
+	}
+	teLevel := 20
+	if req.TELevel != nil {
+		teLevel = *req.TELevel
+	}
+	facilityTax := 1.0
+	if req.FacilityTax != nil {
+		facilityTax = *req.FacilityTax
+	}
+
+	// Auto-assign user station from plan defaults based on activity
+	var stepStationID *int64
+	if bp.Activity == "manufacturing" && plan.DefaultManufacturingStationID != nil {
+		stepStationID = plan.DefaultManufacturingStationID
+	} else if bp.Activity == "reaction" && plan.DefaultReactionStationID != nil {
+		stepStationID = plan.DefaultReactionStationID
+	}
+
+	step := &models.ProductionPlanStep{
+		PlanID:           planID,
+		ParentStepID:     &req.ParentStepID,
+		ProductTypeID:    req.ProductTypeID,
+		BlueprintTypeID:  bp.BlueprintTypeID,
+		Activity:         bp.Activity,
+		MELevel:          meLevel,
+		TELevel:          teLevel,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        withDefault(req.Structure, "raitaru"),
+		Rig:              withDefault(req.Rig, "t2"),
+		Security:         withDefault(req.Security, "high"),
+		FacilityTax:      facilityTax,
+		UserStationID:    stepStationID,
+	}
+
+	created, err := c.plansRepo.CreateStep(ctx, step)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to create step")}
+	}
+
+	return created, nil
+}
+
+type updateStepRequest struct {
+	MELevel              int      `json:"me_level"`
+	TELevel              int      `json:"te_level"`
+	IndustrySkill        int      `json:"industry_skill"`
+	AdvIndustrySkill     int      `json:"adv_industry_skill"`
+	Structure            string   `json:"structure"`
+	Rig                  string   `json:"rig"`
+	Security             string   `json:"security"`
+	FacilityTax          float64  `json:"facility_tax"`
+	StationName          *string  `json:"station_name"`
+	SourceLocationID     *int64   `json:"source_location_id"`
+	SourceContainerID    *int64   `json:"source_container_id"`
+	SourceDivisionNumber *int     `json:"source_division_number"`
+	SourceOwnerType      *string  `json:"source_owner_type"`
+	SourceOwnerID        *int64   `json:"source_owner_id"`
+	OutputOwnerType      *string  `json:"output_owner_type"`
+	OutputOwnerID        *int64   `json:"output_owner_id"`
+	OutputDivisionNumber *int     `json:"output_division_number"`
+	OutputContainerID    *int64   `json:"output_container_id"`
+	UserStationID        *int64   `json:"user_station_id"`
+}
+
+// UpdateStep updates parameters of a production step.
+func (c *ProductionPlans) UpdateStep(args *web.HandlerArgs) (any, *web.HttpError) {
+	planID, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+	stepID, err := parseID(args.Params["stepId"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid step ID")}
+	}
+
+	var req updateStepRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	step := &models.ProductionPlanStep{
+		MELevel:              req.MELevel,
+		TELevel:              req.TELevel,
+		IndustrySkill:        req.IndustrySkill,
+		AdvIndustrySkill:     req.AdvIndustrySkill,
+		Structure:            req.Structure,
+		Rig:                  req.Rig,
+		Security:             req.Security,
+		FacilityTax:          req.FacilityTax,
+		StationName:          req.StationName,
+		SourceLocationID:     req.SourceLocationID,
+		SourceContainerID:    req.SourceContainerID,
+		SourceDivisionNumber: req.SourceDivisionNumber,
+		SourceOwnerType:      req.SourceOwnerType,
+		SourceOwnerID:        req.SourceOwnerID,
+		OutputOwnerType:      req.OutputOwnerType,
+		OutputOwnerID:        req.OutputOwnerID,
+		OutputDivisionNumber: req.OutputDivisionNumber,
+		OutputContainerID:    req.OutputContainerID,
+		UserStationID:        req.UserStationID,
+	}
+
+	if err := c.plansRepo.UpdateStep(args.Request.Context(), stepID, planID, *args.User, step); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to update step")}
+	}
+
+	return map[string]string{"status": "updated"}, nil
+}
+
+type batchUpdateStepsRequest struct {
+	StepIDs              []int64  `json:"step_ids"`
+	MELevel              int      `json:"me_level"`
+	TELevel              int      `json:"te_level"`
+	IndustrySkill        int      `json:"industry_skill"`
+	AdvIndustrySkill     int      `json:"adv_industry_skill"`
+	Structure            string   `json:"structure"`
+	Rig                  string   `json:"rig"`
+	Security             string   `json:"security"`
+	FacilityTax          float64  `json:"facility_tax"`
+	StationName          *string  `json:"station_name"`
+	SourceLocationID     *int64   `json:"source_location_id"`
+	SourceContainerID    *int64   `json:"source_container_id"`
+	SourceDivisionNumber *int     `json:"source_division_number"`
+	SourceOwnerType      *string  `json:"source_owner_type"`
+	SourceOwnerID        *int64   `json:"source_owner_id"`
+	OutputOwnerType      *string  `json:"output_owner_type"`
+	OutputOwnerID        *int64   `json:"output_owner_id"`
+	OutputDivisionNumber *int     `json:"output_division_number"`
+	OutputContainerID    *int64   `json:"output_container_id"`
+	UserStationID        *int64   `json:"user_station_id"`
+}
+
+// BatchUpdateSteps updates multiple steps at once with the same parameters.
+func (c *ProductionPlans) BatchUpdateSteps(args *web.HandlerArgs) (any, *web.HttpError) {
+	planID, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+
+	var req batchUpdateStepsRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if len(req.StepIDs) == 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("step_ids is required and must not be empty")}
+	}
+
+	step := &models.ProductionPlanStep{
+		MELevel:              req.MELevel,
+		TELevel:              req.TELevel,
+		IndustrySkill:        req.IndustrySkill,
+		AdvIndustrySkill:     req.AdvIndustrySkill,
+		Structure:            req.Structure,
+		Rig:                  req.Rig,
+		Security:             req.Security,
+		FacilityTax:          req.FacilityTax,
+		StationName:          req.StationName,
+		SourceLocationID:     req.SourceLocationID,
+		SourceContainerID:    req.SourceContainerID,
+		SourceDivisionNumber: req.SourceDivisionNumber,
+		SourceOwnerType:      req.SourceOwnerType,
+		SourceOwnerID:        req.SourceOwnerID,
+		OutputOwnerType:      req.OutputOwnerType,
+		OutputOwnerID:        req.OutputOwnerID,
+		OutputDivisionNumber: req.OutputDivisionNumber,
+		OutputContainerID:    req.OutputContainerID,
+		UserStationID:        req.UserStationID,
+	}
+
+	rowsAffected, err := c.plansRepo.BatchUpdateSteps(args.Request.Context(), req.StepIDs, planID, *args.User, step)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to batch update steps")}
+	}
+
+	return map[string]any{"status": "updated", "rows_affected": rowsAffected}, nil
+}
+
+// DeleteStep removes a production step (toggles material back to "buy").
+func (c *ProductionPlans) DeleteStep(args *web.HandlerArgs) (any, *web.HttpError) {
+	planID, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+	stepID, err := parseID(args.Params["stepId"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid step ID")}
+	}
+
+	if err := c.plansRepo.DeleteStep(args.Request.Context(), stepID, planID, *args.User); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to delete step")}
+	}
+
+	return map[string]string{"status": "deleted"}, nil
+}
+
+// GetStepMaterials returns the materials for a step with producibility info.
+func (c *ProductionPlans) GetStepMaterials(args *web.HandlerArgs) (any, *web.HttpError) {
+	planID, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+	stepID, err := parseID(args.Params["stepId"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid step ID")}
+	}
+
+	materials, err := c.plansRepo.GetStepMaterials(args.Request.Context(), stepID, planID, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get step materials")}
+	}
+
+	return materials, nil
+}
+
+type hangarsResponse struct {
+	Characters   []hangarsCharacter   `json:"characters"`
+	Corporations []hangarsCorporation `json:"corporations"`
+	Containers   []*models.StationContainer `json:"containers"`
+}
+
+type hangarsCharacter struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+type hangarsCorporation struct {
+	ID        int64             `json:"id"`
+	Name      string            `json:"name"`
+	Divisions map[string]string `json:"divisions"`
+}
+
+// GetHangars returns characters, corporations (with divisions), and containers at a station.
+func (c *ProductionPlans) GetHangars(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+	userID := *args.User
+
+	userStationIDStr := args.Request.URL.Query().Get("user_station_id")
+	if userStationIDStr == "" {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("user_station_id is required")}
+	}
+
+	userStationID, err := parseID(userStationIDStr)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid user_station_id")}
+	}
+
+	// Resolve user_station_id to real station_id
+	station, err := c.stationRepo.GetByID(ctx, userStationID, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get station")}
+	}
+	if station == nil {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.New("station not found")}
+	}
+
+	// Get character names
+	charNames, err := c.characterRepo.GetNames(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get character names")}
+	}
+
+	characters := []hangarsCharacter{}
+	for id, name := range charNames {
+		characters = append(characters, hangarsCharacter{ID: id, Name: name})
+	}
+
+	// Get corporations with divisions
+	corps, err := c.corpRepo.Get(ctx, userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get corporations")}
+	}
+
+	corporations := []hangarsCorporation{}
+	for _, corp := range corps {
+		divisions, err := c.corpRepo.GetDivisions(ctx, corp.ID, userID)
+		if err != nil {
+			return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get corporation divisions")}
+		}
+
+		divMap := map[string]string{}
+		if divisions != nil {
+			for num, name := range divisions.Hanger {
+				divMap[fmt.Sprintf("%d", num)] = name
+			}
+		}
+
+		corporations = append(corporations, hangarsCorporation{
+			ID:        corp.ID,
+			Name:      corp.Name,
+			Divisions: divMap,
+		})
+	}
+
+	// Get containers at station
+	containers, err := c.plansRepo.GetContainersAtStation(ctx, userID, station.StationID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get containers")}
+	}
+
+	return &hangarsResponse{
+		Characters:   characters,
+		Corporations: corporations,
+		Containers:   containers,
+	}, nil
+}
+
+type generateJobsRequest struct {
+	Quantity int `json:"quantity"`
+}
+
+// GenerateJobs creates job queue entries from a production plan for a given quantity.
+func (c *ProductionPlans) GenerateJobs(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+
+	planID, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+
+	var req generateJobsRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+	if req.Quantity <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("quantity must be positive")}
+	}
+
+	// Get the full plan
+	plan, err := c.plansRepo.GetByID(ctx, planID, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get plan")}
+	}
+	if plan == nil {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.New("production plan not found")}
+	}
+	if len(plan.Steps) == 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("plan has no steps")}
+	}
+
+	// Build step index and find root
+	stepsByID := make(map[int64]*models.ProductionPlanStep)
+	childStepsByParent := make(map[int64][]*models.ProductionPlanStep)
+	var rootStep *models.ProductionPlanStep
+
+	for _, step := range plan.Steps {
+		stepsByID[step.ID] = step
+		if step.ParentStepID == nil {
+			rootStep = step
+		} else {
+			childStepsByParent[*step.ParentStepID] = append(childStepsByParent[*step.ParentStepID], step)
+		}
+	}
+
+	if rootStep == nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("plan has no root step")}
+	}
+
+	// Fetch market data for cost calculations
+	jitaPrices, err := c.marketRepo.GetAllJitaPrices(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get Jita prices")}
+	}
+	adjustedPrices, err := c.marketRepo.GetAllAdjustedPrices(ctx)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get adjusted prices")}
+	}
+
+	// Create the plan run
+	run, err := c.runsRepo.Create(ctx, &models.ProductionPlanRun{
+		PlanID:   planID,
+		UserID:   *args.User,
+		Quantity: req.Quantity,
+	})
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to create plan run")}
+	}
+
+	result := &models.GenerateJobsResult{
+		Run:     run,
+		Created: []*models.IndustryJobQueueEntry{},
+		Skipped: []*models.GenerateJobSkipped{},
+	}
+
+	// Walk the tree depth-first, collect jobs bottom-up
+	var walkStep func(step *models.ProductionPlanStep, quantity int)
+	walkStep = func(step *models.ProductionPlanStep, quantity int) {
+		// Look up blueprint to get product quantity per run
+		bp, err := c.sdeRepo.GetManufacturingBlueprint(ctx, step.BlueprintTypeID)
+		if err != nil || bp == nil {
+			result.Skipped = append(result.Skipped, &models.GenerateJobSkipped{
+				TypeID:   step.ProductTypeID,
+				TypeName: step.ProductName,
+				Reason:   "blueprint data not found",
+			})
+			return
+		}
+
+		// Calculate runs needed
+		runs := int(math.Ceil(float64(quantity) / float64(bp.ProductQuantity)))
+		if runs <= 0 {
+			runs = 1
+		}
+
+		// Get materials for this step to calculate child needs
+		materials, err := c.sdeRepo.GetManufacturingMaterials(ctx, step.BlueprintTypeID)
+		if err != nil {
+			result.Skipped = append(result.Skipped, &models.GenerateJobSkipped{
+				TypeID:   step.ProductTypeID,
+				TypeName: step.ProductName,
+				Reason:   "failed to get materials",
+			})
+			return
+		}
+
+		// Calculate ME factor for batch quantity calculation
+		meFactor := calculator.ComputeManufacturingME(step.MELevel, step.Structure, step.Rig, step.Security)
+
+		// Process child steps (materials that are produced)
+		children := childStepsByParent[step.ID]
+		childProductTypeIDs := make(map[int64]*models.ProductionPlanStep)
+		for _, child := range children {
+			childProductTypeIDs[child.ProductTypeID] = child
+		}
+
+		for _, mat := range materials {
+			if childStep, ok := childProductTypeIDs[mat.TypeID]; ok {
+				// This material is produced — calculate needed quantity
+				batchQty := calculator.ComputeBatchQty(runs, mat.Quantity, meFactor)
+				walkStep(childStep, int(batchQty))
+			}
+		}
+
+		// Calculate cost for this step (manufacturing only)
+		var estimatedCost *float64
+		var estimatedDuration *int
+
+		if step.Activity == "manufacturing" {
+			params := &calculator.ManufacturingParams{
+				BlueprintME:      step.MELevel,
+				BlueprintTE:      step.TELevel,
+				Runs:             runs,
+				Structure:        step.Structure,
+				Rig:              step.Rig,
+				Security:         step.Security,
+				IndustrySkill:    step.IndustrySkill,
+				AdvIndustrySkill: step.AdvIndustrySkill,
+				FacilityTax:      step.FacilityTax,
+			}
+
+			data := &calculator.ManufacturingData{
+				Blueprint:      bp,
+				Materials:      materials,
+				CostIndex:      0,
+				AdjustedPrices: adjustedPrices,
+				JitaPrices:     jitaPrices,
+			}
+
+			calcResult := calculator.CalculateManufacturingJob(params, data)
+			estimatedCost = &calcResult.TotalCost
+			estimatedDuration = &calcResult.TotalDuration
+		}
+
+		// Create queue entry
+		productTypeID := step.ProductTypeID
+		stepID := step.ID
+		note := "Generated from plan: " + plan.Name
+		entry := &models.IndustryJobQueueEntry{
+			UserID:            *args.User,
+			BlueprintTypeID:   step.BlueprintTypeID,
+			Activity:          step.Activity,
+			Runs:              runs,
+			MELevel:           step.MELevel,
+			TELevel:           step.TELevel,
+			FacilityTax:       step.FacilityTax,
+			ProductTypeID:     &productTypeID,
+			EstimatedCost:     estimatedCost,
+			EstimatedDuration: estimatedDuration,
+			Notes:             &note,
+			PlanRunID:         &run.ID,
+			PlanStepID:        &stepID,
+		}
+
+		created, err := c.queueRepo.Create(ctx, entry)
+		if err != nil {
+			result.Skipped = append(result.Skipped, &models.GenerateJobSkipped{
+				TypeID:   step.ProductTypeID,
+				TypeName: step.ProductName,
+				Reason:   "failed to create queue entry: " + err.Error(),
+			})
+			return
+		}
+
+		result.Created = append(result.Created, created)
+	}
+
+	walkStep(rootStep, req.Quantity)
+
+	return result, nil
+}
+
+// GetPlanRuns lists all runs for a production plan.
+func (c *ProductionPlans) GetPlanRuns(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+
+	planID, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+
+	// Verify plan exists and belongs to user
+	plan, err := c.plansRepo.GetByID(ctx, planID, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get plan")}
+	}
+	if plan == nil {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.New("production plan not found")}
+	}
+
+	runs, err := c.runsRepo.GetByPlan(ctx, planID, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get plan runs")}
+	}
+
+	return runs, nil
+}
+
+// GetPlanRun returns a single plan run with its jobs.
+func (c *ProductionPlans) GetPlanRun(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+
+	planID, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+
+	runID, err := parseID(args.Params["runId"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid run ID")}
+	}
+
+	run, err := c.runsRepo.GetByID(ctx, runID, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get plan run")}
+	}
+	if run == nil || run.PlanID != planID {
+		return nil, &web.HttpError{StatusCode: 404, Error: errors.New("plan run not found")}
+	}
+
+	return run, nil
+}
+
+// DeletePlanRun deletes a plan run. Jobs survive but lose their plan_run_id link.
+func (c *ProductionPlans) DeletePlanRun(args *web.HandlerArgs) (any, *web.HttpError) {
+	ctx := args.Request.Context()
+
+	_, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid plan ID")}
+	}
+
+	runID, err := parseID(args.Params["runId"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid run ID")}
+	}
+
+	if err := c.runsRepo.Delete(ctx, runID, *args.User); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to delete plan run")}
+	}
+
+	return map[string]string{"status": "deleted"}, nil
+}

--- a/internal/controllers/productionPlans_test.go
+++ b/internal/controllers/productionPlans_test.go
@@ -1,0 +1,1252 @@
+package controllers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/controllers"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// --- Mock repositories ---
+
+type MockProductionPlansRepository struct {
+	mock.Mock
+}
+
+func (m *MockProductionPlansRepository) Create(ctx context.Context, plan *models.ProductionPlan) (*models.ProductionPlan, error) {
+	args := m.Called(ctx, plan)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProductionPlan), args.Error(1)
+}
+
+func (m *MockProductionPlansRepository) GetByUser(ctx context.Context, userID int64) ([]*models.ProductionPlan, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.ProductionPlan), args.Error(1)
+}
+
+func (m *MockProductionPlansRepository) GetByID(ctx context.Context, id, userID int64) (*models.ProductionPlan, error) {
+	args := m.Called(ctx, id, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProductionPlan), args.Error(1)
+}
+
+func (m *MockProductionPlansRepository) Update(ctx context.Context, id, userID int64, name string, notes *string, defaultManufacturingStationID *int64, defaultReactionStationID *int64) error {
+	args := m.Called(ctx, id, userID, name, notes, defaultManufacturingStationID, defaultReactionStationID)
+	return args.Error(0)
+}
+
+func (m *MockProductionPlansRepository) Delete(ctx context.Context, id, userID int64) error {
+	args := m.Called(ctx, id, userID)
+	return args.Error(0)
+}
+
+func (m *MockProductionPlansRepository) CreateStep(ctx context.Context, step *models.ProductionPlanStep) (*models.ProductionPlanStep, error) {
+	args := m.Called(ctx, step)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProductionPlanStep), args.Error(1)
+}
+
+func (m *MockProductionPlansRepository) UpdateStep(ctx context.Context, stepID, planID, userID int64, step *models.ProductionPlanStep) error {
+	args := m.Called(ctx, stepID, planID, userID, step)
+	return args.Error(0)
+}
+
+func (m *MockProductionPlansRepository) BatchUpdateSteps(ctx context.Context, stepIDs []int64, planID, userID int64, step *models.ProductionPlanStep) (int64, error) {
+	args := m.Called(ctx, stepIDs, planID, userID, step)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockProductionPlansRepository) DeleteStep(ctx context.Context, stepID, planID, userID int64) error {
+	args := m.Called(ctx, stepID, planID, userID)
+	return args.Error(0)
+}
+
+func (m *MockProductionPlansRepository) GetStepMaterials(ctx context.Context, stepID, planID, userID int64) ([]*models.PlanMaterial, error) {
+	args := m.Called(ctx, stepID, planID, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.PlanMaterial), args.Error(1)
+}
+
+func (m *MockProductionPlansRepository) GetContainersAtStation(ctx context.Context, userID, stationID int64) ([]*models.StationContainer, error) {
+	args := m.Called(ctx, userID, stationID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.StationContainer), args.Error(1)
+}
+
+type MockProductionPlansCharacterRepository struct {
+	mock.Mock
+}
+
+func (m *MockProductionPlansCharacterRepository) GetNames(ctx context.Context, userID int64) (map[int64]string, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[int64]string), args.Error(1)
+}
+
+type MockProductionPlansCorporationRepository struct {
+	mock.Mock
+}
+
+func (m *MockProductionPlansCorporationRepository) Get(ctx context.Context, user int64) ([]repositories.PlayerCorporation, error) {
+	args := m.Called(ctx, user)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]repositories.PlayerCorporation), args.Error(1)
+}
+
+func (m *MockProductionPlansCorporationRepository) GetDivisions(ctx context.Context, corp, user int64) (*models.CorporationDivisions, error) {
+	args := m.Called(ctx, corp, user)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.CorporationDivisions), args.Error(1)
+}
+
+type MockProductionPlansUserStationRepository struct {
+	mock.Mock
+}
+
+func (m *MockProductionPlansUserStationRepository) GetByID(ctx context.Context, id, userID int64) (*models.UserStation, error) {
+	args := m.Called(ctx, id, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.UserStation), args.Error(1)
+}
+
+type MockProductionPlansSdeRepository struct {
+	mock.Mock
+}
+
+func (m *MockProductionPlansSdeRepository) GetBlueprintByProduct(ctx context.Context, productTypeID int64) (*repositories.BlueprintProductRow, error) {
+	args := m.Called(ctx, productTypeID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repositories.BlueprintProductRow), args.Error(1)
+}
+
+func (m *MockProductionPlansSdeRepository) GetManufacturingBlueprint(ctx context.Context, blueprintTypeID int64) (*repositories.ManufacturingBlueprintRow, error) {
+	args := m.Called(ctx, blueprintTypeID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repositories.ManufacturingBlueprintRow), args.Error(1)
+}
+
+func (m *MockProductionPlansSdeRepository) GetManufacturingMaterials(ctx context.Context, blueprintTypeID int64) ([]*repositories.ManufacturingMaterialRow, error) {
+	args := m.Called(ctx, blueprintTypeID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*repositories.ManufacturingMaterialRow), args.Error(1)
+}
+
+type MockProductionPlansMarketRepository struct {
+	mock.Mock
+}
+
+func (m *MockProductionPlansMarketRepository) GetAllJitaPrices(ctx context.Context) (map[int64]*models.MarketPrice, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[int64]*models.MarketPrice), args.Error(1)
+}
+
+func (m *MockProductionPlansMarketRepository) GetAllAdjustedPrices(ctx context.Context) (map[int64]float64, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[int64]float64), args.Error(1)
+}
+
+type MockProductionPlansCostIndicesRepository struct {
+	mock.Mock
+}
+
+func (m *MockProductionPlansCostIndicesRepository) GetCostIndex(ctx context.Context, systemID int64, activity string) (*models.IndustryCostIndex, error) {
+	args := m.Called(ctx, systemID, activity)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.IndustryCostIndex), args.Error(1)
+}
+
+type MockProductionPlansJobQueueRepository struct {
+	mock.Mock
+}
+
+func (m *MockProductionPlansJobQueueRepository) Create(ctx context.Context, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error) {
+	args := m.Called(ctx, entry)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.IndustryJobQueueEntry), args.Error(1)
+}
+
+type MockProductionPlanRunsRepository struct {
+	mock.Mock
+}
+
+func (m *MockProductionPlanRunsRepository) Create(ctx context.Context, run *models.ProductionPlanRun) (*models.ProductionPlanRun, error) {
+	args := m.Called(ctx, run)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProductionPlanRun), args.Error(1)
+}
+
+func (m *MockProductionPlanRunsRepository) GetByPlan(ctx context.Context, planID, userID int64) ([]*models.ProductionPlanRun, error) {
+	args := m.Called(ctx, planID, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.ProductionPlanRun), args.Error(1)
+}
+
+func (m *MockProductionPlanRunsRepository) GetByID(ctx context.Context, runID, userID int64) (*models.ProductionPlanRun, error) {
+	args := m.Called(ctx, runID, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProductionPlanRun), args.Error(1)
+}
+
+func (m *MockProductionPlanRunsRepository) Delete(ctx context.Context, runID, userID int64) error {
+	args := m.Called(ctx, runID, userID)
+	return args.Error(0)
+}
+
+// --- Helper ---
+
+type productionPlanMocks struct {
+	plansRepo       *MockProductionPlansRepository
+	sdeRepo         *MockProductionPlansSdeRepository
+	queueRepo       *MockProductionPlansJobQueueRepository
+	marketRepo      *MockProductionPlansMarketRepository
+	costIndicesRepo *MockProductionPlansCostIndicesRepository
+	characterRepo   *MockProductionPlansCharacterRepository
+	corpRepo        *MockProductionPlansCorporationRepository
+	stationRepo     *MockProductionPlansUserStationRepository
+	runsRepo        *MockProductionPlanRunsRepository
+}
+
+func setupProductionPlansController() (*controllers.ProductionPlans, *productionPlanMocks) {
+	mocks := &productionPlanMocks{
+		plansRepo:       new(MockProductionPlansRepository),
+		sdeRepo:         new(MockProductionPlansSdeRepository),
+		queueRepo:       new(MockProductionPlansJobQueueRepository),
+		marketRepo:      new(MockProductionPlansMarketRepository),
+		costIndicesRepo: new(MockProductionPlansCostIndicesRepository),
+		characterRepo:   new(MockProductionPlansCharacterRepository),
+		corpRepo:        new(MockProductionPlansCorporationRepository),
+		stationRepo:     new(MockProductionPlansUserStationRepository),
+		runsRepo:        new(MockProductionPlanRunsRepository),
+	}
+
+	controller := controllers.NewProductionPlans(
+		&MockRouter{},
+		mocks.plansRepo,
+		mocks.sdeRepo,
+		mocks.queueRepo,
+		mocks.marketRepo,
+		mocks.costIndicesRepo,
+		mocks.characterRepo,
+		mocks.corpRepo,
+		mocks.stationRepo,
+		mocks.runsRepo,
+	)
+
+	return controller, mocks
+}
+
+// --- GetPlans Tests ---
+
+func Test_ProductionPlans_GetPlans_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	expectedPlans := []*models.ProductionPlan{
+		{ID: 1, UserID: 100, ProductTypeID: 587, Name: "Rifter", ProductName: "Rifter"},
+		{ID: 2, UserID: 100, ProductTypeID: 34, Name: "Tritanium Plan", ProductName: "Tritanium"},
+	}
+
+	mocks.plansRepo.On("GetByUser", mock.Anything, userID).Return(expectedPlans, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetPlans(args)
+
+	assert.Nil(t, httpErr)
+	plans := result.([]*models.ProductionPlan)
+	assert.Len(t, plans, 2)
+	assert.Equal(t, "Rifter", plans[0].Name)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_GetPlans_Error(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.plansRepo.On("GetByUser", mock.Anything, userID).Return(nil, errors.New("db error"))
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetPlans(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 500, httpErr.StatusCode)
+}
+
+// --- CreatePlan Tests ---
+
+func Test_ProductionPlans_CreatePlan_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+
+	mocks.sdeRepo.On("GetBlueprintByProduct", mock.Anything, int64(587)).Return(&repositories.BlueprintProductRow{
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		ProductQuantity: 1,
+	}, nil)
+
+	mocks.sdeRepo.On("GetManufacturingBlueprint", mock.Anything, int64(787)).Return(&repositories.ManufacturingBlueprintRow{
+		BlueprintTypeID: 787,
+		ProductTypeID:   587,
+		ProductName:     "Rifter",
+		ProductQuantity: 1,
+		Time:            7200,
+	}, nil)
+
+	mocks.plansRepo.On("Create", mock.Anything, mock.MatchedBy(func(p *models.ProductionPlan) bool {
+		return p.ProductTypeID == 587 && p.Name == "Rifter"
+	})).Return(&models.ProductionPlan{
+		ID: 1, UserID: 100, ProductTypeID: 587, Name: "Rifter",
+	}, nil)
+
+	mocks.plansRepo.On("CreateStep", mock.Anything, mock.MatchedBy(func(s *models.ProductionPlanStep) bool {
+		return s.PlanID == 1 && s.BlueprintTypeID == 787 && s.Activity == "manufacturing" && s.ParentStepID == nil
+	})).Return(&models.ProductionPlanStep{
+		ID: 10, PlanID: 1, BlueprintTypeID: 787,
+	}, nil)
+
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(&models.ProductionPlan{
+		ID: 1, UserID: 100, ProductTypeID: 587, Name: "Rifter", ProductName: "Rifter",
+		Steps: []*models.ProductionPlanStep{
+			{ID: 10, PlanID: 1, BlueprintTypeID: 787, Activity: "manufacturing", ProductName: "Rifter"},
+		},
+	}, nil)
+
+	body, _ := json.Marshal(map[string]any{"product_type_id": 587})
+	req := httptest.NewRequest("POST", "/v1/industry/plans", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreatePlan(args)
+
+	assert.Nil(t, httpErr)
+	plan := result.(*models.ProductionPlan)
+	assert.Equal(t, "Rifter", plan.Name)
+	assert.Len(t, plan.Steps, 1)
+	mocks.plansRepo.AssertExpectations(t)
+	mocks.sdeRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_CreatePlan_NoBlueprintFound(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+
+	mocks.sdeRepo.On("GetBlueprintByProduct", mock.Anything, int64(34)).Return(nil, nil)
+
+	body, _ := json.Marshal(map[string]any{"product_type_id": 34})
+	req := httptest.NewRequest("POST", "/v1/industry/plans", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreatePlan(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_ProductionPlans_CreatePlan_MissingProductTypeID(t *testing.T) {
+	controller, _ := setupProductionPlansController()
+
+	userID := int64(100)
+
+	body, _ := json.Marshal(map[string]any{})
+	req := httptest.NewRequest("POST", "/v1/industry/plans", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreatePlan(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+// --- GetPlan Tests ---
+
+func Test_ProductionPlans_GetPlan_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	expected := &models.ProductionPlan{
+		ID: 1, UserID: 100, ProductTypeID: 587, Name: "Rifter",
+		Steps: []*models.ProductionPlanStep{
+			{ID: 10, PlanID: 1, Activity: "manufacturing"},
+		},
+	}
+
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(expected, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/1", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.GetPlan(args)
+
+	assert.Nil(t, httpErr)
+	plan := result.(*models.ProductionPlan)
+	assert.Equal(t, "Rifter", plan.Name)
+	assert.Len(t, plan.Steps, 1)
+}
+
+func Test_ProductionPlans_GetPlan_NotFound(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(999), userID).Return(nil, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/999", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "999"}}
+
+	result, httpErr := controller.GetPlan(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+}
+
+// --- DeletePlan Tests ---
+
+func Test_ProductionPlans_DeletePlan_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.plansRepo.On("Delete", mock.Anything, int64(1), userID).Return(nil)
+
+	req := httptest.NewRequest("DELETE", "/v1/industry/plans/1", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.DeletePlan(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+// --- CreateStep Tests ---
+
+func Test_ProductionPlans_CreateStep_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(&models.ProductionPlan{
+		ID: 1, UserID: 100,
+		Steps: []*models.ProductionPlanStep{{ID: 10, PlanID: 1}},
+	}, nil)
+
+	mocks.sdeRepo.On("GetBlueprintByProduct", mock.Anything, int64(34)).Return(&repositories.BlueprintProductRow{
+		BlueprintTypeID: 100,
+		Activity:        "manufacturing",
+		ProductQuantity: 1,
+	}, nil)
+
+	mocks.plansRepo.On("CreateStep", mock.Anything, mock.MatchedBy(func(s *models.ProductionPlanStep) bool {
+		return s.PlanID == 1 && *s.ParentStepID == 10 && s.ProductTypeID == 34 && s.BlueprintTypeID == 100
+	})).Return(&models.ProductionPlanStep{
+		ID: 20, PlanID: 1, ProductTypeID: 34, BlueprintTypeID: 100,
+	}, nil)
+
+	body, _ := json.Marshal(map[string]any{"parent_step_id": 10, "product_type_id": 34})
+	req := httptest.NewRequest("POST", "/v1/industry/plans/1/steps", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.CreateStep(args)
+
+	assert.Nil(t, httpErr)
+	step := result.(*models.ProductionPlanStep)
+	assert.Equal(t, int64(20), step.ID)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_CreateStep_NoBlueprintForMaterial(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(&models.ProductionPlan{
+		ID: 1, UserID: 100, Steps: []*models.ProductionPlanStep{{ID: 10}},
+	}, nil)
+
+	mocks.sdeRepo.On("GetBlueprintByProduct", mock.Anything, int64(9999)).Return(nil, nil)
+
+	body, _ := json.Marshal(map[string]any{"parent_step_id": 10, "product_type_id": 9999})
+	req := httptest.NewRequest("POST", "/v1/industry/plans/1/steps", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.CreateStep(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+// --- UpdateStep Tests ---
+
+func Test_ProductionPlans_UpdateStep_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.plansRepo.On("UpdateStep", mock.Anything, int64(10), int64(1), userID, mock.Anything).Return(nil)
+
+	body, _ := json.Marshal(map[string]any{
+		"me_level": 8, "te_level": 16,
+		"structure": "azbel", "rig": "t2", "security": "low",
+		"facility_tax": 2.5,
+	})
+	req := httptest.NewRequest("PUT", "/v1/industry/plans/1/steps/10", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1", "stepId": "10"}}
+
+	result, httpErr := controller.UpdateStep(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_UpdateStep_WithOutputLocation(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.plansRepo.On("UpdateStep", mock.Anything, int64(10), int64(1), userID, mock.MatchedBy(func(step *models.ProductionPlanStep) bool {
+		return step.OutputOwnerType != nil && *step.OutputOwnerType == "corporation" &&
+			step.OutputOwnerID != nil && *step.OutputOwnerID == int64(5000) &&
+			step.OutputDivisionNumber != nil && *step.OutputDivisionNumber == 3 &&
+			step.OutputContainerID != nil && *step.OutputContainerID == int64(9999)
+	})).Return(nil)
+
+	ownerType := "corporation"
+	ownerID := int64(5000)
+	divNum := 3
+	containerID := int64(9999)
+	body, _ := json.Marshal(map[string]any{
+		"me_level": 10, "te_level": 20,
+		"structure": "raitaru", "rig": "t2", "security": "high",
+		"facility_tax":           1.0,
+		"output_owner_type":      ownerType,
+		"output_owner_id":        ownerID,
+		"output_division_number": divNum,
+		"output_container_id":    containerID,
+	})
+	req := httptest.NewRequest("PUT", "/v1/industry/plans/1/steps/10", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1", "stepId": "10"}}
+
+	result, httpErr := controller.UpdateStep(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+// --- DeleteStep Tests ---
+
+func Test_ProductionPlans_DeleteStep_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.plansRepo.On("DeleteStep", mock.Anything, int64(10), int64(1), userID).Return(nil)
+
+	req := httptest.NewRequest("DELETE", "/v1/industry/plans/1/steps/10", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1", "stepId": "10"}}
+
+	result, httpErr := controller.DeleteStep(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+// --- GetStepMaterials Tests ---
+
+func Test_ProductionPlans_GetStepMaterials_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	bpTypeID := int64(100)
+	activity := "manufacturing"
+	expectedMaterials := []*models.PlanMaterial{
+		{TypeID: 34, TypeName: "Tritanium", Quantity: 1000, HasBlueprint: false, IsProduced: false},
+		{TypeID: 35, TypeName: "Pyerite", Quantity: 500, HasBlueprint: false, IsProduced: false},
+		{TypeID: 5678, TypeName: "Component", Quantity: 10, HasBlueprint: true, BlueprintTypeID: &bpTypeID, Activity: &activity, IsProduced: false},
+	}
+
+	mocks.plansRepo.On("GetStepMaterials", mock.Anything, int64(10), int64(1), userID).Return(expectedMaterials, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/1/steps/10/materials", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1", "stepId": "10"}}
+
+	result, httpErr := controller.GetStepMaterials(args)
+
+	assert.Nil(t, httpErr)
+	materials := result.([]*models.PlanMaterial)
+	assert.Len(t, materials, 3)
+	assert.False(t, materials[0].HasBlueprint)
+	assert.True(t, materials[2].HasBlueprint)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+// --- GenerateJobs Tests ---
+
+func Test_ProductionPlans_GenerateJobs_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	rootStepID := int64(10)
+
+	plan := &models.ProductionPlan{
+		ID: 1, UserID: 100, ProductTypeID: 587, Name: "Rifter",
+		Steps: []*models.ProductionPlanStep{
+			{
+				ID: rootStepID, PlanID: 1, ProductTypeID: 587, BlueprintTypeID: 787,
+				Activity: "manufacturing", MELevel: 10, TELevel: 20,
+				IndustrySkill: 5, AdvIndustrySkill: 5,
+				Structure: "raitaru", Rig: "t2", Security: "high", FacilityTax: 1.0,
+				ProductName: "Rifter",
+			},
+		},
+	}
+
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(plan, nil)
+
+	mocks.marketRepo.On("GetAllJitaPrices", mock.Anything).Return(map[int64]*models.MarketPrice{}, nil)
+	mocks.marketRepo.On("GetAllAdjustedPrices", mock.Anything).Return(map[int64]float64{}, nil)
+
+	mocks.runsRepo.On("Create", mock.Anything, mock.MatchedBy(func(r *models.ProductionPlanRun) bool {
+		return r.PlanID == 1 && r.UserID == 100 && r.Quantity == 40
+	})).Return(&models.ProductionPlanRun{
+		ID: 50, PlanID: 1, UserID: 100, Quantity: 40,
+	}, nil)
+
+	mocks.sdeRepo.On("GetManufacturingBlueprint", mock.Anything, int64(787)).Return(&repositories.ManufacturingBlueprintRow{
+		BlueprintTypeID: 787, ProductTypeID: 587, ProductName: "Rifter",
+		ProductQuantity: 1, Time: 7200,
+	}, nil)
+
+	mocks.sdeRepo.On("GetManufacturingMaterials", mock.Anything, int64(787)).Return([]*repositories.ManufacturingMaterialRow{
+		{BlueprintTypeID: 787, TypeID: 34, TypeName: "Tritanium", Quantity: 1000},
+	}, nil)
+
+	mocks.queueRepo.On("Create", mock.Anything, mock.MatchedBy(func(e *models.IndustryJobQueueEntry) bool {
+		return e.BlueprintTypeID == 787 && e.Runs == 40 && e.Activity == "manufacturing"
+	})).Return(&models.IndustryJobQueueEntry{
+		ID: 99, UserID: 100, BlueprintTypeID: 787, Activity: "manufacturing", Runs: 40, Status: "planned",
+	}, nil)
+
+	body, _ := json.Marshal(map[string]any{"quantity": 40})
+	req := httptest.NewRequest("POST", "/v1/industry/plans/1/generate", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.GenerateJobs(args)
+
+	assert.Nil(t, httpErr)
+	genResult := result.(*models.GenerateJobsResult)
+	assert.NotNil(t, genResult.Run)
+	assert.Equal(t, int64(50), genResult.Run.ID)
+	assert.Equal(t, 40, genResult.Run.Quantity)
+	assert.Len(t, genResult.Created, 1)
+	assert.Len(t, genResult.Skipped, 0)
+	assert.Equal(t, 40, genResult.Created[0].Runs)
+}
+
+func Test_ProductionPlans_GenerateJobs_WithChildStep(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	rootStepID := int64(10)
+	childStepID := int64(20)
+	parentRef := rootStepID
+
+	plan := &models.ProductionPlan{
+		ID: 1, UserID: 100, ProductTypeID: 587, Name: "Rifter",
+		Steps: []*models.ProductionPlanStep{
+			{
+				ID: rootStepID, PlanID: 1, ProductTypeID: 587, BlueprintTypeID: 787,
+				Activity: "manufacturing", MELevel: 10, TELevel: 20,
+				IndustrySkill: 5, AdvIndustrySkill: 5,
+				Structure: "raitaru", Rig: "t2", Security: "high", FacilityTax: 1.0,
+				ProductName: "Rifter",
+			},
+			{
+				ID: childStepID, PlanID: 1, ParentStepID: &parentRef,
+				ProductTypeID: 5678, BlueprintTypeID: 1234,
+				Activity: "manufacturing", MELevel: 10, TELevel: 20,
+				IndustrySkill: 5, AdvIndustrySkill: 5,
+				Structure: "raitaru", Rig: "t2", Security: "high", FacilityTax: 1.0,
+				ProductName: "Component",
+			},
+		},
+	}
+
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(plan, nil)
+	mocks.marketRepo.On("GetAllJitaPrices", mock.Anything).Return(map[int64]*models.MarketPrice{}, nil)
+	mocks.marketRepo.On("GetAllAdjustedPrices", mock.Anything).Return(map[int64]float64{}, nil)
+
+	mocks.runsRepo.On("Create", mock.Anything, mock.Anything).Return(&models.ProductionPlanRun{
+		ID: 51, PlanID: 1, UserID: 100, Quantity: 2,
+	}, nil)
+
+	// Root blueprint: produces 1 Rifter per run, needs 10 Components
+	mocks.sdeRepo.On("GetManufacturingBlueprint", mock.Anything, int64(787)).Return(&repositories.ManufacturingBlueprintRow{
+		BlueprintTypeID: 787, ProductTypeID: 587, ProductName: "Rifter",
+		ProductQuantity: 1, Time: 7200,
+	}, nil)
+	mocks.sdeRepo.On("GetManufacturingMaterials", mock.Anything, int64(787)).Return([]*repositories.ManufacturingMaterialRow{
+		{BlueprintTypeID: 787, TypeID: 5678, TypeName: "Component", Quantity: 10},
+		{BlueprintTypeID: 787, TypeID: 34, TypeName: "Tritanium", Quantity: 1000},
+	}, nil)
+
+	// Child blueprint: produces 5 Components per run
+	mocks.sdeRepo.On("GetManufacturingBlueprint", mock.Anything, int64(1234)).Return(&repositories.ManufacturingBlueprintRow{
+		BlueprintTypeID: 1234, ProductTypeID: 5678, ProductName: "Component",
+		ProductQuantity: 5, Time: 3600,
+	}, nil)
+	mocks.sdeRepo.On("GetManufacturingMaterials", mock.Anything, int64(1234)).Return([]*repositories.ManufacturingMaterialRow{
+		{BlueprintTypeID: 1234, TypeID: 34, TypeName: "Tritanium", Quantity: 100},
+	}, nil)
+
+	// Expect child queue entry created first (depth-first bottom-up)
+	mocks.queueRepo.On("Create", mock.Anything, mock.MatchedBy(func(e *models.IndustryJobQueueEntry) bool {
+		return e.BlueprintTypeID == 1234
+	})).Return(&models.IndustryJobQueueEntry{
+		ID: 98, BlueprintTypeID: 1234, Activity: "manufacturing", Status: "planned",
+	}, nil).Once()
+
+	// Then root queue entry
+	mocks.queueRepo.On("Create", mock.Anything, mock.MatchedBy(func(e *models.IndustryJobQueueEntry) bool {
+		return e.BlueprintTypeID == 787
+	})).Return(&models.IndustryJobQueueEntry{
+		ID: 99, BlueprintTypeID: 787, Activity: "manufacturing", Runs: 2, Status: "planned",
+	}, nil).Once()
+
+	body, _ := json.Marshal(map[string]any{"quantity": 2})
+	req := httptest.NewRequest("POST", "/v1/industry/plans/1/generate", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.GenerateJobs(args)
+
+	assert.Nil(t, httpErr)
+	genResult := result.(*models.GenerateJobsResult)
+	assert.Len(t, genResult.Created, 2)
+	assert.Len(t, genResult.Skipped, 0)
+	// Child should be created first (bottom-up)
+	assert.Equal(t, int64(1234), genResult.Created[0].BlueprintTypeID)
+	assert.Equal(t, int64(787), genResult.Created[1].BlueprintTypeID)
+}
+
+func Test_ProductionPlans_GenerateJobs_PlanNotFound(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(999), userID).Return(nil, nil)
+
+	body, _ := json.Marshal(map[string]any{"quantity": 10})
+	req := httptest.NewRequest("POST", "/v1/industry/plans/999/generate", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "999"}}
+
+	result, httpErr := controller.GenerateJobs(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+}
+
+func Test_ProductionPlans_GenerateJobs_InvalidQuantity(t *testing.T) {
+	controller, _ := setupProductionPlansController()
+
+	userID := int64(100)
+
+	body, _ := json.Marshal(map[string]any{"quantity": 0})
+	req := httptest.NewRequest("POST", "/v1/industry/plans/1/generate", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.GenerateJobs(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_ProductionPlans_GenerateJobs_BlueprintDataMissing(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+
+	plan := &models.ProductionPlan{
+		ID: 1, UserID: 100, ProductTypeID: 587, Name: "Rifter",
+		Steps: []*models.ProductionPlanStep{
+			{
+				ID: 10, PlanID: 1, ProductTypeID: 587, BlueprintTypeID: 787,
+				Activity: "manufacturing", MELevel: 10, TELevel: 20,
+				Structure: "raitaru", Rig: "t2", Security: "high", FacilityTax: 1.0,
+				ProductName: "Rifter",
+			},
+		},
+	}
+
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(plan, nil)
+	mocks.marketRepo.On("GetAllJitaPrices", mock.Anything).Return(map[int64]*models.MarketPrice{}, nil)
+	mocks.marketRepo.On("GetAllAdjustedPrices", mock.Anything).Return(map[int64]float64{}, nil)
+
+	mocks.runsRepo.On("Create", mock.Anything, mock.Anything).Return(&models.ProductionPlanRun{
+		ID: 52, PlanID: 1, UserID: 100, Quantity: 10,
+	}, nil)
+
+	// Blueprint data not found
+	mocks.sdeRepo.On("GetManufacturingBlueprint", mock.Anything, int64(787)).Return(nil, nil)
+
+	body, _ := json.Marshal(map[string]any{"quantity": 10})
+	req := httptest.NewRequest("POST", "/v1/industry/plans/1/generate", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.GenerateJobs(args)
+
+	assert.Nil(t, httpErr)
+	genResult := result.(*models.GenerateJobsResult)
+	assert.Len(t, genResult.Created, 0)
+	assert.Len(t, genResult.Skipped, 1)
+	assert.Equal(t, "blueprint data not found", genResult.Skipped[0].Reason)
+}
+
+// --- Default Station Tests ---
+
+func Test_ProductionPlans_CreatePlan_WithDefaultStations(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mfgStationID := int64(5)
+
+	mocks.sdeRepo.On("GetBlueprintByProduct", mock.Anything, int64(587)).Return(&repositories.BlueprintProductRow{
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		ProductQuantity: 1,
+	}, nil)
+
+	mocks.sdeRepo.On("GetManufacturingBlueprint", mock.Anything, int64(787)).Return(&repositories.ManufacturingBlueprintRow{
+		BlueprintTypeID: 787, ProductTypeID: 587, ProductName: "Rifter",
+		ProductQuantity: 1, Time: 7200,
+	}, nil)
+
+	mocks.plansRepo.On("Create", mock.Anything, mock.MatchedBy(func(p *models.ProductionPlan) bool {
+		return p.ProductTypeID == 587 &&
+			p.DefaultManufacturingStationID != nil && *p.DefaultManufacturingStationID == 5
+	})).Return(&models.ProductionPlan{
+		ID: 1, UserID: 100, ProductTypeID: 587, Name: "Rifter",
+		DefaultManufacturingStationID: &mfgStationID,
+	}, nil)
+
+	// Root step should have UserStationID set to manufacturing station
+	mocks.plansRepo.On("CreateStep", mock.Anything, mock.MatchedBy(func(s *models.ProductionPlanStep) bool {
+		return s.PlanID == 1 && s.Activity == "manufacturing" &&
+			s.UserStationID != nil && *s.UserStationID == 5
+	})).Return(&models.ProductionPlanStep{
+		ID: 10, PlanID: 1, BlueprintTypeID: 787, UserStationID: &mfgStationID,
+	}, nil)
+
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(&models.ProductionPlan{
+		ID: 1, UserID: 100, ProductTypeID: 587, Name: "Rifter",
+		DefaultManufacturingStationID: &mfgStationID,
+		Steps: []*models.ProductionPlanStep{
+			{ID: 10, PlanID: 1, BlueprintTypeID: 787, Activity: "manufacturing", UserStationID: &mfgStationID},
+		},
+	}, nil)
+
+	body, _ := json.Marshal(map[string]any{
+		"product_type_id":                   587,
+		"default_manufacturing_station_id": 5,
+	})
+	req := httptest.NewRequest("POST", "/v1/industry/plans", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.CreatePlan(args)
+
+	assert.Nil(t, httpErr)
+	plan := result.(*models.ProductionPlan)
+	assert.NotNil(t, plan.DefaultManufacturingStationID)
+	assert.Equal(t, int64(5), *plan.DefaultManufacturingStationID)
+	assert.NotNil(t, plan.Steps[0].UserStationID)
+	assert.Equal(t, int64(5), *plan.Steps[0].UserStationID)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_CreateStep_InheritsDefaultStation(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mfgStationID := int64(5)
+
+	// Plan has a default manufacturing station
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(&models.ProductionPlan{
+		ID: 1, UserID: 100,
+		DefaultManufacturingStationID: &mfgStationID,
+		Steps:                         []*models.ProductionPlanStep{{ID: 10, PlanID: 1}},
+	}, nil)
+
+	mocks.sdeRepo.On("GetBlueprintByProduct", mock.Anything, int64(34)).Return(&repositories.BlueprintProductRow{
+		BlueprintTypeID: 100,
+		Activity:        "manufacturing",
+		ProductQuantity: 1,
+	}, nil)
+
+	// Step should inherit the manufacturing station
+	mocks.plansRepo.On("CreateStep", mock.Anything, mock.MatchedBy(func(s *models.ProductionPlanStep) bool {
+		return s.PlanID == 1 && s.ProductTypeID == 34 &&
+			s.UserStationID != nil && *s.UserStationID == 5
+	})).Return(&models.ProductionPlanStep{
+		ID: 20, PlanID: 1, ProductTypeID: 34, UserStationID: &mfgStationID,
+	}, nil)
+
+	body, _ := json.Marshal(map[string]any{"parent_step_id": 10, "product_type_id": 34})
+	req := httptest.NewRequest("POST", "/v1/industry/plans/1/steps", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.CreateStep(args)
+
+	assert.Nil(t, httpErr)
+	step := result.(*models.ProductionPlanStep)
+	assert.NotNil(t, step.UserStationID)
+	assert.Equal(t, int64(5), *step.UserStationID)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_CreateStep_InheritsReactionStation(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	rxnStationID := int64(7)
+
+	// Plan has a default reaction station
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(&models.ProductionPlan{
+		ID: 1, UserID: 100,
+		DefaultReactionStationID: &rxnStationID,
+		Steps:                    []*models.ProductionPlanStep{{ID: 10, PlanID: 1}},
+	}, nil)
+
+	mocks.sdeRepo.On("GetBlueprintByProduct", mock.Anything, int64(9000)).Return(&repositories.BlueprintProductRow{
+		BlueprintTypeID: 9001,
+		Activity:        "reaction",
+		ProductQuantity: 1,
+	}, nil)
+
+	// Step should inherit the reaction station
+	mocks.plansRepo.On("CreateStep", mock.Anything, mock.MatchedBy(func(s *models.ProductionPlanStep) bool {
+		return s.PlanID == 1 && s.ProductTypeID == 9000 &&
+			s.UserStationID != nil && *s.UserStationID == 7
+	})).Return(&models.ProductionPlanStep{
+		ID: 30, PlanID: 1, ProductTypeID: 9000, UserStationID: &rxnStationID,
+	}, nil)
+
+	body, _ := json.Marshal(map[string]any{"parent_step_id": 10, "product_type_id": 9000})
+	req := httptest.NewRequest("POST", "/v1/industry/plans/1/steps", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.CreateStep(args)
+
+	assert.Nil(t, httpErr)
+	step := result.(*models.ProductionPlanStep)
+	assert.NotNil(t, step.UserStationID)
+	assert.Equal(t, int64(7), *step.UserStationID)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+// --- GetHangars Tests ---
+
+func Test_ProductionPlans_GetHangars_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	stationID := int64(60003760)
+
+	mocks.stationRepo.On("GetByID", mock.Anything, int64(5), userID).Return(&models.UserStation{
+		ID: 5, StationID: stationID,
+	}, nil)
+
+	mocks.characterRepo.On("GetNames", mock.Anything, userID).Return(map[int64]string{
+		1001: "Main Char",
+		1002: "Alt Char",
+	}, nil)
+
+	mocks.corpRepo.On("Get", mock.Anything, userID).Return([]repositories.PlayerCorporation{
+		{ID: 2001, Name: "My Corp"},
+	}, nil)
+
+	mocks.corpRepo.On("GetDivisions", mock.Anything, int64(2001), userID).Return(&models.CorporationDivisions{
+		Hanger: map[int]string{1: "Main Hangar", 2: "Manufacturing"},
+		Wallet: map[int]string{},
+	}, nil)
+
+	divNum := 2
+	mocks.plansRepo.On("GetContainersAtStation", mock.Anything, userID, stationID).Return([]*models.StationContainer{
+		{ID: 99001, Name: "BPC Container", OwnerType: "character", OwnerID: 1001},
+		{ID: 99002, Name: "Components Box", OwnerType: "corporation", OwnerID: 2001, DivisionNumber: &divNum},
+	}, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/hangars?user_station_id=5", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetHangars(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	// Verify character/corp/container data
+	mocks.stationRepo.AssertExpectations(t)
+	mocks.characterRepo.AssertExpectations(t)
+	mocks.corpRepo.AssertExpectations(t)
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_GetHangars_MissingStationID(t *testing.T) {
+	controller, _ := setupProductionPlansController()
+
+	userID := int64(100)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/hangars", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetHangars(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+// --- BatchUpdateSteps Tests ---
+
+func Test_ProductionPlans_BatchUpdateSteps_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.plansRepo.On("BatchUpdateSteps", mock.Anything,
+		[]int64{10, 20, 30}, int64(1), userID,
+		mock.MatchedBy(func(step *models.ProductionPlanStep) bool {
+			return step.MELevel == 8 && step.TELevel == 16 && step.Structure == "azbel"
+		}),
+	).Return(int64(3), nil)
+
+	body, _ := json.Marshal(map[string]any{
+		"step_ids":     []int64{10, 20, 30},
+		"me_level":     8,
+		"te_level":     16,
+		"structure":    "azbel",
+		"rig":          "t2",
+		"security":     "low",
+		"facility_tax": 2.5,
+	})
+	req := httptest.NewRequest("PUT", "/v1/industry/plans/1/steps/batch", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.BatchUpdateSteps(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	resultMap := result.(map[string]any)
+	assert.Equal(t, "updated", resultMap["status"])
+	assert.Equal(t, int64(3), resultMap["rows_affected"])
+	mocks.plansRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_BatchUpdateSteps_EmptyStepIDs(t *testing.T) {
+	controller, _ := setupProductionPlansController()
+
+	userID := int64(100)
+
+	body, _ := json.Marshal(map[string]any{
+		"step_ids":     []int64{},
+		"me_level":     10,
+		"te_level":     20,
+		"structure":    "raitaru",
+		"rig":          "t2",
+		"security":     "high",
+		"facility_tax": 1.0,
+	})
+	req := httptest.NewRequest("PUT", "/v1/industry/plans/1/steps/batch", bytes.NewReader(body))
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.BatchUpdateSteps(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_ProductionPlans_GetHangars_StationNotFound(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+
+	mocks.stationRepo.On("GetByID", mock.Anything, int64(999), userID).Return(nil, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/hangars?user_station_id=999", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID}
+
+	result, httpErr := controller.GetHangars(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+}
+
+// --- Plan Runs Tests ---
+
+func Test_ProductionPlans_GetPlanRuns_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(1), userID).Return(&models.ProductionPlan{
+		ID: 1, UserID: 100, Name: "Test Plan",
+	}, nil)
+
+	expectedRuns := []*models.ProductionPlanRun{
+		{ID: 10, PlanID: 1, UserID: 100, Quantity: 5, Status: "completed", PlanName: "Test Plan"},
+		{ID: 11, PlanID: 1, UserID: 100, Quantity: 10, Status: "pending", PlanName: "Test Plan"},
+	}
+
+	mocks.runsRepo.On("GetByPlan", mock.Anything, int64(1), userID).Return(expectedRuns, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/1/runs", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1"}}
+
+	result, httpErr := controller.GetPlanRuns(args)
+
+	assert.Nil(t, httpErr)
+	runs := result.([]*models.ProductionPlanRun)
+	assert.Len(t, runs, 2)
+	assert.Equal(t, int64(10), runs[0].ID)
+	assert.Equal(t, "completed", runs[0].Status)
+	mocks.plansRepo.AssertExpectations(t)
+	mocks.runsRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_GetPlanRuns_PlanNotFound(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.plansRepo.On("GetByID", mock.Anything, int64(999), userID).Return(nil, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/999/runs", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "999"}}
+
+	result, httpErr := controller.GetPlanRuns(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+}
+
+func Test_ProductionPlans_GetPlanRun_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+
+	expectedRun := &models.ProductionPlanRun{
+		ID: 10, PlanID: 1, UserID: 100, Quantity: 5, Status: "in_progress",
+		PlanName: "Test Plan",
+		Jobs: []*models.IndustryJobQueueEntry{
+			{ID: 99, Activity: "manufacturing", Status: "active"},
+			{ID: 100, Activity: "manufacturing", Status: "planned"},
+		},
+		JobSummary: &models.PlanRunJobSummary{Total: 2, Active: 1, Planned: 1},
+	}
+
+	mocks.runsRepo.On("GetByID", mock.Anything, int64(10), userID).Return(expectedRun, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/1/runs/10", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1", "runId": "10"}}
+
+	result, httpErr := controller.GetPlanRun(args)
+
+	assert.Nil(t, httpErr)
+	run := result.(*models.ProductionPlanRun)
+	assert.Equal(t, int64(10), run.ID)
+	assert.Equal(t, "in_progress", run.Status)
+	assert.Len(t, run.Jobs, 2)
+	mocks.runsRepo.AssertExpectations(t)
+}
+
+func Test_ProductionPlans_GetPlanRun_NotFound(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.runsRepo.On("GetByID", mock.Anything, int64(999), userID).Return(nil, nil)
+
+	req := httptest.NewRequest("GET", "/v1/industry/plans/1/runs/999", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1", "runId": "999"}}
+
+	result, httpErr := controller.GetPlanRun(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+}
+
+func Test_ProductionPlans_DeletePlanRun_Success(t *testing.T) {
+	controller, mocks := setupProductionPlansController()
+
+	userID := int64(100)
+	mocks.runsRepo.On("Delete", mock.Anything, int64(10), userID).Return(nil)
+
+	req := httptest.NewRequest("DELETE", "/v1/industry/plans/1/runs/10", nil)
+	args := &web.HandlerArgs{Request: req, User: &userID, Params: map[string]string{"id": "1", "runId": "10"}}
+
+	result, httpErr := controller.DeletePlanRun(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+	resultMap := result.(map[string]string)
+	assert.Equal(t, "deleted", resultMap["status"])
+	mocks.runsRepo.AssertExpectations(t)
+}

--- a/internal/controllers/userStations.go
+++ b/internal/controllers/userStations.go
@@ -1,0 +1,162 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/parser"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/pkg/errors"
+)
+
+type UserStationsRepository interface {
+	GetByUser(ctx context.Context, userID int64) ([]*models.UserStation, error)
+	GetByID(ctx context.Context, id, userID int64) (*models.UserStation, error)
+	Create(ctx context.Context, station *models.UserStation) (*models.UserStation, error)
+	Update(ctx context.Context, station *models.UserStation) error
+	Delete(ctx context.Context, id, userID int64) error
+}
+
+type UserStationsStationRepository interface {
+	IsNpcStation(ctx context.Context, stationID int64) (bool, error)
+}
+
+type UserStations struct {
+	stationsRepo UserStationsRepository
+}
+
+func NewUserStations(router Routerer, stationsRepo UserStationsRepository) *UserStations {
+	c := &UserStations{
+		stationsRepo: stationsRepo,
+	}
+
+	router.RegisterRestAPIRoute("/v1/user-stations/parse-scan", web.AuthAccessUser, c.ParseScan, "POST")
+	router.RegisterRestAPIRoute("/v1/user-stations", web.AuthAccessUser, c.GetStations, "GET")
+	router.RegisterRestAPIRoute("/v1/user-stations", web.AuthAccessUser, c.CreateStation, "POST")
+	router.RegisterRestAPIRoute("/v1/user-stations/{id:[0-9]+}", web.AuthAccessUser, c.UpdateStation, "PUT")
+	router.RegisterRestAPIRoute("/v1/user-stations/{id:[0-9]+}", web.AuthAccessUser, c.DeleteStation, "DELETE")
+
+	return c
+}
+
+func (c *UserStations) GetStations(args *web.HandlerArgs) (any, *web.HttpError) {
+	stations, err := c.stationsRepo.GetByUser(args.Request.Context(), *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get user stations")}
+	}
+	return stations, nil
+}
+
+type createStationRequest struct {
+	StationID   int64                      `json:"stationId"`
+	Structure   string                     `json:"structure"`
+	FacilityTax float64                    `json:"facilityTax"`
+	Rigs        []*models.UserStationRig    `json:"rigs"`
+	Services    []*models.UserStationService `json:"services"`
+}
+
+func (c *UserStations) CreateStation(args *web.HandlerArgs) (any, *web.HttpError) {
+	var req createStationRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if req.StationID <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("station_id is required")}
+	}
+	if req.Structure == "" {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("structure is required")}
+	}
+
+	station := &models.UserStation{
+		UserID:      *args.User,
+		StationID:   req.StationID,
+		Structure:   req.Structure,
+		FacilityTax: req.FacilityTax,
+		Rigs:        req.Rigs,
+		Services:    req.Services,
+	}
+
+	if station.Rigs == nil {
+		station.Rigs = []*models.UserStationRig{}
+	}
+	if station.Services == nil {
+		station.Services = []*models.UserStationService{}
+	}
+
+	created, err := c.stationsRepo.Create(args.Request.Context(), station)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to create user station")}
+	}
+
+	return created, nil
+}
+
+type updateStationRequest struct {
+	Structure   string                     `json:"structure"`
+	FacilityTax float64                    `json:"facilityTax"`
+	Rigs        []*models.UserStationRig    `json:"rigs"`
+	Services    []*models.UserStationService `json:"services"`
+}
+
+func (c *UserStations) UpdateStation(args *web.HandlerArgs) (any, *web.HttpError) {
+	id, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid station ID")}
+	}
+
+	var req updateStationRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	station := &models.UserStation{
+		ID:          id,
+		UserID:      *args.User,
+		Structure:   req.Structure,
+		FacilityTax: req.FacilityTax,
+		Rigs:        req.Rigs,
+		Services:    req.Services,
+	}
+
+	if station.Rigs == nil {
+		station.Rigs = []*models.UserStationRig{}
+	}
+	if station.Services == nil {
+		station.Services = []*models.UserStationService{}
+	}
+
+	if err := c.stationsRepo.Update(args.Request.Context(), station); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to update user station")}
+	}
+
+	return map[string]string{"status": "updated"}, nil
+}
+
+func (c *UserStations) DeleteStation(args *web.HandlerArgs) (any, *web.HttpError) {
+	id, err := parseID(args.Params["id"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid station ID")}
+	}
+
+	if err := c.stationsRepo.Delete(args.Request.Context(), id, *args.User); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to delete user station")}
+	}
+
+	return map[string]string{"status": "deleted"}, nil
+}
+
+type parseScanRequest struct {
+	ScanText string `json:"scanText"`
+}
+
+func (c *UserStations) ParseScan(args *web.HandlerArgs) (any, *web.HttpError) {
+	var req parseScanRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	result := parser.ParseStructureScan(req.ScanText)
+	return result, nil
+}

--- a/internal/controllers/userStations_test.go
+++ b/internal/controllers/userStations_test.go
@@ -1,0 +1,236 @@
+package controllers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/controllers"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// --- Mock repository ---
+
+type MockUserStationsRepository struct {
+	mock.Mock
+}
+
+func (m *MockUserStationsRepository) GetByUser(ctx context.Context, userID int64) ([]*models.UserStation, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.UserStation), args.Error(1)
+}
+
+func (m *MockUserStationsRepository) GetByID(ctx context.Context, id, userID int64) (*models.UserStation, error) {
+	args := m.Called(ctx, id, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.UserStation), args.Error(1)
+}
+
+func (m *MockUserStationsRepository) Create(ctx context.Context, station *models.UserStation) (*models.UserStation, error) {
+	args := m.Called(ctx, station)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.UserStation), args.Error(1)
+}
+
+func (m *MockUserStationsRepository) Update(ctx context.Context, station *models.UserStation) error {
+	args := m.Called(ctx, station)
+	return args.Error(0)
+}
+
+func (m *MockUserStationsRepository) Delete(ctx context.Context, id, userID int64) error {
+	args := m.Called(ctx, id, userID)
+	return args.Error(0)
+}
+
+// --- Tests ---
+
+func Test_UserStationsGetStations(t *testing.T) {
+	mockRepo := &MockUserStationsRepository{}
+	mockRouter := &MockRouter{}
+
+	controller := controllers.NewUserStations(mockRouter, mockRepo)
+
+	expectedStations := []*models.UserStation{
+		{
+			ID: 1, UserID: 42, StationID: 99000001, Structure: "sotiyo", FacilityTax: 1.5,
+			StationName: "Test Station", SolarSystemName: "Jita", Security: "high",
+			Rigs: []*models.UserStationRig{
+				{ID: 1, Category: "ship", Tier: "t1"},
+			},
+			Services:   []*models.UserStationService{},
+			Activities: []string{"manufacturing"},
+		},
+	}
+
+	mockRepo.On("GetByUser", mock.Anything, int64(42)).Return(expectedStations, nil)
+
+	userID := int64(42)
+	result, httpErr := controller.GetStations(&web.HandlerArgs{
+		Request: httptest.NewRequest("GET", "/v1/user-stations", nil),
+		User:    &userID,
+	})
+
+	assert.Nil(t, httpErr)
+	stations := result.([]*models.UserStation)
+	assert.Len(t, stations, 1)
+	assert.Equal(t, "sotiyo", stations[0].Structure)
+}
+
+func Test_UserStationsGetStationsError(t *testing.T) {
+	mockRepo := &MockUserStationsRepository{}
+	mockRouter := &MockRouter{}
+
+	controller := controllers.NewUserStations(mockRouter, mockRepo)
+	mockRepo.On("GetByUser", mock.Anything, int64(42)).Return(nil, errors.New("db error"))
+
+	userID := int64(42)
+	_, httpErr := controller.GetStations(&web.HandlerArgs{
+		Request: httptest.NewRequest("GET", "/v1/user-stations", nil),
+		User:    &userID,
+	})
+
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 500, httpErr.StatusCode)
+}
+
+func Test_UserStationsCreateStation(t *testing.T) {
+	mockRepo := &MockUserStationsRepository{}
+	mockRouter := &MockRouter{}
+
+	controller := controllers.NewUserStations(mockRouter, mockRepo)
+
+	mockRepo.On("Create", mock.Anything, mock.AnythingOfType("*models.UserStation")).Return(
+		&models.UserStation{
+			ID: 1, UserID: 42, StationID: 99000001, Structure: "sotiyo", FacilityTax: 1.5,
+			Rigs:     []*models.UserStationRig{},
+			Services: []*models.UserStationService{},
+		}, nil,
+	)
+
+	body, _ := json.Marshal(map[string]any{
+		"stationId":   99000001,
+		"structure":   "sotiyo",
+		"facilityTax": 1.5,
+		"rigs":        []any{},
+		"services":    []any{},
+	})
+
+	userID := int64(42)
+	result, httpErr := controller.CreateStation(&web.HandlerArgs{
+		Request: httptest.NewRequest("POST", "/v1/user-stations", bytes.NewReader(body)),
+		User:    &userID,
+	})
+
+	assert.Nil(t, httpErr)
+	station := result.(*models.UserStation)
+	assert.Equal(t, int64(1), station.ID)
+	assert.Equal(t, "sotiyo", station.Structure)
+}
+
+func Test_UserStationsCreateStationMissingStationID(t *testing.T) {
+	mockRepo := &MockUserStationsRepository{}
+	mockRouter := &MockRouter{}
+
+	controller := controllers.NewUserStations(mockRouter, mockRepo)
+
+	body, _ := json.Marshal(map[string]any{
+		"structure":    "sotiyo",
+		"facility_tax": 1.5,
+	})
+
+	userID := int64(42)
+	_, httpErr := controller.CreateStation(&web.HandlerArgs{
+		Request: httptest.NewRequest("POST", "/v1/user-stations", bytes.NewReader(body)),
+		User:    &userID,
+	})
+
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+}
+
+func Test_UserStationsUpdateStation(t *testing.T) {
+	mockRepo := &MockUserStationsRepository{}
+	mockRouter := &MockRouter{}
+
+	controller := controllers.NewUserStations(mockRouter, mockRepo)
+
+	mockRepo.On("Update", mock.Anything, mock.AnythingOfType("*models.UserStation")).Return(nil)
+
+	body, _ := json.Marshal(map[string]any{
+		"structure":   "azbel",
+		"facilityTax": 2.0,
+		"rigs": []any{
+			map[string]any{"rigName": "Ship Rig", "category": "ship", "tier": "t2"},
+		},
+		"services": []any{},
+	})
+
+	userID := int64(42)
+	result, httpErr := controller.UpdateStation(&web.HandlerArgs{
+		Request: httptest.NewRequest("PUT", "/v1/user-stations/1", bytes.NewReader(body)),
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	})
+
+	assert.Nil(t, httpErr)
+	resp := result.(map[string]string)
+	assert.Equal(t, "updated", resp["status"])
+}
+
+func Test_UserStationsDeleteStation(t *testing.T) {
+	mockRepo := &MockUserStationsRepository{}
+	mockRouter := &MockRouter{}
+
+	controller := controllers.NewUserStations(mockRouter, mockRepo)
+
+	mockRepo.On("Delete", mock.Anything, int64(1), int64(42)).Return(nil)
+
+	userID := int64(42)
+	result, httpErr := controller.DeleteStation(&web.HandlerArgs{
+		Request: httptest.NewRequest("DELETE", "/v1/user-stations/1", nil),
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	})
+
+	assert.Nil(t, httpErr)
+	resp := result.(map[string]string)
+	assert.Equal(t, "deleted", resp["status"])
+}
+
+func Test_UserStationsParseScan(t *testing.T) {
+	mockRepo := &MockUserStationsRepository{}
+	mockRouter := &MockRouter{}
+
+	controller := controllers.NewUserStations(mockRouter, mockRepo)
+
+	body, _ := json.Marshal(map[string]any{
+		"scanText": "Rig Slots\nStandup XL-Set Ship Manufacturing Efficiency I\nService Slots\nStandup Manufacturing Plant I",
+	})
+
+	userID := int64(42)
+	result, httpErr := controller.ParseScan(&web.HandlerArgs{
+		Request: httptest.NewRequest("POST", "/v1/user-stations/parse-scan", bytes.NewReader(body)),
+		User:    &userID,
+	})
+
+	assert.Nil(t, httpErr)
+	scanResult := result.(*models.ScanResult)
+	assert.Equal(t, "sotiyo", scanResult.Structure)
+	assert.Len(t, scanResult.Rigs, 1)
+	assert.Equal(t, "ship", scanResult.Rigs[0].Category)
+	assert.Len(t, scanResult.Services, 1)
+	assert.Equal(t, "manufacturing", scanResult.Services[0].Activity)
+}

--- a/internal/database/migrations/20260222151815_create_production_plans.down.sql
+++ b/internal/database/migrations/20260222151815_create_production_plans.down.sql
@@ -1,0 +1,2 @@
+drop table if exists production_plan_steps;
+drop table if exists production_plans;

--- a/internal/database/migrations/20260222151815_create_production_plans.up.sql
+++ b/internal/database/migrations/20260222151815_create_production_plans.up.sql
@@ -1,0 +1,37 @@
+create table production_plans (
+	id bigserial primary key,
+	user_id bigint not null references users(id),
+	product_type_id bigint not null,
+	name text not null default '',
+	notes text,
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now()
+);
+
+create index idx_production_plans_user_id on production_plans(user_id);
+
+create table production_plan_steps (
+	id bigserial primary key,
+	plan_id bigint not null references production_plans(id) on delete cascade,
+	parent_step_id bigint references production_plan_steps(id) on delete cascade,
+	product_type_id bigint not null,
+	blueprint_type_id bigint not null,
+	activity text not null,
+	me_level int not null default 10,
+	te_level int not null default 20,
+	industry_skill int not null default 5,
+	adv_industry_skill int not null default 5,
+	structure text not null default 'raitaru',
+	rig text not null default 't2',
+	security text not null default 'high',
+	facility_tax numeric(5, 2) not null default 1.0,
+	system_id bigint,
+	source_location_id bigint,
+	source_container_id bigint,
+	source_division_number int,
+	source_owner_type text,
+	source_owner_id bigint
+);
+
+create index idx_production_plan_steps_plan_id on production_plan_steps(plan_id);
+create index idx_production_plan_steps_parent on production_plan_steps(parent_step_id);

--- a/internal/database/migrations/20260222170233_rename_system_id_to_station_id.down.sql
+++ b/internal/database/migrations/20260222170233_rename_system_id_to_station_id.down.sql
@@ -1,0 +1,2 @@
+alter table production_plan_steps drop column station_name;
+alter table production_plan_steps add column system_id bigint;

--- a/internal/database/migrations/20260222170233_rename_system_id_to_station_id.up.sql
+++ b/internal/database/migrations/20260222170233_rename_system_id_to_station_id.up.sql
@@ -1,0 +1,2 @@
+alter table production_plan_steps drop column system_id;
+alter table production_plan_steps add column station_name text;

--- a/internal/database/migrations/20260222175330_create_user_stations.down.sql
+++ b/internal/database/migrations/20260222175330_create_user_stations.down.sql
@@ -1,0 +1,7 @@
+-- Migration: create_user_stations
+-- Created: Sun Feb 22 05:53:30 PM PST 2026
+
+alter table production_plan_steps drop column if exists user_station_id;
+drop table if exists user_station_services;
+drop table if exists user_station_rigs;
+drop table if exists user_stations;

--- a/internal/database/migrations/20260222175330_create_user_stations.up.sql
+++ b/internal/database/migrations/20260222175330_create_user_stations.up.sql
@@ -1,0 +1,32 @@
+-- Migration: create_user_stations
+-- Created: Sun Feb 22 05:53:30 PM PST 2026
+
+create table user_stations (
+	id bigserial primary key,
+	user_id bigint not null references users(id),
+	station_id bigint not null references stations(station_id),
+	structure text not null default 'raitaru',
+	facility_tax numeric(5, 2) not null default 1.0,
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now()
+);
+create index idx_user_stations_user_id on user_stations(user_id);
+
+create table user_station_rigs (
+	id bigserial primary key,
+	user_station_id bigint not null references user_stations(id) on delete cascade,
+	rig_name text not null,
+	category text not null,
+	tier text not null
+);
+create index idx_user_station_rigs_station_id on user_station_rigs(user_station_id);
+
+create table user_station_services (
+	id bigserial primary key,
+	user_station_id bigint not null references user_stations(id) on delete cascade,
+	service_name text not null,
+	activity text not null
+);
+create index idx_user_station_services_station_id on user_station_services(user_station_id);
+
+alter table production_plan_steps add column user_station_id bigint references user_stations(id) on delete set null;

--- a/internal/database/migrations/20260222185246_add_plan_default_stations.down.sql
+++ b/internal/database/migrations/20260222185246_add_plan_default_stations.down.sql
@@ -1,0 +1,5 @@
+-- Migration: add_plan_default_stations
+-- Created: Sun Feb 22 06:52:46 PM PST 2026
+
+alter table production_plans drop column default_manufacturing_station_id;
+alter table production_plans drop column default_reaction_station_id;

--- a/internal/database/migrations/20260222185246_add_plan_default_stations.up.sql
+++ b/internal/database/migrations/20260222185246_add_plan_default_stations.up.sql
@@ -1,0 +1,8 @@
+-- Migration: add_plan_default_stations
+-- Created: Sun Feb 22 06:52:46 PM PST 2026
+
+alter table production_plans
+	add column default_manufacturing_station_id bigint references user_stations(id) on delete set null;
+
+alter table production_plans
+	add column default_reaction_station_id bigint references user_stations(id) on delete set null;

--- a/internal/database/migrations/20260222220229_add_step_output_location.down.sql
+++ b/internal/database/migrations/20260222220229_add_step_output_location.down.sql
@@ -1,0 +1,7 @@
+-- Migration: add_step_output_location
+-- Created: Sun Feb 22 10:02:29 PM PST 2026
+
+alter table production_plan_steps drop column output_owner_type;
+alter table production_plan_steps drop column output_owner_id;
+alter table production_plan_steps drop column output_division_number;
+alter table production_plan_steps drop column output_container_id;

--- a/internal/database/migrations/20260222220229_add_step_output_location.up.sql
+++ b/internal/database/migrations/20260222220229_add_step_output_location.up.sql
@@ -1,0 +1,7 @@
+-- Migration: add_step_output_location
+-- Created: Sun Feb 22 10:02:29 PM PST 2026
+
+alter table production_plan_steps add column output_owner_type text;
+alter table production_plan_steps add column output_owner_id bigint;
+alter table production_plan_steps add column output_division_number int;
+alter table production_plan_steps add column output_container_id bigint;

--- a/internal/database/migrations/20260222231117_plan_runs.down.sql
+++ b/internal/database/migrations/20260222231117_plan_runs.down.sql
@@ -1,0 +1,4 @@
+drop index if exists idx_job_queue_plan_run_id;
+alter table industry_job_queue drop column if exists plan_step_id;
+alter table industry_job_queue drop column if exists plan_run_id;
+drop table if exists production_plan_runs;

--- a/internal/database/migrations/20260222231117_plan_runs.up.sql
+++ b/internal/database/migrations/20260222231117_plan_runs.up.sql
@@ -1,0 +1,15 @@
+create table production_plan_runs (
+	id		bigserial	primary key,
+	plan_id		bigint		not null references production_plans(id) on delete cascade,
+	user_id		bigint		not null references users(id),
+	quantity	int		not null,
+	created_at	timestamptz	not null default now()
+);
+
+create index idx_plan_runs_plan_id on production_plan_runs(plan_id);
+create index idx_plan_runs_user_id on production_plan_runs(user_id);
+
+alter table industry_job_queue add column plan_run_id bigint references production_plan_runs(id) on delete set null;
+alter table industry_job_queue add column plan_step_id bigint;
+
+create index idx_job_queue_plan_run_id on industry_job_queue(plan_run_id);

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -818,6 +818,8 @@ type IndustryJobQueueEntry struct {
 	EstimatedCost     *float64   `json:"estimatedCost"`
 	EstimatedDuration *int       `json:"estimatedDuration"`
 	Notes             *string    `json:"notes"`
+	PlanRunID         *int64     `json:"planRunId,omitempty"`
+	PlanStepID        *int64     `json:"planStepId,omitempty"`
 	CreatedAt         time.Time  `json:"createdAt"`
 	UpdatedAt         time.Time  `json:"updatedAt"`
 	// Enriched fields
@@ -855,4 +857,166 @@ type ManufacturingMaterial struct {
 	BatchQty int64   `json:"batchQty"`
 	Price    float64 `json:"price"`
 	Cost     float64 `json:"cost"`
+}
+
+// Production Plans
+
+type ProductionPlan struct {
+	ID            int64     `json:"id"`
+	UserID        int64     `json:"userId"`
+	ProductTypeID int64     `json:"productTypeId"`
+	Name          string    `json:"name"`
+	Notes                         *string   `json:"notes"`
+	DefaultManufacturingStationID *int64    `json:"defaultManufacturingStationId"`
+	DefaultReactionStationID      *int64    `json:"defaultReactionStationId"`
+	CreatedAt                     time.Time `json:"createdAt"`
+	UpdatedAt                     time.Time `json:"updatedAt"`
+	// Enriched
+	ProductName string                `json:"productName,omitempty"`
+	Steps       []*ProductionPlanStep `json:"steps,omitempty"`
+}
+
+type ProductionPlanStep struct {
+	ID                   int64    `json:"id"`
+	PlanID               int64    `json:"planId"`
+	ParentStepID         *int64   `json:"parentStepId"`
+	ProductTypeID        int64    `json:"productTypeId"`
+	BlueprintTypeID      int64    `json:"blueprintTypeId"`
+	Activity             string   `json:"activity"`
+	MELevel              int      `json:"meLevel"`
+	TELevel              int      `json:"teLevel"`
+	IndustrySkill        int      `json:"industrySkill"`
+	AdvIndustrySkill     int      `json:"advIndustrySkill"`
+	Structure            string   `json:"structure"`
+	Rig                  string   `json:"rig"`
+	Security             string   `json:"security"`
+	FacilityTax          float64  `json:"facilityTax"`
+	StationName          *string  `json:"stationName"`
+	SourceLocationID     *int64   `json:"sourceLocationId"`
+	SourceContainerID    *int64   `json:"sourceContainerId"`
+	SourceDivisionNumber *int     `json:"sourceDivisionNumber"`
+	SourceOwnerType      *string  `json:"sourceOwnerType"`
+	SourceOwnerID        *int64   `json:"sourceOwnerId"`
+	OutputOwnerType      *string  `json:"outputOwnerType"`
+	OutputOwnerID        *int64   `json:"outputOwnerId"`
+	OutputDivisionNumber *int     `json:"outputDivisionNumber"`
+	OutputContainerID    *int64   `json:"outputContainerId"`
+	UserStationID        *int64   `json:"userStationId"`
+	// Enriched
+	ProductName         string `json:"productName,omitempty"`
+	BlueprintName       string `json:"blueprintName,omitempty"`
+	RigCategory         string `json:"rigCategory,omitempty"`
+	SourceOwnerName     string `json:"sourceOwnerName,omitempty"`
+	SourceDivisionName  string `json:"sourceDivisionName,omitempty"`
+	SourceContainerName string `json:"sourceContainerName,omitempty"`
+	OutputOwnerName     string `json:"outputOwnerName,omitempty"`
+	OutputDivisionName  string `json:"outputDivisionName,omitempty"`
+	OutputContainerName string `json:"outputContainerName,omitempty"`
+}
+
+type StationContainer struct {
+	ID             int64  `json:"id"`
+	Name           string `json:"name"`
+	OwnerType      string `json:"ownerType"`
+	OwnerID        int64  `json:"ownerId"`
+	DivisionNumber *int   `json:"divisionNumber,omitempty"`
+}
+
+type PlanMaterial struct {
+	TypeID          int64   `json:"typeId"`
+	TypeName        string  `json:"typeName"`
+	Quantity        int     `json:"quantity"`
+	Volume          float64 `json:"volume"`
+	HasBlueprint    bool    `json:"hasBlueprint"`
+	BlueprintTypeID *int64  `json:"blueprintTypeId,omitempty"`
+	Activity        *string `json:"activity,omitempty"`
+	IsProduced      bool    `json:"isProduced"`
+}
+
+type GenerateJobsResult struct {
+	Run     *ProductionPlanRun       `json:"run"`
+	Created []*IndustryJobQueueEntry `json:"created"`
+	Skipped []*GenerateJobSkipped    `json:"skipped"`
+}
+
+type GenerateJobSkipped struct {
+	TypeID   int64  `json:"typeId"`
+	TypeName string `json:"typeName"`
+	Reason   string `json:"reason"`
+}
+
+// Production Plan Runs
+
+type ProductionPlanRun struct {
+	ID        int64     `json:"id"`
+	PlanID    int64     `json:"planId"`
+	UserID    int64     `json:"userId"`
+	Quantity  int       `json:"quantity"`
+	CreatedAt time.Time `json:"createdAt"`
+	// Enriched
+	PlanName    string                   `json:"planName,omitempty"`
+	ProductName string                   `json:"productName,omitempty"`
+	Status      string                   `json:"status"`
+	Jobs        []*IndustryJobQueueEntry `json:"jobs,omitempty"`
+	JobSummary  *PlanRunJobSummary       `json:"jobSummary,omitempty"`
+}
+
+type PlanRunJobSummary struct {
+	Total     int `json:"total"`
+	Planned   int `json:"planned"`
+	Active    int `json:"active"`
+	Completed int `json:"completed"`
+	Cancelled int `json:"cancelled"`
+}
+
+// User Stations
+
+type UserStation struct {
+	ID          int64   `json:"id"`
+	UserID      int64   `json:"userId"`
+	StationID   int64   `json:"stationId"`
+	Structure   string  `json:"structure"`
+	FacilityTax float64 `json:"facilityTax"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	// Enriched
+	StationName     string               `json:"stationName,omitempty"`
+	SolarSystemName string               `json:"solarSystemName,omitempty"`
+	SecurityStatus  float64              `json:"securityStatus,omitempty"`
+	Security        string               `json:"security,omitempty"`
+	Rigs            []*UserStationRig     `json:"rigs"`
+	Services        []*UserStationService `json:"services"`
+	Activities      []string             `json:"activities"`
+}
+
+type UserStationRig struct {
+	ID            int64  `json:"id"`
+	UserStationID int64  `json:"userStationId"`
+	RigName       string `json:"rigName"`
+	Category      string `json:"category"`
+	Tier          string `json:"tier"`
+}
+
+type UserStationService struct {
+	ID            int64  `json:"id"`
+	UserStationID int64  `json:"userStationId"`
+	ServiceName   string `json:"serviceName"`
+	Activity      string `json:"activity"`
+}
+
+type ScanResult struct {
+	Structure string        `json:"structure"`
+	Rigs      []ScanRig     `json:"rigs"`
+	Services  []ScanService `json:"services"`
+}
+
+type ScanRig struct {
+	Name     string `json:"name"`
+	Category string `json:"category"`
+	Tier     string `json:"tier"`
+}
+
+type ScanService struct {
+	Name     string `json:"name"`
+	Activity string `json:"activity"`
 }

--- a/internal/parser/scan.go
+++ b/internal/parser/scan.go
@@ -1,0 +1,181 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+)
+
+// ParseStructureScan parses an EVE Online structure fitting scan text and extracts
+// rigs (with category and tier) and services (with activity type).
+func ParseStructureScan(scanText string) *models.ScanResult {
+	result := &models.ScanResult{
+		Rigs:     []models.ScanRig{},
+		Services: []models.ScanService{},
+	}
+
+	lines := strings.Split(scanText, "\n")
+	section := ""
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Detect section headers
+		lower := strings.ToLower(line)
+		if lower == "high power slots" || lower == "medium power slots" || lower == "low power slots" {
+			section = "other"
+			continue
+		}
+		if lower == "rig slots" {
+			section = "rigs"
+			continue
+		}
+		if lower == "service slots" {
+			section = "services"
+			continue
+		}
+
+		switch section {
+		case "rigs":
+			rig := parseRig(line)
+			if rig != nil {
+				// Detect structure type from first valid rig
+				if result.Structure == "" {
+					result.Structure = detectStructureFromRig(line, rig.Category)
+				}
+				result.Rigs = append(result.Rigs, *rig)
+			}
+		case "services":
+			svc := parseService(line)
+			if svc != nil {
+				result.Services = append(result.Services, *svc)
+			}
+		}
+	}
+
+	return result
+}
+
+func parseRig(name string) *models.ScanRig {
+	tier := detectTier(name)
+	if tier == "" {
+		return nil
+	}
+
+	category := detectRigCategory(name)
+	if category == "" {
+		return nil
+	}
+
+	return &models.ScanRig{
+		Name:     name,
+		Category: category,
+		Tier:     tier,
+	}
+}
+
+func detectTier(name string) string {
+	if strings.HasSuffix(name, " II") {
+		return "t2"
+	}
+	if strings.HasSuffix(name, " I") {
+		return "t1"
+	}
+	return ""
+}
+
+func detectRigCategory(name string) string {
+	upper := strings.ToUpper(name)
+
+	if strings.Contains(upper, "SHIP MANUFACTURING") {
+		return "ship"
+	}
+	if strings.Contains(upper, "STRUCTURE AND COMPONENT") {
+		return "component"
+	}
+	if strings.Contains(upper, "EQUIPMENT MANUFACTURING") {
+		return "equipment"
+	}
+	if strings.Contains(upper, "AMMUNITION MANUFACTURING") {
+		return "ammo"
+	}
+	if strings.Contains(upper, "DRONE AND FIGHTER") {
+		return "drone"
+	}
+	if strings.Contains(upper, "BIOCHEMICAL REACTOR") {
+		return "reaction"
+	}
+	if strings.Contains(upper, "COMPOSITE REACTOR") {
+		return "reaction"
+	}
+	if strings.Contains(upper, "HYBRID REACTOR") {
+		return "reaction"
+	}
+	if strings.Contains(upper, "POLYMER REACTOR") {
+		return "reaction"
+	}
+	if strings.Contains(upper, "THUKKER COMPONENT") {
+		return "component"
+	}
+	if strings.Contains(upper, "REACTOR") {
+		return "reaction"
+	}
+	if strings.Contains(upper, "REPROCESSING") {
+		return "reprocessing"
+	}
+
+	// Lab rigs, moon drilling, etc. — not manufacturing/reaction
+	return ""
+}
+
+func detectStructureFromRig(name string, category string) string {
+	upper := strings.ToUpper(name)
+
+	isRefinery := category == "reaction" || category == "reprocessing" || strings.Contains(upper, "THUKKER")
+
+	if strings.Contains(upper, "XL-SET") {
+		return "sotiyo"
+	}
+	if strings.Contains(upper, "L-SET") {
+		if isRefinery {
+			return "tatara"
+		}
+		return "azbel"
+	}
+	if strings.Contains(upper, "M-SET") {
+		if isRefinery {
+			return "athanor"
+		}
+		return "raitaru"
+	}
+
+	return ""
+}
+
+func parseService(name string) *models.ScanService {
+	upper := strings.ToUpper(name)
+
+	if strings.Contains(upper, "MANUFACTURING PLANT") ||
+		strings.Contains(upper, "CAPITAL SHIPYARD") ||
+		strings.Contains(upper, "SUPERCAPITAL SHIPYARD") {
+		return &models.ScanService{
+			Name:     name,
+			Activity: "manufacturing",
+		}
+	}
+
+	if strings.Contains(upper, "COMPOSITE REACTOR") ||
+		strings.Contains(upper, "BIOCHEMICAL REACTOR") ||
+		strings.Contains(upper, "HYBRID REACTOR") ||
+		strings.Contains(upper, "POLYMER REACTOR") {
+		return &models.ScanService{
+			Name:     name,
+			Activity: "reaction",
+		}
+	}
+
+	return nil
+}

--- a/internal/parser/scan_test.go
+++ b/internal/parser/scan_test.go
@@ -1,0 +1,240 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ParseStructureScan_SotiyoWithManufacturingRigs(t *testing.T) {
+	scan := `High Power Slots
+Standup Anticapital Missile Launcher II
+Standup Multirole Missile Launcher II
+Medium Power Slots
+Standup Warp Scrambler II
+Low Power Slots
+Standup Armor Reinforcer II
+Rig Slots
+Standup XL-Set Ship Manufacturing Efficiency I
+Standup XL-Set Structure and Component Manufacturing Efficiency I
+Service Slots
+Standup Capital Shipyard I
+Standup Manufacturing Plant I
+Standup Invention Lab I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "sotiyo", result.Structure)
+	assert.Len(t, result.Rigs, 2)
+
+	assert.Equal(t, "Standup XL-Set Ship Manufacturing Efficiency I", result.Rigs[0].Name)
+	assert.Equal(t, "ship", result.Rigs[0].Category)
+	assert.Equal(t, "t1", result.Rigs[0].Tier)
+
+	assert.Equal(t, "Standup XL-Set Structure and Component Manufacturing Efficiency I", result.Rigs[1].Name)
+	assert.Equal(t, "component", result.Rigs[1].Category)
+	assert.Equal(t, "t1", result.Rigs[1].Tier)
+
+	assert.Len(t, result.Services, 2)
+	assert.Equal(t, "Standup Capital Shipyard I", result.Services[0].Name)
+	assert.Equal(t, "manufacturing", result.Services[0].Activity)
+	assert.Equal(t, "Standup Manufacturing Plant I", result.Services[1].Name)
+	assert.Equal(t, "manufacturing", result.Services[1].Activity)
+}
+
+func Test_ParseStructureScan_RaitaruWithT2ShipRig(t *testing.T) {
+	scan := `Rig Slots
+Standup M-Set Ship Manufacturing Efficiency II
+Service Slots
+Standup Manufacturing Plant I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "raitaru", result.Structure)
+	assert.Len(t, result.Rigs, 1)
+	assert.Equal(t, "ship", result.Rigs[0].Category)
+	assert.Equal(t, "t2", result.Rigs[0].Tier)
+
+	assert.Len(t, result.Services, 1)
+	assert.Equal(t, "manufacturing", result.Services[0].Activity)
+}
+
+func Test_ParseStructureScan_TataraWithReactionRigs(t *testing.T) {
+	scan := `Rig Slots
+Standup L-Set Biochemical Reactor Efficiency II
+Standup L-Set Composite Reactor Efficiency I
+Service Slots
+Standup Biochemical Reactor I
+Standup Composite Reactor I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "tatara", result.Structure)
+	assert.Len(t, result.Rigs, 2)
+
+	assert.Equal(t, "reaction", result.Rigs[0].Category)
+	assert.Equal(t, "t2", result.Rigs[0].Tier)
+
+	assert.Equal(t, "reaction", result.Rigs[1].Category)
+	assert.Equal(t, "t1", result.Rigs[1].Tier)
+
+	assert.Len(t, result.Services, 2)
+	assert.Equal(t, "reaction", result.Services[0].Activity)
+	assert.Equal(t, "reaction", result.Services[1].Activity)
+}
+
+func Test_ParseStructureScan_AthanorWithPolymerReactorRig(t *testing.T) {
+	scan := `Rig Slots
+Standup M-Set Polymer Reactor Efficiency I
+Service Slots
+Standup Polymer Reactor I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "athanor", result.Structure)
+	assert.Len(t, result.Rigs, 1)
+	assert.Equal(t, "reaction", result.Rigs[0].Category)
+	assert.Equal(t, "t1", result.Rigs[0].Tier)
+
+	assert.Len(t, result.Services, 1)
+	assert.Equal(t, "reaction", result.Services[0].Activity)
+}
+
+func Test_ParseStructureScan_AzbelWithEquipmentAndAmmoRigs(t *testing.T) {
+	scan := `Rig Slots
+Standup L-Set Equipment Manufacturing Efficiency II
+Standup L-Set Ammunition Manufacturing Efficiency I
+Service Slots
+Standup Manufacturing Plant I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "azbel", result.Structure)
+	assert.Len(t, result.Rigs, 2)
+
+	assert.Equal(t, "equipment", result.Rigs[0].Category)
+	assert.Equal(t, "t2", result.Rigs[0].Tier)
+
+	assert.Equal(t, "ammo", result.Rigs[1].Category)
+	assert.Equal(t, "t1", result.Rigs[1].Tier)
+}
+
+func Test_ParseStructureScan_DroneRig(t *testing.T) {
+	scan := `Rig Slots
+Standup M-Set Drone and Fighter Manufacturing Efficiency I
+Service Slots
+Standup Manufacturing Plant I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "raitaru", result.Structure)
+	assert.Len(t, result.Rigs, 1)
+	assert.Equal(t, "drone", result.Rigs[0].Category)
+	assert.Equal(t, "t1", result.Rigs[0].Tier)
+}
+
+func Test_ParseStructureScan_EmptyScan(t *testing.T) {
+	result := ParseStructureScan("")
+
+	assert.Equal(t, "", result.Structure)
+	assert.Len(t, result.Rigs, 0)
+	assert.Len(t, result.Services, 0)
+}
+
+func Test_ParseStructureScan_LabOnlyRigs(t *testing.T) {
+	scan := `Rig Slots
+Standup M-Set Laboratory Optimization I
+Service Slots
+Standup Research Lab I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "", result.Structure)
+	assert.Len(t, result.Rigs, 0)
+	assert.Len(t, result.Services, 0)
+}
+
+func Test_ParseStructureScan_ThukkerComponentRig(t *testing.T) {
+	scan := `Rig Slots
+Standup M-Set Thukker Component Manufacturing Efficiency I
+Service Slots
+Standup Manufacturing Plant I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "athanor", result.Structure)
+	assert.Len(t, result.Rigs, 1)
+	assert.Equal(t, "component", result.Rigs[0].Category)
+	assert.Equal(t, "t1", result.Rigs[0].Tier)
+}
+
+func Test_ParseStructureScan_MixedManufacturingAndReaction(t *testing.T) {
+	scan := `Rig Slots
+Standup L-Set Ship Manufacturing Efficiency I
+Standup L-Set Composite Reactor Efficiency II
+Service Slots
+Standup Manufacturing Plant I
+Standup Composite Reactor I`
+
+	result := ParseStructureScan(scan)
+
+	// First rig is a manufacturing rig, so structure should be azbel
+	assert.Equal(t, "azbel", result.Structure)
+	assert.Len(t, result.Rigs, 2)
+
+	assert.Equal(t, "ship", result.Rigs[0].Category)
+	assert.Equal(t, "t1", result.Rigs[0].Tier)
+
+	assert.Equal(t, "reaction", result.Rigs[1].Category)
+	assert.Equal(t, "t2", result.Rigs[1].Tier)
+
+	assert.Len(t, result.Services, 2)
+	assert.Equal(t, "manufacturing", result.Services[0].Activity)
+	assert.Equal(t, "reaction", result.Services[1].Activity)
+}
+
+func Test_ParseStructureScan_HybridReactorRig(t *testing.T) {
+	scan := `Rig Slots
+Standup L-Set Hybrid Reactor Efficiency I
+Service Slots
+Standup Hybrid Reactor I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "tatara", result.Structure)
+	assert.Len(t, result.Rigs, 1)
+	assert.Equal(t, "reaction", result.Rigs[0].Category)
+	assert.Equal(t, "t1", result.Rigs[0].Tier)
+}
+
+func Test_ParseStructureScan_GenericReactorRig(t *testing.T) {
+	scan := `Rig Slots
+Standup L-Set Reactor Efficiency II
+Service Slots
+Standup Biochemical Reactor I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "tatara", result.Structure)
+	assert.Len(t, result.Rigs, 1)
+	assert.Equal(t, "reaction", result.Rigs[0].Category)
+	assert.Equal(t, "t2", result.Rigs[0].Tier)
+
+	assert.Len(t, result.Services, 1)
+	assert.Equal(t, "reaction", result.Services[0].Activity)
+}
+
+func Test_ParseStructureScan_ReprocessingRig(t *testing.T) {
+	scan := `Rig Slots
+Standup L-Set Reprocessing Monitor II
+Service Slots
+Standup Manufacturing Plant I`
+
+	result := ParseStructureScan(scan)
+
+	assert.Equal(t, "tatara", result.Structure)
+	assert.Len(t, result.Rigs, 1)
+	assert.Equal(t, "Standup L-Set Reprocessing Monitor II", result.Rigs[0].Name)
+	assert.Equal(t, "reprocessing", result.Rigs[0].Category)
+	assert.Equal(t, "t2", result.Rigs[0].Tier)
+}

--- a/internal/repositories/jobQueue.go
+++ b/internal/repositories/jobQueue.go
@@ -21,12 +21,13 @@ func (r *JobQueue) Create(ctx context.Context, entry *models.IndustryJobQueueEnt
 		INSERT INTO industry_job_queue
 			(user_id, character_id, blueprint_type_id, activity, runs,
 			 me_level, te_level, system_id, facility_tax, status,
-			 product_type_id, estimated_cost, estimated_duration, notes)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'planned', $10, $11, $12, $13)
+			 product_type_id, estimated_cost, estimated_duration, notes,
+			 plan_run_id, plan_step_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'planned', $10, $11, $12, $13, $14, $15)
 		RETURNING id, user_id, character_id, blueprint_type_id, activity, runs,
 		          me_level, te_level, system_id, facility_tax, status, esi_job_id,
 		          product_type_id, estimated_cost, estimated_duration, notes,
-		          created_at, updated_at
+		          plan_run_id, plan_step_id, created_at, updated_at
 	`
 
 	var created models.IndustryJobQueueEntry
@@ -44,6 +45,8 @@ func (r *JobQueue) Create(ctx context.Context, entry *models.IndustryJobQueueEnt
 		entry.EstimatedCost,
 		entry.EstimatedDuration,
 		entry.Notes,
+		entry.PlanRunID,
+		entry.PlanStepID,
 	).Scan(
 		&created.ID,
 		&created.UserID,
@@ -61,6 +64,8 @@ func (r *JobQueue) Create(ctx context.Context, entry *models.IndustryJobQueueEnt
 		&created.EstimatedCost,
 		&created.EstimatedDuration,
 		&created.Notes,
+		&created.PlanRunID,
+		&created.PlanStepID,
 		&created.CreatedAt,
 		&created.UpdatedAt,
 	)
@@ -76,7 +81,7 @@ func (r *JobQueue) GetByUser(ctx context.Context, userID int64) ([]*models.Indus
 		SELECT q.id, q.user_id, q.character_id, q.blueprint_type_id, q.activity, q.runs,
 		       q.me_level, q.te_level, q.system_id, q.facility_tax, q.status, q.esi_job_id,
 		       q.product_type_id, q.estimated_cost, q.estimated_duration, q.notes,
-		       q.created_at, q.updated_at,
+		       q.plan_run_id, q.plan_step_id, q.created_at, q.updated_at,
 		       COALESCE(bp.type_name, ''),
 		       COALESCE(prod.type_name, ''),
 		       COALESCE(c.name, installer.name, ''),
@@ -103,7 +108,7 @@ func (r *JobQueue) GetPlannedJobs(ctx context.Context, userID int64) ([]*models.
 		SELECT q.id, q.user_id, q.character_id, q.blueprint_type_id, q.activity, q.runs,
 		       q.me_level, q.te_level, q.system_id, q.facility_tax, q.status, q.esi_job_id,
 		       q.product_type_id, q.estimated_cost, q.estimated_duration, q.notes,
-		       q.created_at, q.updated_at,
+		       q.plan_run_id, q.plan_step_id, q.created_at, q.updated_at,
 		       '', '', '', '',
 		       CAST(NULL AS timestamptz),
 		       ''
@@ -136,7 +141,7 @@ func (r *JobQueue) Update(ctx context.Context, id, userID int64, entry *models.I
 		RETURNING id, user_id, character_id, blueprint_type_id, activity, runs,
 		          me_level, te_level, system_id, facility_tax, status, esi_job_id,
 		          product_type_id, estimated_cost, estimated_duration, notes,
-		          created_at, updated_at
+		          plan_run_id, plan_step_id, created_at, updated_at
 	`
 
 	var updated models.IndustryJobQueueEntry
@@ -172,6 +177,8 @@ func (r *JobQueue) Update(ctx context.Context, id, userID int64, entry *models.I
 		&updated.EstimatedCost,
 		&updated.EstimatedDuration,
 		&updated.Notes,
+		&updated.PlanRunID,
+		&updated.PlanStepID,
 		&updated.CreatedAt,
 		&updated.UpdatedAt,
 	)
@@ -238,7 +245,7 @@ func (r *JobQueue) GetLinkedActiveJobs(ctx context.Context, userID int64) ([]*mo
 		SELECT q.id, q.user_id, q.character_id, q.blueprint_type_id, q.activity, q.runs,
 		       q.me_level, q.te_level, q.system_id, q.facility_tax, q.status, q.esi_job_id,
 		       q.product_type_id, q.estimated_cost, q.estimated_duration, q.notes,
-		       q.created_at, q.updated_at,
+		       q.plan_run_id, q.plan_step_id, q.created_at, q.updated_at,
 		       '', '', '', '',
 		       CAST(NULL AS timestamptz),
 		       ''
@@ -279,6 +286,8 @@ func (r *JobQueue) queryEntries(ctx context.Context, query string, args ...inter
 			&entry.EstimatedCost,
 			&entry.EstimatedDuration,
 			&entry.Notes,
+			&entry.PlanRunID,
+			&entry.PlanStepID,
 			&entry.CreatedAt,
 			&entry.UpdatedAt,
 			&entry.BlueprintName,

--- a/internal/repositories/planRuns.go
+++ b/internal/repositories/planRuns.go
@@ -1,0 +1,254 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/pkg/errors"
+)
+
+type PlanRuns struct {
+	db *sql.DB
+}
+
+func NewPlanRuns(db *sql.DB) *PlanRuns {
+	return &PlanRuns{db: db}
+}
+
+func (r *PlanRuns) Create(ctx context.Context, run *models.ProductionPlanRun) (*models.ProductionPlanRun, error) {
+	query := `
+		INSERT INTO production_plan_runs (plan_id, user_id, quantity)
+		VALUES ($1, $2, $3)
+		RETURNING id, plan_id, user_id, quantity, created_at
+	`
+
+	var created models.ProductionPlanRun
+	err := r.db.QueryRowContext(ctx, query,
+		run.PlanID,
+		run.UserID,
+		run.Quantity,
+	).Scan(
+		&created.ID,
+		&created.PlanID,
+		&created.UserID,
+		&created.Quantity,
+		&created.CreatedAt,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create plan run")
+	}
+
+	return &created, nil
+}
+
+func (r *PlanRuns) GetByPlan(ctx context.Context, planID, userID int64) ([]*models.ProductionPlanRun, error) {
+	query := `
+		SELECT r.id, r.plan_id, r.user_id, r.quantity, r.created_at,
+		       COALESCE(p.name, ''),
+		       COALESCE(t.type_name, ''),
+		       COALESCE(counts.total, 0),
+		       COALESCE(counts.planned, 0),
+		       COALESCE(counts.active, 0),
+		       COALESCE(counts.completed, 0),
+		       COALESCE(counts.cancelled, 0),
+		       CASE
+		         WHEN COALESCE(counts.total, 0) = 0 THEN 'pending'
+		         WHEN COALESCE(counts.completed, 0) + COALESCE(counts.cancelled, 0) = counts.total THEN 'completed'
+		         WHEN COALESCE(counts.active, 0) > 0 OR COALESCE(counts.completed, 0) > 0 THEN 'in_progress'
+		         ELSE 'pending'
+		       END
+		FROM production_plan_runs r
+		JOIN production_plans p ON p.id = r.plan_id
+		LEFT JOIN asset_item_types t ON t.type_id = p.product_type_id
+		LEFT JOIN LATERAL (
+		  SELECT count(*) AS total,
+		         count(*) FILTER (WHERE q.status = 'planned') AS planned,
+		         count(*) FILTER (WHERE q.status = 'active') AS active,
+		         count(*) FILTER (WHERE q.status = 'completed') AS completed,
+		         count(*) FILTER (WHERE q.status = 'cancelled') AS cancelled
+		  FROM industry_job_queue q
+		  WHERE q.plan_run_id = r.id
+		) counts ON true
+		WHERE r.plan_id = $1 AND r.user_id = $2
+		ORDER BY r.created_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, planID, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query plan runs")
+	}
+	defer rows.Close()
+
+	runs := []*models.ProductionPlanRun{}
+	for rows.Next() {
+		var run models.ProductionPlanRun
+		var summary models.PlanRunJobSummary
+		err = rows.Scan(
+			&run.ID,
+			&run.PlanID,
+			&run.UserID,
+			&run.Quantity,
+			&run.CreatedAt,
+			&run.PlanName,
+			&run.ProductName,
+			&summary.Total,
+			&summary.Planned,
+			&summary.Active,
+			&summary.Completed,
+			&summary.Cancelled,
+			&run.Status,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan plan run")
+		}
+		run.JobSummary = &summary
+		runs = append(runs, &run)
+	}
+
+	return runs, nil
+}
+
+func (r *PlanRuns) GetByID(ctx context.Context, runID, userID int64) (*models.ProductionPlanRun, error) {
+	query := `
+		SELECT r.id, r.plan_id, r.user_id, r.quantity, r.created_at,
+		       COALESCE(p.name, ''),
+		       COALESCE(t.type_name, ''),
+		       COALESCE(counts.total, 0),
+		       COALESCE(counts.planned, 0),
+		       COALESCE(counts.active, 0),
+		       COALESCE(counts.completed, 0),
+		       COALESCE(counts.cancelled, 0),
+		       CASE
+		         WHEN COALESCE(counts.total, 0) = 0 THEN 'pending'
+		         WHEN COALESCE(counts.completed, 0) + COALESCE(counts.cancelled, 0) = counts.total THEN 'completed'
+		         WHEN COALESCE(counts.active, 0) > 0 OR COALESCE(counts.completed, 0) > 0 THEN 'in_progress'
+		         ELSE 'pending'
+		       END
+		FROM production_plan_runs r
+		JOIN production_plans p ON p.id = r.plan_id
+		LEFT JOIN asset_item_types t ON t.type_id = p.product_type_id
+		LEFT JOIN LATERAL (
+		  SELECT count(*) AS total,
+		         count(*) FILTER (WHERE q.status = 'planned') AS planned,
+		         count(*) FILTER (WHERE q.status = 'active') AS active,
+		         count(*) FILTER (WHERE q.status = 'completed') AS completed,
+		         count(*) FILTER (WHERE q.status = 'cancelled') AS cancelled
+		  FROM industry_job_queue q
+		  WHERE q.plan_run_id = r.id
+		) counts ON true
+		WHERE r.id = $1 AND r.user_id = $2
+	`
+
+	var run models.ProductionPlanRun
+	var summary models.PlanRunJobSummary
+	err := r.db.QueryRowContext(ctx, query, runID, userID).Scan(
+		&run.ID,
+		&run.PlanID,
+		&run.UserID,
+		&run.Quantity,
+		&run.CreatedAt,
+		&run.PlanName,
+		&run.ProductName,
+		&summary.Total,
+		&summary.Planned,
+		&summary.Active,
+		&summary.Completed,
+		&summary.Cancelled,
+		&run.Status,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get plan run")
+	}
+	run.JobSummary = &summary
+
+	// Fetch jobs for this run
+	jobQuery := `
+		SELECT q.id, q.user_id, q.character_id, q.blueprint_type_id, q.activity, q.runs,
+		       q.me_level, q.te_level, q.system_id, q.facility_tax, q.status, q.esi_job_id,
+		       q.product_type_id, q.estimated_cost, q.estimated_duration, q.notes,
+		       q.plan_run_id, q.plan_step_id, q.created_at, q.updated_at,
+		       COALESCE(bp.type_name, ''),
+		       COALESCE(prod.type_name, ''),
+		       COALESCE(c.name, ''),
+		       COALESCE(ss.name, ''),
+		       j.end_date,
+		       COALESCE(j.source, '')
+		FROM industry_job_queue q
+		LEFT JOIN asset_item_types bp ON bp.type_id = q.blueprint_type_id
+		LEFT JOIN asset_item_types prod ON prod.type_id = q.product_type_id
+		LEFT JOIN characters c ON c.id = q.character_id
+		LEFT JOIN solar_systems ss ON ss.solar_system_id = q.system_id
+		LEFT JOIN esi_industry_jobs j ON j.job_id = q.esi_job_id
+		WHERE q.plan_run_id = $1
+		ORDER BY q.created_at ASC
+	`
+
+	jobRows, err := r.db.QueryContext(ctx, jobQuery, runID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query plan run jobs")
+	}
+	defer jobRows.Close()
+
+	run.Jobs = []*models.IndustryJobQueueEntry{}
+	for jobRows.Next() {
+		var entry models.IndustryJobQueueEntry
+		err = jobRows.Scan(
+			&entry.ID,
+			&entry.UserID,
+			&entry.CharacterID,
+			&entry.BlueprintTypeID,
+			&entry.Activity,
+			&entry.Runs,
+			&entry.MELevel,
+			&entry.TELevel,
+			&entry.SystemID,
+			&entry.FacilityTax,
+			&entry.Status,
+			&entry.EsiJobID,
+			&entry.ProductTypeID,
+			&entry.EstimatedCost,
+			&entry.EstimatedDuration,
+			&entry.Notes,
+			&entry.PlanRunID,
+			&entry.PlanStepID,
+			&entry.CreatedAt,
+			&entry.UpdatedAt,
+			&entry.BlueprintName,
+			&entry.ProductName,
+			&entry.CharacterName,
+			&entry.SystemName,
+			&entry.EsiJobEndDate,
+			&entry.EsiJobSource,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan plan run job")
+		}
+		run.Jobs = append(run.Jobs, &entry)
+	}
+
+	return &run, nil
+}
+
+func (r *PlanRuns) Delete(ctx context.Context, runID, userID int64) error {
+	result, err := r.db.ExecContext(ctx, `
+		DELETE FROM production_plan_runs
+		WHERE id = $1 AND user_id = $2
+	`, runID, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete plan run")
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected for delete plan run")
+	}
+	if rows == 0 {
+		return errors.New("plan run not found")
+	}
+
+	return nil
+}

--- a/internal/repositories/planRuns_test.go
+++ b/internal/repositories/planRuns_test.go
@@ -1,0 +1,396 @@
+package repositories_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_PlanRunsShouldCreateAndGetByPlan(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+	runsRepo := repositories.NewPlanRuns(db)
+
+	user := &repositories.User{ID: 8500, Name: "Plan Runs Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Rifter Plan",
+	})
+	assert.NoError(t, err)
+
+	run, err := runsRepo.Create(context.Background(), &models.ProductionPlanRun{
+		PlanID:   plan.ID,
+		UserID:   user.ID,
+		Quantity: 10,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, run)
+	assert.NotZero(t, run.ID)
+	assert.Equal(t, plan.ID, run.PlanID)
+	assert.Equal(t, user.ID, run.UserID)
+	assert.Equal(t, 10, run.Quantity)
+	assert.NotZero(t, run.CreatedAt)
+
+	runs, err := runsRepo.GetByPlan(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, runs, 1)
+	assert.Equal(t, run.ID, runs[0].ID)
+	assert.Equal(t, 10, runs[0].Quantity)
+	assert.Equal(t, "Rifter Plan", runs[0].PlanName)
+	assert.Equal(t, "pending", runs[0].Status)
+	assert.NotNil(t, runs[0].JobSummary)
+	assert.Equal(t, 0, runs[0].JobSummary.Total)
+}
+
+func Test_PlanRunsShouldGetByIDWithJobs(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+	runsRepo := repositories.NewPlanRuns(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 8510, Name: "Plan Run GetByID User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Test Plan",
+	})
+	assert.NoError(t, err)
+
+	run, err := runsRepo.Create(context.Background(), &models.ProductionPlanRun{
+		PlanID:   plan.ID,
+		UserID:   user.ID,
+		Quantity: 5,
+	})
+	assert.NoError(t, err)
+
+	// Create a job linked to this run
+	stepID := int64(999)
+	_, err = queueRepo.Create(context.Background(), &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            5,
+		FacilityTax:     1.0,
+		PlanRunID:       &run.ID,
+		PlanStepID:      &stepID,
+	})
+	assert.NoError(t, err)
+
+	fetched, err := runsRepo.GetByID(context.Background(), run.ID, user.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, fetched)
+	assert.Equal(t, run.ID, fetched.ID)
+	assert.Equal(t, 5, fetched.Quantity)
+	assert.Equal(t, "Test Plan", fetched.PlanName)
+	assert.Equal(t, "pending", fetched.Status)
+	assert.NotNil(t, fetched.Jobs)
+	assert.Len(t, fetched.Jobs, 1)
+	assert.Equal(t, "manufacturing", fetched.Jobs[0].Activity)
+	assert.Equal(t, &run.ID, fetched.Jobs[0].PlanRunID)
+	assert.Equal(t, &stepID, fetched.Jobs[0].PlanStepID)
+	assert.NotNil(t, fetched.JobSummary)
+	assert.Equal(t, 1, fetched.JobSummary.Total)
+	assert.Equal(t, 1, fetched.JobSummary.Planned)
+}
+
+func Test_PlanRunsShouldDeriveStatusPending(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+	runsRepo := repositories.NewPlanRuns(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 8520, Name: "Status Pending User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Pending Plan",
+	})
+	assert.NoError(t, err)
+
+	run, err := runsRepo.Create(context.Background(), &models.ProductionPlanRun{
+		PlanID:   plan.ID,
+		UserID:   user.ID,
+		Quantity: 1,
+	})
+	assert.NoError(t, err)
+
+	// Create planned jobs
+	for i := 0; i < 3; i++ {
+		_, err = queueRepo.Create(context.Background(), &models.IndustryJobQueueEntry{
+			UserID:          user.ID,
+			BlueprintTypeID: 787,
+			Activity:        "manufacturing",
+			Runs:            1,
+			FacilityTax:     1.0,
+			PlanRunID:       &run.ID,
+		})
+		assert.NoError(t, err)
+	}
+
+	runs, err := runsRepo.GetByPlan(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, runs, 1)
+	assert.Equal(t, "pending", runs[0].Status)
+	assert.Equal(t, 3, runs[0].JobSummary.Total)
+	assert.Equal(t, 3, runs[0].JobSummary.Planned)
+}
+
+func Test_PlanRunsShouldDeriveStatusInProgress(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+	runsRepo := repositories.NewPlanRuns(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 8530, Name: "Status InProgress User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "InProgress Plan",
+	})
+	assert.NoError(t, err)
+
+	run, err := runsRepo.Create(context.Background(), &models.ProductionPlanRun{
+		PlanID:   plan.ID,
+		UserID:   user.ID,
+		Quantity: 1,
+	})
+	assert.NoError(t, err)
+
+	// Create a planned job and an active job
+	job1, err := queueRepo.Create(context.Background(), &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            1,
+		FacilityTax:     1.0,
+		PlanRunID:       &run.ID,
+	})
+	assert.NoError(t, err)
+
+	_, err = queueRepo.Create(context.Background(), &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 788,
+		Activity:        "manufacturing",
+		Runs:            1,
+		FacilityTax:     1.0,
+		PlanRunID:       &run.ID,
+	})
+	assert.NoError(t, err)
+
+	// Mark first job as active via LinkToEsiJob
+	err = queueRepo.LinkToEsiJob(context.Background(), job1.ID, 99999)
+	assert.NoError(t, err)
+
+	runs, err := runsRepo.GetByPlan(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, runs, 1)
+	assert.Equal(t, "in_progress", runs[0].Status)
+	assert.Equal(t, 2, runs[0].JobSummary.Total)
+	assert.Equal(t, 1, runs[0].JobSummary.Planned)
+	assert.Equal(t, 1, runs[0].JobSummary.Active)
+}
+
+func Test_PlanRunsShouldDeriveStatusCompleted(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+	runsRepo := repositories.NewPlanRuns(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 8540, Name: "Status Completed User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Completed Plan",
+	})
+	assert.NoError(t, err)
+
+	run, err := runsRepo.Create(context.Background(), &models.ProductionPlanRun{
+		PlanID:   plan.ID,
+		UserID:   user.ID,
+		Quantity: 1,
+	})
+	assert.NoError(t, err)
+
+	// Create two jobs and complete both
+	job1, err := queueRepo.Create(context.Background(), &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            1,
+		FacilityTax:     1.0,
+		PlanRunID:       &run.ID,
+	})
+	assert.NoError(t, err)
+
+	job2, err := queueRepo.Create(context.Background(), &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 788,
+		Activity:        "manufacturing",
+		Runs:            1,
+		FacilityTax:     1.0,
+		PlanRunID:       &run.ID,
+	})
+	assert.NoError(t, err)
+
+	err = queueRepo.CompleteJob(context.Background(), job1.ID)
+	assert.NoError(t, err)
+	err = queueRepo.CompleteJob(context.Background(), job2.ID)
+	assert.NoError(t, err)
+
+	runs, err := runsRepo.GetByPlan(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, runs, 1)
+	assert.Equal(t, "completed", runs[0].Status)
+	assert.Equal(t, 2, runs[0].JobSummary.Total)
+	assert.Equal(t, 2, runs[0].JobSummary.Completed)
+}
+
+func Test_PlanRunsShouldNotReturnOtherUsersRuns(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+	runsRepo := repositories.NewPlanRuns(db)
+
+	user1 := &repositories.User{ID: 8550, Name: "User 1"}
+	err = userRepo.Add(context.Background(), user1)
+	assert.NoError(t, err)
+
+	user2 := &repositories.User{ID: 8551, Name: "User 2"}
+	err = userRepo.Add(context.Background(), user2)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user1.ID,
+		ProductTypeID: 587,
+		Name:          "User 1 Plan",
+	})
+	assert.NoError(t, err)
+
+	_, err = runsRepo.Create(context.Background(), &models.ProductionPlanRun{
+		PlanID:   plan.ID,
+		UserID:   user1.ID,
+		Quantity: 10,
+	})
+	assert.NoError(t, err)
+
+	// User 2 should see no runs
+	runs, err := runsRepo.GetByPlan(context.Background(), plan.ID, user2.ID)
+	assert.NoError(t, err)
+	assert.Len(t, runs, 0)
+}
+
+func Test_PlanRunsShouldReturnEmptyForNoRuns(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+	runsRepo := repositories.NewPlanRuns(db)
+
+	user := &repositories.User{ID: 8560, Name: "No Runs User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Empty Plan",
+	})
+	assert.NoError(t, err)
+
+	runs, err := runsRepo.GetByPlan(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, runs)
+	assert.Len(t, runs, 0)
+}
+
+func Test_PlanRunsShouldDelete(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+	runsRepo := repositories.NewPlanRuns(db)
+	queueRepo := repositories.NewJobQueue(db)
+
+	user := &repositories.User{ID: 8570, Name: "Delete Run User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Delete Test Plan",
+	})
+	assert.NoError(t, err)
+
+	run, err := runsRepo.Create(context.Background(), &models.ProductionPlanRun{
+		PlanID:   plan.ID,
+		UserID:   user.ID,
+		Quantity: 5,
+	})
+	assert.NoError(t, err)
+
+	// Create a job linked to this run
+	job, err := queueRepo.Create(context.Background(), &models.IndustryJobQueueEntry{
+		UserID:          user.ID,
+		BlueprintTypeID: 787,
+		Activity:        "manufacturing",
+		Runs:            5,
+		FacilityTax:     1.0,
+		PlanRunID:       &run.ID,
+	})
+	assert.NoError(t, err)
+
+	// Delete the run
+	err = runsRepo.Delete(context.Background(), run.ID, user.ID)
+	assert.NoError(t, err)
+
+	// Run should be gone
+	fetched, err := runsRepo.GetByID(context.Background(), run.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Nil(t, fetched)
+
+	// Job should still exist but with null plan_run_id (ON DELETE SET NULL)
+	entries, err := queueRepo.GetByUser(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, job.ID, entries[0].ID)
+	assert.Nil(t, entries[0].PlanRunID)
+}

--- a/internal/repositories/productionPlans.go
+++ b/internal/repositories/productionPlans.go
@@ -1,0 +1,681 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+type ProductionPlans struct {
+	db *sql.DB
+}
+
+func NewProductionPlans(db *sql.DB) *ProductionPlans {
+	return &ProductionPlans{db: db}
+}
+
+func (r *ProductionPlans) Create(ctx context.Context, plan *models.ProductionPlan) (*models.ProductionPlan, error) {
+	query := `
+		INSERT INTO production_plans (user_id, product_type_id, name, notes,
+			default_manufacturing_station_id, default_reaction_station_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, user_id, product_type_id, name, notes,
+			default_manufacturing_station_id, default_reaction_station_id,
+			created_at, updated_at
+	`
+
+	var result models.ProductionPlan
+	err := r.db.QueryRowContext(ctx, query,
+		plan.UserID,
+		plan.ProductTypeID,
+		plan.Name,
+		plan.Notes,
+		plan.DefaultManufacturingStationID,
+		plan.DefaultReactionStationID,
+	).Scan(
+		&result.ID,
+		&result.UserID,
+		&result.ProductTypeID,
+		&result.Name,
+		&result.Notes,
+		&result.DefaultManufacturingStationID,
+		&result.DefaultReactionStationID,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create production plan")
+	}
+
+	return &result, nil
+}
+
+func (r *ProductionPlans) GetByUser(ctx context.Context, userID int64) ([]*models.ProductionPlan, error) {
+	query := `
+		SELECT p.id, p.user_id, p.product_type_id, p.name, p.notes,
+		       p.default_manufacturing_station_id, p.default_reaction_station_id,
+		       p.created_at, p.updated_at,
+		       COALESCE(ait.type_name, '') as product_name,
+		       (SELECT COUNT(*) FROM production_plan_steps WHERE plan_id = p.id) as step_count
+		FROM production_plans p
+		LEFT JOIN asset_item_types ait ON ait.type_id = p.product_type_id
+		WHERE p.user_id = $1
+		ORDER BY p.updated_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query production plans")
+	}
+	defer rows.Close()
+
+	plans := []*models.ProductionPlan{}
+	for rows.Next() {
+		var plan models.ProductionPlan
+		var stepCount int
+		err := rows.Scan(
+			&plan.ID,
+			&plan.UserID,
+			&plan.ProductTypeID,
+			&plan.Name,
+			&plan.Notes,
+			&plan.DefaultManufacturingStationID,
+			&plan.DefaultReactionStationID,
+			&plan.CreatedAt,
+			&plan.UpdatedAt,
+			&plan.ProductName,
+			&stepCount,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan production plan")
+		}
+		plans = append(plans, &plan)
+	}
+
+	return plans, nil
+}
+
+func (r *ProductionPlans) GetByID(ctx context.Context, id, userID int64) (*models.ProductionPlan, error) {
+	// Get plan
+	planQuery := `
+		SELECT p.id, p.user_id, p.product_type_id, p.name, p.notes,
+		       p.default_manufacturing_station_id, p.default_reaction_station_id,
+		       p.created_at, p.updated_at,
+		       COALESCE(ait.type_name, '') as product_name
+		FROM production_plans p
+		LEFT JOIN asset_item_types ait ON ait.type_id = p.product_type_id
+		WHERE p.id = $1 AND p.user_id = $2
+	`
+
+	var plan models.ProductionPlan
+	err := r.db.QueryRowContext(ctx, planQuery, id, userID).Scan(
+		&plan.ID,
+		&plan.UserID,
+		&plan.ProductTypeID,
+		&plan.Name,
+		&plan.Notes,
+		&plan.DefaultManufacturingStationID,
+		&plan.DefaultReactionStationID,
+		&plan.CreatedAt,
+		&plan.UpdatedAt,
+		&plan.ProductName,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query production plan")
+	}
+
+	// Get all steps with rigCategory enrichment and source name resolution
+	stepsQuery := `
+		SELECT s.id, s.plan_id, s.parent_step_id, s.product_type_id, s.blueprint_type_id,
+		       s.activity, s.me_level, s.te_level, s.industry_skill, s.adv_industry_skill,
+		       s.structure, s.rig, s.security, s.facility_tax, s.station_name,
+		       s.source_location_id, s.source_container_id, s.source_division_number,
+		       s.source_owner_type, s.source_owner_id,
+		       s.user_station_id,
+		       COALESCE(product.type_name, '') as product_name,
+		       COALESCE(bp.type_name, '') as blueprint_name,
+		       CASE
+		           WHEN s.activity = 'reaction' THEN 'reaction'
+		           WHEN sg.category_id = 6 THEN 'ship'
+		           WHEN sg.category_id = 7 THEN 'equipment'
+		           WHEN sg.category_id = 8 THEN 'ammo'
+		           WHEN sg.category_id IN (18, 87) THEN 'drone'
+		           ELSE 'component'
+		       END AS rig_category,
+		       COALESCE(src_char.name, src_corp.name, '') AS source_owner_name,
+		       COALESCE(src_div.name, '') AS source_division_name,
+		       COALESCE(src_cname.name, src_ccname.name, '') AS source_container_name,
+		       s.output_owner_type, s.output_owner_id, s.output_division_number, s.output_container_id,
+		       COALESCE(out_char.name, out_corp.name, '') AS output_owner_name,
+		       COALESCE(out_div.name, '') AS output_division_name,
+		       COALESCE(out_cname.name, out_ccname.name, '') AS output_container_name
+		FROM production_plan_steps s
+		LEFT JOIN asset_item_types product ON product.type_id = s.product_type_id
+		LEFT JOIN asset_item_types bp ON bp.type_id = s.blueprint_type_id
+		LEFT JOIN sde_groups sg ON sg.group_id = product.group_id
+		LEFT JOIN characters src_char ON s.source_owner_type = 'character' AND src_char.id = s.source_owner_id
+		LEFT JOIN player_corporations src_corp ON s.source_owner_type = 'corporation' AND src_corp.id = s.source_owner_id
+		LEFT JOIN corporation_divisions src_div ON s.source_owner_type = 'corporation'
+		    AND src_div.corporation_id = s.source_owner_id
+		    AND src_div.division_number = s.source_division_number
+		    AND src_div.division_type = 'hangar'
+		    AND src_div.user_id = $2
+		LEFT JOIN character_asset_location_names src_cname ON src_cname.item_id = s.source_container_id
+		LEFT JOIN corporation_asset_location_names src_ccname ON src_ccname.item_id = s.source_container_id
+		LEFT JOIN characters out_char ON s.output_owner_type = 'character' AND out_char.id = s.output_owner_id
+		LEFT JOIN player_corporations out_corp ON s.output_owner_type = 'corporation' AND out_corp.id = s.output_owner_id
+		LEFT JOIN corporation_divisions out_div ON s.output_owner_type = 'corporation'
+		    AND out_div.corporation_id = s.output_owner_id
+		    AND out_div.division_number = s.output_division_number
+		    AND out_div.division_type = 'hangar'
+		    AND out_div.user_id = $2
+		LEFT JOIN character_asset_location_names out_cname ON out_cname.item_id = s.output_container_id
+		LEFT JOIN corporation_asset_location_names out_ccname ON out_ccname.item_id = s.output_container_id
+		WHERE s.plan_id = $1
+		ORDER BY s.parent_step_id NULLS FIRST, s.id
+	`
+
+	rows, err := r.db.QueryContext(ctx, stepsQuery, id, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query production plan steps")
+	}
+	defer rows.Close()
+
+	plan.Steps = []*models.ProductionPlanStep{}
+	stationIDs := []int64{}
+	stationIDSet := map[int64]bool{}
+	for rows.Next() {
+		var step models.ProductionPlanStep
+		err := rows.Scan(
+			&step.ID,
+			&step.PlanID,
+			&step.ParentStepID,
+			&step.ProductTypeID,
+			&step.BlueprintTypeID,
+			&step.Activity,
+			&step.MELevel,
+			&step.TELevel,
+			&step.IndustrySkill,
+			&step.AdvIndustrySkill,
+			&step.Structure,
+			&step.Rig,
+			&step.Security,
+			&step.FacilityTax,
+			&step.StationName,
+			&step.SourceLocationID,
+			&step.SourceContainerID,
+			&step.SourceDivisionNumber,
+			&step.SourceOwnerType,
+			&step.SourceOwnerID,
+			&step.UserStationID,
+			&step.ProductName,
+			&step.BlueprintName,
+			&step.RigCategory,
+			&step.SourceOwnerName,
+			&step.SourceDivisionName,
+			&step.SourceContainerName,
+			&step.OutputOwnerType,
+			&step.OutputOwnerID,
+			&step.OutputDivisionNumber,
+			&step.OutputContainerID,
+			&step.OutputOwnerName,
+			&step.OutputDivisionName,
+			&step.OutputContainerName,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan production plan step")
+		}
+		if step.UserStationID != nil && !stationIDSet[*step.UserStationID] {
+			stationIDs = append(stationIDs, *step.UserStationID)
+			stationIDSet[*step.UserStationID] = true
+		}
+		plan.Steps = append(plan.Steps, &step)
+	}
+
+	// Enrich steps that reference a user station
+	if len(stationIDs) > 0 {
+		if err := r.enrichStepsWithStationData(ctx, plan.Steps, stationIDs); err != nil {
+			return nil, err
+		}
+	}
+
+	return &plan, nil
+}
+
+func (r *ProductionPlans) Update(ctx context.Context, id, userID int64, name string, notes *string, defaultManufacturingStationID *int64, defaultReactionStationID *int64) error {
+	query := `
+		UPDATE production_plans
+		SET name = $3, notes = $4,
+		    default_manufacturing_station_id = $5,
+		    default_reaction_station_id = $6,
+		    updated_at = NOW()
+		WHERE id = $1 AND user_id = $2
+	`
+
+	result, err := r.db.ExecContext(ctx, query, id, userID, name, notes, defaultManufacturingStationID, defaultReactionStationID)
+	if err != nil {
+		return errors.Wrap(err, "failed to update production plan")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+	if rowsAffected == 0 {
+		return errors.New("production plan not found")
+	}
+
+	return nil
+}
+
+func (r *ProductionPlans) Delete(ctx context.Context, id, userID int64) error {
+	query := `DELETE FROM production_plans WHERE id = $1 AND user_id = $2`
+
+	result, err := r.db.ExecContext(ctx, query, id, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete production plan")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+	if rowsAffected == 0 {
+		return errors.New("production plan not found")
+	}
+
+	return nil
+}
+
+func (r *ProductionPlans) CreateStep(ctx context.Context, step *models.ProductionPlanStep) (*models.ProductionPlanStep, error) {
+	query := `
+		INSERT INTO production_plan_steps
+		(plan_id, parent_step_id, product_type_id, blueprint_type_id, activity,
+		 me_level, te_level, industry_skill, adv_industry_skill,
+		 structure, rig, security, facility_tax, station_name,
+		 source_location_id, source_container_id, source_division_number,
+		 source_owner_type, source_owner_id, user_station_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+		RETURNING id
+	`
+
+	err := r.db.QueryRowContext(ctx, query,
+		step.PlanID,
+		step.ParentStepID,
+		step.ProductTypeID,
+		step.BlueprintTypeID,
+		step.Activity,
+		step.MELevel,
+		step.TELevel,
+		step.IndustrySkill,
+		step.AdvIndustrySkill,
+		step.Structure,
+		step.Rig,
+		step.Security,
+		step.FacilityTax,
+		step.StationName,
+		step.SourceLocationID,
+		step.SourceContainerID,
+		step.SourceDivisionNumber,
+		step.SourceOwnerType,
+		step.SourceOwnerID,
+		step.UserStationID,
+	).Scan(&step.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create production plan step")
+	}
+
+	return step, nil
+}
+
+func (r *ProductionPlans) UpdateStep(ctx context.Context, stepID, planID, userID int64, step *models.ProductionPlanStep) error {
+	query := `
+		UPDATE production_plan_steps s
+		SET me_level = $4, te_level = $5,
+		    industry_skill = $6, adv_industry_skill = $7,
+		    structure = $8, rig = $9, security = $10,
+		    facility_tax = $11, station_name = $12,
+		    source_location_id = $13, source_container_id = $14,
+		    source_division_number = $15, source_owner_type = $16, source_owner_id = $17,
+		    user_station_id = $18,
+		    output_owner_type = $19, output_owner_id = $20,
+		    output_division_number = $21, output_container_id = $22
+		FROM production_plans p
+		WHERE s.id = $1 AND s.plan_id = $2 AND p.id = s.plan_id AND p.user_id = $3
+	`
+
+	result, err := r.db.ExecContext(ctx, query,
+		stepID, planID, userID,
+		step.MELevel,
+		step.TELevel,
+		step.IndustrySkill,
+		step.AdvIndustrySkill,
+		step.Structure,
+		step.Rig,
+		step.Security,
+		step.FacilityTax,
+		step.StationName,
+		step.SourceLocationID,
+		step.SourceContainerID,
+		step.SourceDivisionNumber,
+		step.SourceOwnerType,
+		step.SourceOwnerID,
+		step.UserStationID,
+		step.OutputOwnerType,
+		step.OutputOwnerID,
+		step.OutputDivisionNumber,
+		step.OutputContainerID,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to update production plan step")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+	if rowsAffected == 0 {
+		return errors.New("production plan step not found")
+	}
+
+	return nil
+}
+
+func (r *ProductionPlans) DeleteStep(ctx context.Context, stepID, planID, userID int64) error {
+	// Verify ownership via join, then delete (CASCADE will remove children)
+	query := `
+		DELETE FROM production_plan_steps s
+		USING production_plans p
+		WHERE s.id = $1 AND s.plan_id = $2 AND p.id = s.plan_id AND p.user_id = $3
+	`
+
+	result, err := r.db.ExecContext(ctx, query, stepID, planID, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete production plan step")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+	if rowsAffected == 0 {
+		return errors.New("production plan step not found")
+	}
+
+	return nil
+}
+
+func (r *ProductionPlans) BatchUpdateSteps(ctx context.Context, stepIDs []int64, planID, userID int64, step *models.ProductionPlanStep) (int64, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback()
+
+	query := `
+		UPDATE production_plan_steps s
+		SET me_level = $4, te_level = $5,
+		    industry_skill = $6, adv_industry_skill = $7,
+		    structure = $8, rig = $9, security = $10,
+		    facility_tax = $11, station_name = $12,
+		    source_location_id = $13, source_container_id = $14,
+		    source_division_number = $15, source_owner_type = $16, source_owner_id = $17,
+		    user_station_id = $18,
+		    output_owner_type = $19, output_owner_id = $20,
+		    output_division_number = $21, output_container_id = $22
+		FROM production_plans p
+		WHERE s.id = ANY($1) AND s.plan_id = $2 AND p.id = s.plan_id AND p.user_id = $3
+	`
+
+	result, err := tx.ExecContext(ctx, query,
+		pq.Array(stepIDs), planID, userID,
+		step.MELevel,
+		step.TELevel,
+		step.IndustrySkill,
+		step.AdvIndustrySkill,
+		step.Structure,
+		step.Rig,
+		step.Security,
+		step.FacilityTax,
+		step.StationName,
+		step.SourceLocationID,
+		step.SourceContainerID,
+		step.SourceDivisionNumber,
+		step.SourceOwnerType,
+		step.SourceOwnerID,
+		step.UserStationID,
+		step.OutputOwnerType,
+		step.OutputOwnerID,
+		step.OutputDivisionNumber,
+		step.OutputContainerID,
+	)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to batch update production plan steps")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get rows affected")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return rowsAffected, nil
+}
+
+// GetStepMaterials returns the blueprint materials for a step, with producibility info
+// and whether each material already has a production step in this plan.
+func (r *ProductionPlans) GetStepMaterials(ctx context.Context, stepID, planID, userID int64) ([]*models.PlanMaterial, error) {
+	query := `
+		SELECT
+			bm.type_id,
+			COALESCE(ait.type_name, '') as type_name,
+			bm.quantity,
+			COALESCE(ait.volume, 0) as volume,
+			CASE WHEN prod.blueprint_type_id IS NOT NULL THEN true ELSE false END as has_blueprint,
+			prod.blueprint_type_id,
+			prod.activity as blueprint_activity,
+			CASE WHEN existing.id IS NOT NULL THEN true ELSE false END as is_produced
+		FROM production_plan_steps s
+		INNER JOIN production_plans p ON p.id = s.plan_id
+		INNER JOIN sde_blueprint_materials bm ON bm.blueprint_type_id = s.blueprint_type_id AND bm.activity = s.activity
+		LEFT JOIN asset_item_types ait ON ait.type_id = bm.type_id
+		LEFT JOIN LATERAL (
+			SELECT bp.blueprint_type_id, bp.activity
+			FROM sde_blueprint_products bp
+			WHERE bp.type_id = bm.type_id
+			  AND bp.activity IN ('manufacturing', 'reaction')
+			ORDER BY CASE bp.activity WHEN 'manufacturing' THEN 1 WHEN 'reaction' THEN 2 END
+			LIMIT 1
+		) prod ON true
+		LEFT JOIN production_plan_steps existing ON existing.plan_id = s.plan_id
+			AND existing.parent_step_id = s.id
+			AND existing.product_type_id = bm.type_id
+		WHERE s.id = $1 AND s.plan_id = $2 AND p.user_id = $3
+		ORDER BY ait.type_name
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, stepID, planID, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query step materials")
+	}
+	defer rows.Close()
+
+	materials := []*models.PlanMaterial{}
+	for rows.Next() {
+		var mat models.PlanMaterial
+		err := rows.Scan(
+			&mat.TypeID,
+			&mat.TypeName,
+			&mat.Quantity,
+			&mat.Volume,
+			&mat.HasBlueprint,
+			&mat.BlueprintTypeID,
+			&mat.Activity,
+			&mat.IsProduced,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan step material")
+		}
+		materials = append(materials, &mat)
+	}
+
+	return materials, nil
+}
+
+// GetContainersAtStation returns containers (character and corporation) at a given station.
+func (r *ProductionPlans) GetContainersAtStation(ctx context.Context, userID, stationID int64) ([]*models.StationContainer, error) {
+	query := `
+		SELECT ca.item_id, COALESCE(loc.name, ait.type_name), 'character', ca.character_id, NULL::int
+		FROM character_assets ca
+		JOIN asset_item_types ait ON ait.type_id = ca.type_id
+		LEFT JOIN character_asset_location_names loc ON loc.item_id = ca.item_id
+		WHERE ca.user_id = $1 AND ca.location_id = $2
+		  AND ca.is_singleton = true AND ait.type_name LIKE '%Container'
+
+		UNION ALL
+
+		SELECT ca.item_id, COALESCE(loc.name, ait.type_name), 'corporation', ca.corporation_id,
+		       SUBSTRING(ca.location_flag, 8, 1)::int
+		FROM corporation_assets ca
+		JOIN asset_item_types ait ON ait.type_id = ca.type_id
+		LEFT JOIN corporation_asset_location_names loc ON loc.item_id = ca.item_id
+		JOIN corporation_assets office
+		  ON office.item_id = ca.location_id
+		  AND office.location_flag = 'OfficeFolder'
+		  AND office.corporation_id = ca.corporation_id
+		  AND office.user_id = ca.user_id
+		WHERE ca.user_id = $1 AND office.location_id = $2
+		  AND ca.is_singleton = true AND ait.type_name LIKE '%Container'
+		  AND ca.location_flag LIKE 'CorpSAG%'
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID, stationID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query containers at station")
+	}
+	defer rows.Close()
+
+	containers := []*models.StationContainer{}
+	for rows.Next() {
+		var c models.StationContainer
+		err := rows.Scan(&c.ID, &c.Name, &c.OwnerType, &c.OwnerID, &c.DivisionNumber)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan station container")
+		}
+		containers = append(containers, &c)
+	}
+
+	return containers, nil
+}
+
+// enrichStepsWithStationData overrides step fields with data from referenced user stations.
+// When a step has user_station_id set, its structure, facilityTax, stationName, security,
+// and rig are derived from the station rather than the step's own fields.
+func (r *ProductionPlans) enrichStepsWithStationData(ctx context.Context, steps []*models.ProductionPlanStep, stationIDs []int64) error {
+	// Fetch station data
+	stationQuery := `
+		SELECT us.id, us.structure, us.facility_tax,
+		       COALESCE(st.name, '') as station_name,
+		       CASE
+		           WHEN ss.security >= 0.45 THEN 'high'
+		           WHEN ss.security > 0.0 THEN 'low'
+		           ELSE 'null'
+		       END AS security
+		FROM user_stations us
+		JOIN stations st ON st.station_id = us.station_id
+		JOIN solar_systems ss ON ss.solar_system_id = st.solar_system_id
+		WHERE us.id = ANY($1)
+	`
+
+	type stationData struct {
+		ID          int64
+		Structure   string
+		FacilityTax float64
+		StationName string
+		Security    string
+	}
+
+	rows, err := r.db.QueryContext(ctx, stationQuery, pq.Array(stationIDs))
+	if err != nil {
+		return errors.Wrap(err, "failed to query user stations for enrichment")
+	}
+	defer rows.Close()
+
+	stationMap := map[int64]*stationData{}
+	for rows.Next() {
+		var sd stationData
+		err := rows.Scan(&sd.ID, &sd.Structure, &sd.FacilityTax, &sd.StationName, &sd.Security)
+		if err != nil {
+			return errors.Wrap(err, "failed to scan station data")
+		}
+		stationMap[sd.ID] = &sd
+	}
+
+	// Fetch rigs for these stations
+	rigQuery := `
+		SELECT user_station_id, category, tier
+		FROM user_station_rigs
+		WHERE user_station_id = ANY($1)
+	`
+
+	type rigData struct {
+		StationID int64
+		Category  string
+		Tier      string
+	}
+
+	rigRows, err := r.db.QueryContext(ctx, rigQuery, pq.Array(stationIDs))
+	if err != nil {
+		return errors.Wrap(err, "failed to query user station rigs for enrichment")
+	}
+	defer rigRows.Close()
+
+	// Map station ID → category → tier
+	rigMap := map[int64]map[string]string{}
+	for rigRows.Next() {
+		var rd rigData
+		err := rigRows.Scan(&rd.StationID, &rd.Category, &rd.Tier)
+		if err != nil {
+			return errors.Wrap(err, "failed to scan rig data")
+		}
+		if rigMap[rd.StationID] == nil {
+			rigMap[rd.StationID] = map[string]string{}
+		}
+		rigMap[rd.StationID][rd.Category] = rd.Tier
+	}
+
+	// Override step fields from station data
+	for _, step := range steps {
+		if step.UserStationID == nil {
+			continue
+		}
+		sd, ok := stationMap[*step.UserStationID]
+		if !ok {
+			continue
+		}
+
+		step.Structure = sd.Structure
+		step.FacilityTax = sd.FacilityTax
+		step.StationName = &sd.StationName
+		step.Security = sd.Security
+
+		// Derive rig from station's rigs + step's rigCategory
+		step.Rig = "none"
+		if rigs, ok := rigMap[*step.UserStationID]; ok {
+			if tier, ok := rigs[step.RigCategory]; ok {
+				step.Rig = tier
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/repositories/productionPlans_test.go
+++ b/internal/repositories/productionPlans_test.go
@@ -1,0 +1,626 @@
+package repositories_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ProductionPlansShouldCreateAndGetByUser(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8000, Name: "Plans Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Rifter Plan",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, plan)
+	assert.NotZero(t, plan.ID)
+	assert.Equal(t, user.ID, plan.UserID)
+	assert.Equal(t, int64(587), plan.ProductTypeID)
+	assert.Equal(t, "Rifter Plan", plan.Name)
+
+	plans, err := plansRepo.GetByUser(context.Background(), user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, plans, 1)
+	assert.Equal(t, plan.ID, plans[0].ID)
+	assert.Equal(t, "Rifter Plan", plans[0].Name)
+}
+
+func Test_ProductionPlansShouldGetByID(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8010, Name: "GetByID Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Test Plan",
+	})
+	assert.NoError(t, err)
+
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, fetched)
+	assert.Equal(t, plan.ID, fetched.ID)
+	assert.Equal(t, "Test Plan", fetched.Name)
+	assert.NotNil(t, fetched.Steps)
+	assert.Len(t, fetched.Steps, 0) // No steps yet
+}
+
+func Test_ProductionPlansShouldReturnNilForWrongUser(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8020, Name: "Owner"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "My Plan",
+	})
+	assert.NoError(t, err)
+
+	// Different user should not see this plan
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, 9999)
+	assert.NoError(t, err)
+	assert.Nil(t, fetched)
+}
+
+func Test_ProductionPlansShouldUpdate(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8030, Name: "Update Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Old Name",
+	})
+	assert.NoError(t, err)
+
+	notes := "Some notes"
+	err = plansRepo.Update(context.Background(), plan.ID, user.ID, "New Name", &notes, nil, nil)
+	assert.NoError(t, err)
+
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, "New Name", fetched.Name)
+	assert.NotNil(t, fetched.Notes)
+	assert.Equal(t, "Some notes", *fetched.Notes)
+}
+
+func Test_ProductionPlansShouldDelete(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8040, Name: "Delete Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "To Delete",
+	})
+	assert.NoError(t, err)
+
+	err = plansRepo.Delete(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Nil(t, fetched)
+}
+
+func Test_ProductionPlansShouldCreateAndGetSteps(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8050, Name: "Steps Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Steps Test",
+	})
+	assert.NoError(t, err)
+
+	// Create root step
+	rootStep, err := plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ProductTypeID:    587,
+		BlueprintTypeID:  787,
+		Activity:         "manufacturing",
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+	})
+	assert.NoError(t, err)
+	assert.NotZero(t, rootStep.ID)
+
+	// Create child step
+	childStep, err := plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ParentStepID:     &rootStep.ID,
+		ProductTypeID:    34,
+		BlueprintTypeID:  100,
+		Activity:         "manufacturing",
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+	})
+	assert.NoError(t, err)
+	assert.NotZero(t, childStep.ID)
+	assert.Equal(t, &rootStep.ID, childStep.ParentStepID)
+
+	// Get full plan with steps
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, fetched.Steps, 2)
+	// Root step first (parent_step_id IS NULL)
+	assert.Nil(t, fetched.Steps[0].ParentStepID)
+	assert.NotNil(t, fetched.Steps[1].ParentStepID)
+}
+
+func Test_ProductionPlansShouldUpdateStep(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8060, Name: "Update Step User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Update Step Test",
+	})
+	assert.NoError(t, err)
+
+	step, err := plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ProductTypeID:    587,
+		BlueprintTypeID:  787,
+		Activity:         "manufacturing",
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+	})
+	assert.NoError(t, err)
+
+	// Update step params
+	locationID := int64(60003760)
+	ownerType := "character"
+	ownerID := int64(1001)
+	err = plansRepo.UpdateStep(context.Background(), step.ID, plan.ID, user.ID, &models.ProductionPlanStep{
+		MELevel:          8,
+		TELevel:          16,
+		IndustrySkill:    4,
+		AdvIndustrySkill: 3,
+		Structure:        "azbel",
+		Rig:              "t1",
+		Security:         "low",
+		FacilityTax:      2.5,
+		SourceLocationID: &locationID,
+		SourceOwnerType:  &ownerType,
+		SourceOwnerID:    &ownerID,
+	})
+	assert.NoError(t, err)
+
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, fetched.Steps, 1)
+	assert.Equal(t, 8, fetched.Steps[0].MELevel)
+	assert.Equal(t, "azbel", fetched.Steps[0].Structure)
+	assert.Equal(t, &locationID, fetched.Steps[0].SourceLocationID)
+}
+
+func Test_ProductionPlansShouldUpdateStepWithOutputFields(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8065, Name: "Output Fields User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Output Fields Test",
+	})
+	assert.NoError(t, err)
+
+	step, err := plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ProductTypeID:    587,
+		BlueprintTypeID:  787,
+		Activity:         "manufacturing",
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+	})
+	assert.NoError(t, err)
+
+	// Update with output location fields
+	outOwnerType := "corporation"
+	outOwnerID := int64(5000)
+	outDivNum := 3
+	outContainerID := int64(9999)
+	err = plansRepo.UpdateStep(context.Background(), step.ID, plan.ID, user.ID, &models.ProductionPlanStep{
+		MELevel:              10,
+		TELevel:              20,
+		IndustrySkill:        5,
+		AdvIndustrySkill:     5,
+		Structure:            "raitaru",
+		Rig:                  "t2",
+		Security:             "high",
+		FacilityTax:          1.0,
+		OutputOwnerType:      &outOwnerType,
+		OutputOwnerID:        &outOwnerID,
+		OutputDivisionNumber: &outDivNum,
+		OutputContainerID:    &outContainerID,
+	})
+	assert.NoError(t, err)
+
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, fetched.Steps, 1)
+	assert.NotNil(t, fetched.Steps[0].OutputOwnerType)
+	assert.Equal(t, "corporation", *fetched.Steps[0].OutputOwnerType)
+	assert.NotNil(t, fetched.Steps[0].OutputOwnerID)
+	assert.Equal(t, int64(5000), *fetched.Steps[0].OutputOwnerID)
+	assert.NotNil(t, fetched.Steps[0].OutputDivisionNumber)
+	assert.Equal(t, 3, *fetched.Steps[0].OutputDivisionNumber)
+	assert.NotNil(t, fetched.Steps[0].OutputContainerID)
+	assert.Equal(t, int64(9999), *fetched.Steps[0].OutputContainerID)
+}
+
+func Test_ProductionPlansShouldBatchUpdateSteps(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8090, Name: "Batch Update User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Batch Update Test",
+	})
+	assert.NoError(t, err)
+
+	rootStep, err := plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ProductTypeID:    587,
+		BlueprintTypeID:  787,
+		Activity:         "manufacturing",
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+	})
+	assert.NoError(t, err)
+
+	// Create 3 child steps with same product type
+	var stepIDs []int64
+	for i := 0; i < 3; i++ {
+		step, err := plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+			PlanID:           plan.ID,
+			ParentStepID:     &rootStep.ID,
+			ProductTypeID:    34,
+			BlueprintTypeID:  100,
+			Activity:         "manufacturing",
+			MELevel:          10,
+			TELevel:          20,
+			IndustrySkill:    5,
+			AdvIndustrySkill: 5,
+			Structure:        "raitaru",
+			Rig:              "t2",
+			Security:         "high",
+			FacilityTax:      1.0,
+		})
+		assert.NoError(t, err)
+		stepIDs = append(stepIDs, step.ID)
+	}
+
+	// Batch update all 3 steps
+	rowsAffected, err := plansRepo.BatchUpdateSteps(context.Background(), stepIDs, plan.ID, user.ID, &models.ProductionPlanStep{
+		MELevel:          8,
+		TELevel:          16,
+		IndustrySkill:    4,
+		AdvIndustrySkill: 3,
+		Structure:        "azbel",
+		Rig:              "t1",
+		Security:         "low",
+		FacilityTax:      2.5,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), rowsAffected)
+
+	// Verify all steps were updated
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	for _, step := range fetched.Steps {
+		if step.ID == rootStep.ID {
+			continue // skip root
+		}
+		assert.Equal(t, 8, step.MELevel)
+		assert.Equal(t, 16, step.TELevel)
+		assert.Equal(t, 4, step.IndustrySkill)
+		assert.Equal(t, 3, step.AdvIndustrySkill)
+		assert.Equal(t, "azbel", step.Structure)
+		assert.Equal(t, "t1", step.Rig)
+		assert.Equal(t, "low", step.Security)
+		assert.Equal(t, 2.5, step.FacilityTax)
+	}
+}
+
+func Test_ProductionPlansShouldBatchUpdateOnlySelectedSteps(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8095, Name: "Partial Batch User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Partial Batch Test",
+	})
+	assert.NoError(t, err)
+
+	rootStep, err := plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ProductTypeID:    587,
+		BlueprintTypeID:  787,
+		Activity:         "manufacturing",
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+	})
+	assert.NoError(t, err)
+
+	// Create 3 child steps
+	var stepIDs []int64
+	for i := 0; i < 3; i++ {
+		step, err := plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+			PlanID:           plan.ID,
+			ParentStepID:     &rootStep.ID,
+			ProductTypeID:    34,
+			BlueprintTypeID:  100,
+			Activity:         "manufacturing",
+			MELevel:          10,
+			TELevel:          20,
+			IndustrySkill:    5,
+			AdvIndustrySkill: 5,
+			Structure:        "raitaru",
+			Rig:              "t2",
+			Security:         "high",
+			FacilityTax:      1.0,
+		})
+		assert.NoError(t, err)
+		stepIDs = append(stepIDs, step.ID)
+	}
+
+	// Batch update only first 2 steps
+	rowsAffected, err := plansRepo.BatchUpdateSteps(context.Background(), stepIDs[:2], plan.ID, user.ID, &models.ProductionPlanStep{
+		MELevel:          5,
+		TELevel:          10,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "sotiyo",
+		Rig:              "t2",
+		Security:         "null",
+		FacilityTax:      0.5,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), rowsAffected)
+
+	// Verify the third step was NOT updated
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+
+	for _, step := range fetched.Steps {
+		if step.ID == stepIDs[2] {
+			// Third step should remain unchanged
+			assert.Equal(t, 10, step.MELevel)
+			assert.Equal(t, 20, step.TELevel)
+			assert.Equal(t, "raitaru", step.Structure)
+		} else if step.ID == stepIDs[0] || step.ID == stepIDs[1] {
+			// First two should be updated
+			assert.Equal(t, 5, step.MELevel)
+			assert.Equal(t, 10, step.TELevel)
+			assert.Equal(t, "sotiyo", step.Structure)
+		}
+	}
+}
+
+func Test_ProductionPlansShouldDeleteStepAndCascadeChildren(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8070, Name: "Cascade Test User"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Cascade Test",
+	})
+	assert.NoError(t, err)
+
+	rootStep, err := plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ProductTypeID:    587,
+		BlueprintTypeID:  787,
+		Activity:         "manufacturing",
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+	})
+	assert.NoError(t, err)
+
+	// Create child step
+	_, err = plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ParentStepID:     &rootStep.ID,
+		ProductTypeID:    34,
+		BlueprintTypeID:  100,
+		Activity:         "manufacturing",
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+	})
+	assert.NoError(t, err)
+
+	// Verify 2 steps
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, fetched.Steps, 2)
+
+	// Delete root step — should cascade delete the child
+	err = plansRepo.DeleteStep(context.Background(), rootStep.ID, plan.ID, user.ID)
+	assert.NoError(t, err)
+
+	fetched, err = plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Len(t, fetched.Steps, 0)
+}
+
+func Test_ProductionPlansShouldDeletePlanAndCascadeSteps(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	plansRepo := repositories.NewProductionPlans(db)
+
+	user := &repositories.User{ID: 8080, Name: "Plan Cascade Test"}
+	err = userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	plan, err := plansRepo.Create(context.Background(), &models.ProductionPlan{
+		UserID:        user.ID,
+		ProductTypeID: 587,
+		Name:          "Plan Cascade",
+	})
+	assert.NoError(t, err)
+
+	_, err = plansRepo.CreateStep(context.Background(), &models.ProductionPlanStep{
+		PlanID:           plan.ID,
+		ProductTypeID:    587,
+		BlueprintTypeID:  787,
+		Activity:         "manufacturing",
+		MELevel:          10,
+		TELevel:          20,
+		IndustrySkill:    5,
+		AdvIndustrySkill: 5,
+		Structure:        "raitaru",
+		Rig:              "t2",
+		Security:         "high",
+		FacilityTax:      1.0,
+	})
+	assert.NoError(t, err)
+
+	// Delete plan — should cascade delete steps
+	err = plansRepo.Delete(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+
+	fetched, err := plansRepo.GetByID(context.Background(), plan.ID, user.ID)
+	assert.NoError(t, err)
+	assert.Nil(t, fetched)
+}

--- a/internal/repositories/userStations.go
+++ b/internal/repositories/userStations.go
@@ -1,0 +1,354 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+type UserStations struct {
+	db *sql.DB
+}
+
+func NewUserStations(db *sql.DB) *UserStations {
+	return &UserStations{db: db}
+}
+
+func (r *UserStations) GetByUser(ctx context.Context, userID int64) ([]*models.UserStation, error) {
+	stationQuery := `
+		SELECT us.id, us.user_id, us.station_id, us.structure, us.facility_tax,
+		       us.created_at, us.updated_at,
+		       COALESCE(st.name, '') as station_name,
+		       COALESCE(ss.name, '') as solar_system_name,
+		       COALESCE(ss.security, 0) as security_status,
+		       CASE
+		           WHEN ss.security >= 0.45 THEN 'high'
+		           WHEN ss.security > 0.0 THEN 'low'
+		           ELSE 'null'
+		       END AS security
+		FROM user_stations us
+		JOIN stations st ON st.station_id = us.station_id
+		JOIN solar_systems ss ON ss.solar_system_id = st.solar_system_id
+		WHERE us.user_id = $1
+		ORDER BY us.id
+	`
+
+	rows, err := r.db.QueryContext(ctx, stationQuery, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query user stations")
+	}
+	defer rows.Close()
+
+	stations := []*models.UserStation{}
+	stationIDs := []int64{}
+	stationMap := map[int64]*models.UserStation{}
+
+	for rows.Next() {
+		var s models.UserStation
+		err := rows.Scan(
+			&s.ID, &s.UserID, &s.StationID, &s.Structure, &s.FacilityTax,
+			&s.CreatedAt, &s.UpdatedAt,
+			&s.StationName, &s.SolarSystemName, &s.SecurityStatus, &s.Security,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan user station")
+		}
+		s.Rigs = []*models.UserStationRig{}
+		s.Services = []*models.UserStationService{}
+		s.Activities = []string{}
+		stations = append(stations, &s)
+		stationIDs = append(stationIDs, s.ID)
+		stationMap[s.ID] = &s
+	}
+
+	if len(stationIDs) == 0 {
+		return stations, nil
+	}
+
+	if err := r.loadRigs(ctx, stationMap); err != nil {
+		return nil, err
+	}
+
+	if err := r.loadServices(ctx, stationMap); err != nil {
+		return nil, err
+	}
+
+	return stations, nil
+}
+
+func (r *UserStations) GetByID(ctx context.Context, id, userID int64) (*models.UserStation, error) {
+	stationQuery := `
+		SELECT us.id, us.user_id, us.station_id, us.structure, us.facility_tax,
+		       us.created_at, us.updated_at,
+		       COALESCE(st.name, '') as station_name,
+		       COALESCE(ss.name, '') as solar_system_name,
+		       COALESCE(ss.security, 0) as security_status,
+		       CASE
+		           WHEN ss.security >= 0.45 THEN 'high'
+		           WHEN ss.security > 0.0 THEN 'low'
+		           ELSE 'null'
+		       END AS security
+		FROM user_stations us
+		JOIN stations st ON st.station_id = us.station_id
+		JOIN solar_systems ss ON ss.solar_system_id = st.solar_system_id
+		WHERE us.id = $1 AND us.user_id = $2
+	`
+
+	var s models.UserStation
+	err := r.db.QueryRowContext(ctx, stationQuery, id, userID).Scan(
+		&s.ID, &s.UserID, &s.StationID, &s.Structure, &s.FacilityTax,
+		&s.CreatedAt, &s.UpdatedAt,
+		&s.StationName, &s.SolarSystemName, &s.SecurityStatus, &s.Security,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query user station")
+	}
+
+	s.Rigs = []*models.UserStationRig{}
+	s.Services = []*models.UserStationService{}
+	s.Activities = []string{}
+
+	stationMap := map[int64]*models.UserStation{s.ID: &s}
+
+	if err := r.loadRigs(ctx, stationMap); err != nil {
+		return nil, err
+	}
+
+	if err := r.loadServices(ctx, stationMap); err != nil {
+		return nil, err
+	}
+
+	return &s, nil
+}
+
+func (r *UserStations) Create(ctx context.Context, station *models.UserStation) (*models.UserStation, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback()
+
+	query := `
+		INSERT INTO user_stations (user_id, station_id, structure, facility_tax)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, created_at, updated_at
+	`
+
+	err = tx.QueryRowContext(ctx, query,
+		station.UserID, station.StationID, station.Structure, station.FacilityTax,
+	).Scan(&station.ID, &station.CreatedAt, &station.UpdatedAt)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to insert user station")
+	}
+
+	if err := r.insertRigs(ctx, tx, station.ID, station.Rigs); err != nil {
+		return nil, err
+	}
+
+	if err := r.insertServices(ctx, tx, station.ID, station.Services); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return station, nil
+}
+
+func (r *UserStations) Update(ctx context.Context, station *models.UserStation) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback()
+
+	query := `
+		UPDATE user_stations
+		SET structure = $3, facility_tax = $4, updated_at = NOW()
+		WHERE id = $1 AND user_id = $2
+	`
+
+	result, err := tx.ExecContext(ctx, query,
+		station.ID, station.UserID, station.Structure, station.FacilityTax,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to update user station")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+	if rowsAffected == 0 {
+		return errors.New("user station not found")
+	}
+
+	// Delete existing rigs and services, then re-insert
+	_, err = tx.ExecContext(ctx, `DELETE FROM user_station_rigs WHERE user_station_id = $1`, station.ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete existing rigs")
+	}
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM user_station_services WHERE user_station_id = $1`, station.ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete existing services")
+	}
+
+	if err := r.insertRigs(ctx, tx, station.ID, station.Rigs); err != nil {
+		return err
+	}
+
+	if err := r.insertServices(ctx, tx, station.ID, station.Services); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (r *UserStations) Delete(ctx context.Context, id, userID int64) error {
+	query := `DELETE FROM user_stations WHERE id = $1 AND user_id = $2`
+
+	result, err := r.db.ExecContext(ctx, query, id, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete user station")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+	if rowsAffected == 0 {
+		return errors.New("user station not found")
+	}
+
+	return nil
+}
+
+func (r *UserStations) loadRigs(ctx context.Context, stationMap map[int64]*models.UserStation) error {
+	ids := make([]int64, 0, len(stationMap))
+	for id := range stationMap {
+		ids = append(ids, id)
+	}
+
+	query := `
+		SELECT id, user_station_id, rig_name, category, tier
+		FROM user_station_rigs
+		WHERE user_station_id = ANY($1)
+		ORDER BY id
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, pq.Array(ids))
+	if err != nil {
+		return errors.Wrap(err, "failed to query user station rigs")
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var rig models.UserStationRig
+		err := rows.Scan(&rig.ID, &rig.UserStationID, &rig.RigName, &rig.Category, &rig.Tier)
+		if err != nil {
+			return errors.Wrap(err, "failed to scan user station rig")
+		}
+		if station, ok := stationMap[rig.UserStationID]; ok {
+			station.Rigs = append(station.Rigs, &rig)
+		}
+	}
+
+	return nil
+}
+
+func (r *UserStations) loadServices(ctx context.Context, stationMap map[int64]*models.UserStation) error {
+	ids := make([]int64, 0, len(stationMap))
+	for id := range stationMap {
+		ids = append(ids, id)
+	}
+
+	query := `
+		SELECT id, user_station_id, service_name, activity
+		FROM user_station_services
+		WHERE user_station_id = ANY($1)
+		ORDER BY id
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, pq.Array(ids))
+	if err != nil {
+		return errors.Wrap(err, "failed to query user station services")
+	}
+	defer rows.Close()
+
+	activitySeen := map[int64]map[string]bool{}
+	for rows.Next() {
+		var svc models.UserStationService
+		err := rows.Scan(&svc.ID, &svc.UserStationID, &svc.ServiceName, &svc.Activity)
+		if err != nil {
+			return errors.Wrap(err, "failed to scan user station service")
+		}
+		if station, ok := stationMap[svc.UserStationID]; ok {
+			station.Services = append(station.Services, &svc)
+			if activitySeen[svc.UserStationID] == nil {
+				activitySeen[svc.UserStationID] = map[string]bool{}
+			}
+			if !activitySeen[svc.UserStationID][svc.Activity] {
+				station.Activities = append(station.Activities, svc.Activity)
+				activitySeen[svc.UserStationID][svc.Activity] = true
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *UserStations) insertRigs(ctx context.Context, tx *sql.Tx, stationID int64, rigs []*models.UserStationRig) error {
+	if len(rigs) == 0 {
+		return nil
+	}
+
+	query := `
+		INSERT INTO user_station_rigs (user_station_id, rig_name, category, tier)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id
+	`
+
+	for _, rig := range rigs {
+		err := tx.QueryRowContext(ctx, query,
+			stationID, rig.RigName, rig.Category, rig.Tier,
+		).Scan(&rig.ID)
+		if err != nil {
+			return errors.Wrap(err, "failed to insert user station rig")
+		}
+		rig.UserStationID = stationID
+	}
+
+	return nil
+}
+
+func (r *UserStations) insertServices(ctx context.Context, tx *sql.Tx, stationID int64, services []*models.UserStationService) error {
+	if len(services) == 0 {
+		return nil
+	}
+
+	query := `
+		INSERT INTO user_station_services (user_station_id, service_name, activity)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`
+
+	for _, svc := range services {
+		err := tx.QueryRowContext(ctx, query,
+			stationID, svc.ServiceName, svc.Activity,
+		).Scan(&svc.ID)
+		if err != nil {
+			return errors.Wrap(err, "failed to insert user station service")
+		}
+		svc.UserStationID = stationID
+	}
+
+	return nil
+}

--- a/internal/repositories/userStations_test.go
+++ b/internal/repositories/userStations_test.go
@@ -1,0 +1,370 @@
+package repositories_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_UserStationsShouldCreateAndGetByUser(t *testing.T) {
+	db, err := setupDatabase(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Set up location data
+	_, err = db.ExecContext(ctx, `INSERT INTO regions (region_id, name) VALUES (10000002, 'The Forge') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO constellations (constellation_id, name, region_id) VALUES (20000020, 'Kimotoro', 10000002) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES (30000142, 'Jita', 20000020, 0.9) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO stations (station_id, name, solar_system_id, corporation_id, is_npc_station) VALUES (99000001, 'Test Player Station', 30000142, 98000001, false) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	stationsRepo := repositories.NewUserStations(db)
+
+	user := &repositories.User{ID: 9000, Name: "Station Test User"}
+	err = userRepo.Add(ctx, user)
+	require.NoError(t, err)
+
+	// Create station with rigs and services
+	station, err := stationsRepo.Create(ctx, &models.UserStation{
+		UserID:      user.ID,
+		StationID:   99000001,
+		Structure:   "sotiyo",
+		FacilityTax: 1.5,
+		Rigs: []*models.UserStationRig{
+			{RigName: "Standup XL-Set Ship Manufacturing Efficiency I", Category: "ship", Tier: "t1"},
+			{RigName: "Standup XL-Set Structure and Component Manufacturing Efficiency I", Category: "component", Tier: "t1"},
+		},
+		Services: []*models.UserStationService{
+			{ServiceName: "Standup Manufacturing Plant I", Activity: "manufacturing"},
+			{ServiceName: "Standup Capital Shipyard I", Activity: "manufacturing"},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, station.ID)
+
+	// Get by user
+	stations, err := stationsRepo.GetByUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Len(t, stations, 1)
+
+	s := stations[0]
+	assert.Equal(t, station.ID, s.ID)
+	assert.Equal(t, "sotiyo", s.Structure)
+	assert.Equal(t, 1.5, s.FacilityTax)
+	assert.Equal(t, "Test Player Station", s.StationName)
+	assert.Equal(t, "Jita", s.SolarSystemName)
+	assert.Equal(t, "high", s.Security)
+
+	// Check rigs
+	assert.Len(t, s.Rigs, 2)
+	assert.Equal(t, "ship", s.Rigs[0].Category)
+	assert.Equal(t, "t1", s.Rigs[0].Tier)
+	assert.Equal(t, "component", s.Rigs[1].Category)
+
+	// Check services
+	assert.Len(t, s.Services, 2)
+	assert.Equal(t, "manufacturing", s.Services[0].Activity)
+
+	// Check activities
+	assert.Len(t, s.Activities, 1)
+	assert.Contains(t, s.Activities, "manufacturing")
+}
+
+func Test_UserStationsShouldGetByID(t *testing.T) {
+	db, err := setupDatabase(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO regions (region_id, name) VALUES (10000002, 'The Forge') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO constellations (constellation_id, name, region_id) VALUES (20000020, 'Kimotoro', 10000002) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES (30000142, 'Jita', 20000020, 0.9) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO stations (station_id, name, solar_system_id, corporation_id, is_npc_station) VALUES (99000002, 'GetByID Station', 30000142, 98000001, false) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	stationsRepo := repositories.NewUserStations(db)
+
+	user := &repositories.User{ID: 9010, Name: "GetByID Test"}
+	err = userRepo.Add(ctx, user)
+	require.NoError(t, err)
+
+	station, err := stationsRepo.Create(ctx, &models.UserStation{
+		UserID:      user.ID,
+		StationID:   99000002,
+		Structure:   "tatara",
+		FacilityTax: 2.0,
+		Rigs: []*models.UserStationRig{
+			{RigName: "Standup L-Set Biochemical Reactor Efficiency II", Category: "reaction", Tier: "t2"},
+		},
+		Services: []*models.UserStationService{
+			{ServiceName: "Standup Biochemical Reactor I", Activity: "reaction"},
+		},
+	})
+	require.NoError(t, err)
+
+	fetched, err := stationsRepo.GetByID(ctx, station.ID, user.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	assert.Equal(t, "tatara", fetched.Structure)
+	assert.Len(t, fetched.Rigs, 1)
+	assert.Equal(t, "reaction", fetched.Rigs[0].Category)
+	assert.Equal(t, "t2", fetched.Rigs[0].Tier)
+	assert.Len(t, fetched.Services, 1)
+	assert.Equal(t, "reaction", fetched.Services[0].Activity)
+	assert.Contains(t, fetched.Activities, "reaction")
+}
+
+func Test_UserStationsShouldReturnNilForWrongUser(t *testing.T) {
+	db, err := setupDatabase(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO regions (region_id, name) VALUES (10000002, 'The Forge') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO constellations (constellation_id, name, region_id) VALUES (20000020, 'Kimotoro', 10000002) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES (30000142, 'Jita', 20000020, 0.9) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO stations (station_id, name, solar_system_id, corporation_id, is_npc_station) VALUES (99000003, 'Wrong User Station', 30000142, 98000001, false) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	stationsRepo := repositories.NewUserStations(db)
+
+	user := &repositories.User{ID: 9020, Name: "Owner"}
+	err = userRepo.Add(ctx, user)
+	require.NoError(t, err)
+
+	station, err := stationsRepo.Create(ctx, &models.UserStation{
+		UserID:      user.ID,
+		StationID:   99000003,
+		Structure:   "raitaru",
+		FacilityTax: 1.0,
+		Rigs:        []*models.UserStationRig{},
+		Services:    []*models.UserStationService{},
+	})
+	require.NoError(t, err)
+
+	// Different user should not see this station
+	fetched, err := stationsRepo.GetByID(ctx, station.ID, 9999)
+	require.NoError(t, err)
+	assert.Nil(t, fetched)
+}
+
+func Test_UserStationsShouldUpdate(t *testing.T) {
+	db, err := setupDatabase(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO regions (region_id, name) VALUES (10000002, 'The Forge') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO constellations (constellation_id, name, region_id) VALUES (20000020, 'Kimotoro', 10000002) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES (30000142, 'Jita', 20000020, 0.9) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO stations (station_id, name, solar_system_id, corporation_id, is_npc_station) VALUES (99000004, 'Update Test Station', 30000142, 98000001, false) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	stationsRepo := repositories.NewUserStations(db)
+
+	user := &repositories.User{ID: 9030, Name: "Update Test"}
+	err = userRepo.Add(ctx, user)
+	require.NoError(t, err)
+
+	station, err := stationsRepo.Create(ctx, &models.UserStation{
+		UserID:      user.ID,
+		StationID:   99000004,
+		Structure:   "raitaru",
+		FacilityTax: 1.0,
+		Rigs: []*models.UserStationRig{
+			{RigName: "Standup M-Set Ship Manufacturing Efficiency I", Category: "ship", Tier: "t1"},
+		},
+		Services: []*models.UserStationService{
+			{ServiceName: "Standup Manufacturing Plant I", Activity: "manufacturing"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Update with new rigs and services
+	err = stationsRepo.Update(ctx, &models.UserStation{
+		ID:          station.ID,
+		UserID:      user.ID,
+		Structure:   "azbel",
+		FacilityTax: 2.5,
+		Rigs: []*models.UserStationRig{
+			{RigName: "Standup L-Set Ship Manufacturing Efficiency II", Category: "ship", Tier: "t2"},
+			{RigName: "Standup L-Set Equipment Manufacturing Efficiency I", Category: "equipment", Tier: "t1"},
+		},
+		Services: []*models.UserStationService{
+			{ServiceName: "Standup Manufacturing Plant I", Activity: "manufacturing"},
+		},
+	})
+	require.NoError(t, err)
+
+	fetched, err := stationsRepo.GetByID(ctx, station.ID, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "azbel", fetched.Structure)
+	assert.Equal(t, 2.5, fetched.FacilityTax)
+	assert.Len(t, fetched.Rigs, 2)
+	assert.Equal(t, "ship", fetched.Rigs[0].Category)
+	assert.Equal(t, "t2", fetched.Rigs[0].Tier)
+	assert.Equal(t, "equipment", fetched.Rigs[1].Category)
+	assert.Len(t, fetched.Services, 1)
+}
+
+func Test_UserStationsShouldDelete(t *testing.T) {
+	db, err := setupDatabase(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO regions (region_id, name) VALUES (10000002, 'The Forge') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO constellations (constellation_id, name, region_id) VALUES (20000020, 'Kimotoro', 10000002) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES (30000142, 'Jita', 20000020, 0.9) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO stations (station_id, name, solar_system_id, corporation_id, is_npc_station) VALUES (99000005, 'Delete Test Station', 30000142, 98000001, false) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	stationsRepo := repositories.NewUserStations(db)
+
+	user := &repositories.User{ID: 9040, Name: "Delete Test"}
+	err = userRepo.Add(ctx, user)
+	require.NoError(t, err)
+
+	station, err := stationsRepo.Create(ctx, &models.UserStation{
+		UserID:      user.ID,
+		StationID:   99000005,
+		Structure:   "raitaru",
+		FacilityTax: 1.0,
+		Rigs: []*models.UserStationRig{
+			{RigName: "Standup M-Set Ship Manufacturing Efficiency I", Category: "ship", Tier: "t1"},
+		},
+		Services: []*models.UserStationService{
+			{ServiceName: "Standup Manufacturing Plant I", Activity: "manufacturing"},
+		},
+	})
+	require.NoError(t, err)
+
+	err = stationsRepo.Delete(ctx, station.ID, user.ID)
+	require.NoError(t, err)
+
+	fetched, err := stationsRepo.GetByID(ctx, station.ID, user.ID)
+	require.NoError(t, err)
+	assert.Nil(t, fetched)
+}
+
+func Test_UserStationsShouldDeriveSecurityCorrectly(t *testing.T) {
+	db, err := setupDatabase(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Set up low-sec system
+	_, err = db.ExecContext(ctx, `INSERT INTO regions (region_id, name) VALUES (10000043, 'Domain') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO constellations (constellation_id, name, region_id) VALUES (20000600, 'Hed', 10000043) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES (30004000, 'LowSec System', 20000600, 0.3) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO stations (station_id, name, solar_system_id, corporation_id, is_npc_station) VALUES (99000006, 'LowSec Station', 30004000, 98000001, false) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	// Set up null-sec system
+	_, err = db.ExecContext(ctx, `INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES (30004001, 'NullSec System', 20000600, -0.5) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO stations (station_id, name, solar_system_id, corporation_id, is_npc_station) VALUES (99000007, 'NullSec Station', 30004001, 98000001, false) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	stationsRepo := repositories.NewUserStations(db)
+
+	user := &repositories.User{ID: 9050, Name: "Security Test"}
+	err = userRepo.Add(ctx, user)
+	require.NoError(t, err)
+
+	// Create low-sec station
+	lowStation, err := stationsRepo.Create(ctx, &models.UserStation{
+		UserID: user.ID, StationID: 99000006, Structure: "raitaru", FacilityTax: 1.0,
+		Rigs: []*models.UserStationRig{}, Services: []*models.UserStationService{},
+	})
+	require.NoError(t, err)
+
+	// Create null-sec station
+	nullStation, err := stationsRepo.Create(ctx, &models.UserStation{
+		UserID: user.ID, StationID: 99000007, Structure: "raitaru", FacilityTax: 1.0,
+		Rigs: []*models.UserStationRig{}, Services: []*models.UserStationService{},
+	})
+	require.NoError(t, err)
+
+	lowFetched, err := stationsRepo.GetByID(ctx, lowStation.ID, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "low", lowFetched.Security)
+
+	nullFetched, err := stationsRepo.GetByID(ctx, nullStation.ID, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "null", nullFetched.Security)
+}
+
+func Test_UserStationsMultipleActivities(t *testing.T) {
+	db, err := setupDatabase(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO regions (region_id, name) VALUES (10000002, 'The Forge') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO constellations (constellation_id, name, region_id) VALUES (20000020, 'Kimotoro', 10000002) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES (30000142, 'Jita', 20000020, 0.9) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO stations (station_id, name, solar_system_id, corporation_id, is_npc_station) VALUES (99000008, 'Multi Activity Station', 30000142, 98000001, false) ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	userRepo := repositories.NewUserRepository(db)
+	stationsRepo := repositories.NewUserStations(db)
+
+	user := &repositories.User{ID: 9060, Name: "Multi Activity Test"}
+	err = userRepo.Add(ctx, user)
+	require.NoError(t, err)
+
+	station, err := stationsRepo.Create(ctx, &models.UserStation{
+		UserID:      user.ID,
+		StationID:   99000008,
+		Structure:   "tatara",
+		FacilityTax: 1.0,
+		Rigs:        []*models.UserStationRig{},
+		Services: []*models.UserStationService{
+			{ServiceName: "Standup Manufacturing Plant I", Activity: "manufacturing"},
+			{ServiceName: "Standup Composite Reactor I", Activity: "reaction"},
+			{ServiceName: "Standup Biochemical Reactor I", Activity: "reaction"},
+		},
+	})
+	require.NoError(t, err)
+
+	fetched, err := stationsRepo.GetByID(ctx, station.ID, user.ID)
+	require.NoError(t, err)
+	assert.Len(t, fetched.Services, 3)
+	// Activities should have unique values only
+	assert.Len(t, fetched.Activities, 2)
+	assert.Contains(t, fetched.Activities, "manufacturing")
+	assert.Contains(t, fetched.Activities, "reaction")
+}


### PR DESCRIPTION
## Summary
- **Production Plans**: Full production chain tree with step management, material calculations, and job generation from blueprints
- **Batch Configure**: Group and configure identical production steps across the tree in bulk, with buy/build toggles and station assignment
- **Preferred Stations**: Save station configs from in-game structure scans with auto-detected rigs/services, referenced by plan steps for accurate cost calculations
- **Plan Runs**: Track each plan execution with derived status (pending → in_progress → completed) and per-run job summaries via LATERAL subquery aggregation

## Test plan
- [ ] Backend controller tests pass (32 production plan tests, 5 user station tests)
- [ ] Frontend snapshot tests pass (196 tests, 37 snapshots)
- [ ] Repository integration tests pass with database (plan runs, job queue, production plans, user stations)
- [ ] Generate jobs from a plan → response includes `run` object with linked jobs
- [ ] `GET /plans/{id}/runs` returns list with derived status and job summary
- [ ] Batch configure correctly groups steps and propagates station/build changes
- [ ] Station scan parser detects structure type, rigs, and services

🤖 Generated with [Claude Code](https://claude.com/claude-code)