### PR TITLE
Add plan runs list page and cancel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@
 5. **Create/update feature docs in `docs/features/`** for every new feature or significant change. Use `lowercase-kebab-case.md` naming (e.g., `sde-import.md`, `reactions-calculator.md`).
 6. **Go slices: initialize as `items := []*Type{}` NOT `var items []*Type`.** Prevents nil JSON marshaling (`null` instead of `[]`).
 7. **Do NOT include Discord usernames or other personal attributions in GitHub issues.**
+8. **Check feature docs first.** Before exploring code or planning a feature, read the relevant `docs/features/` doc (if one exists). Feature docs contain schema, API, key decisions, and file paths — use them as the starting point.
 
 ---
 

--- a/frontend/packages/client/data/models.ts
+++ b/frontend/packages/client/data/models.ts
@@ -534,8 +534,30 @@ export type PlanMaterial = {
 };
 
 export type GenerateJobsResult = {
+  run: PlanRun;
   created: IndustryJobQueueEntry[];
   skipped: GenerateJobSkipped[];
+};
+
+export type PlanRunJobSummary = {
+  total: number;
+  planned: number;
+  active: number;
+  completed: number;
+  cancelled: number;
+};
+
+export type PlanRun = {
+  id: number;
+  planId: number;
+  userId: number;
+  quantity: number;
+  createdAt: string;
+  planName?: string;
+  productName?: string;
+  status: string;
+  jobs?: IndustryJobQueueEntry[];
+  jobSummary?: PlanRunJobSummary;
 };
 
 export type GenerateJobSkipped = {

--- a/frontend/packages/components/Navbar.tsx
+++ b/frontend/packages/components/Navbar.tsx
@@ -102,6 +102,9 @@ export default function Navbar() {
           <Button color="inherit" href="/production-plans">
             Plans
           </Button>
+          <Button color="inherit" href="/plan-runs">
+            Runs
+          </Button>
           <Button color="inherit" href="/stations">
             Stations
           </Button>

--- a/frontend/packages/components/__tests__/__snapshots__/Navbar.test.tsx.snap
+++ b/frontend/packages/components/__tests__/__snapshots__/Navbar.test.tsx.snap
@@ -104,6 +104,13 @@ exports[`Navbar Component should match snapshot when not authenticated 1`] = `
       </a>
       <a
         class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-plnrbk-MuiButtonBase-root-MuiButton-root"
+        href="/plan-runs"
+        tabindex="0"
+      >
+        Runs
+      </a>
+      <a
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-plnrbk-MuiButtonBase-root-MuiButton-root"
         href="/stations"
         tabindex="0"
       >

--- a/frontend/packages/components/industry/PlanRunsList.tsx
+++ b/frontend/packages/components/industry/PlanRunsList.tsx
@@ -1,0 +1,275 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { PlanRun } from "@industry-tool/client/data/models";
+import Navbar from "@industry-tool/components/Navbar";
+import Loading from "@industry-tool/components/loading";
+import Container from "@mui/material/Container";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import Chip from "@mui/material/Chip";
+import IconButton from "@mui/material/IconButton";
+import CancelIcon from "@mui/icons-material/Cancel";
+import Snackbar from "@mui/material/Snackbar";
+import Alert from "@mui/material/Alert";
+
+function getStatusColor(
+  status: string,
+): "success" | "warning" | "info" | "error" | "default" {
+  switch (status) {
+    case "pending":
+      return "info";
+    case "in_progress":
+      return "warning";
+    case "completed":
+      return "default";
+    default:
+      return "default";
+  }
+}
+
+function formatStatus(status: string): string {
+  switch (status) {
+    case "in_progress":
+      return "In Progress";
+    case "pending":
+      return "Pending";
+    case "completed":
+      return "Completed";
+    default:
+      return status;
+  }
+}
+
+function formatJobProgress(run: PlanRun): string {
+  if (!run.jobSummary || run.jobSummary.total === 0) return "—";
+  const { completed, active, total } = run.jobSummary;
+  return `${completed}/${total} done${active > 0 ? `, ${active} active` : ""}`;
+}
+
+export default function PlanRunsList() {
+  const { data: session } = useSession();
+  const [runs, setRuns] = useState<PlanRun[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: "success" | "error";
+  }>({ open: false, message: "", severity: "success" });
+  const hasFetchedRef = useRef(false);
+
+  const fetchRuns = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/industry/plans/runs");
+      if (res.ok) {
+        const data = await res.json();
+        setRuns(data || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch plan runs:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (session && !hasFetchedRef.current) {
+      hasFetchedRef.current = true;
+      fetchRuns();
+    }
+  }, [session, fetchRuns]);
+
+  const handleCancel = async (runId: number) => {
+    if (
+      !confirm(
+        "Are you sure you want to cancel all planned jobs for this run?",
+      )
+    ) {
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/industry/plans/runs/${runId}/cancel`, {
+        method: "POST",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSnackbar({
+          open: true,
+          message: `Cancelled ${data.jobsCancelled} planned job${data.jobsCancelled !== 1 ? "s" : ""}`,
+          severity: "success",
+        });
+        fetchRuns();
+      } else {
+        setSnackbar({
+          open: true,
+          message: "Failed to cancel plan run",
+          severity: "error",
+        });
+      }
+    } catch (err) {
+      console.error("Failed to cancel plan run:", err);
+      setSnackbar({
+        open: true,
+        message: "Failed to cancel plan run",
+        severity: "error",
+      });
+    }
+  };
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
+        <Box sx={{ mb: 2 }}>
+          <Typography
+            variant="h5"
+            sx={{ color: "#e2e8f0", fontWeight: 600 }}
+          >
+            Plan Runs
+          </Typography>
+        </Box>
+
+        {loading ? (
+          <Loading />
+        ) : runs.length === 0 ? (
+          <Paper
+            sx={{
+              backgroundColor: "#12151f",
+              p: 4,
+              textAlign: "center",
+            }}
+          >
+            <Typography sx={{ color: "#64748b" }}>
+              No plan runs yet. Generate jobs from a production plan to create a
+              run.
+            </Typography>
+          </Paper>
+        ) : (
+          <TableContainer
+            component={Paper}
+            sx={{ backgroundColor: "#12151f" }}
+          >
+            <Table size="small">
+              <TableHead>
+                <TableRow sx={{ backgroundColor: "#0f1219" }}>
+                  <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                    Product
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                    Plan
+                  </TableCell>
+                  <TableCell
+                    sx={{ color: "#94a3b8", fontWeight: 600 }}
+                    align="right"
+                  >
+                    Qty
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                    Status
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                    Jobs
+                  </TableCell>
+                  <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>
+                    Created
+                  </TableCell>
+                  <TableCell
+                    sx={{ color: "#94a3b8", fontWeight: 600 }}
+                    align="center"
+                  >
+                    Actions
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {runs.map((run, idx) => (
+                  <TableRow
+                    key={run.id}
+                    sx={{
+                      backgroundColor:
+                        idx % 2 === 0 ? "#12151f" : "#0f1219",
+                      "&:hover": { backgroundColor: "#1a1d2e" },
+                    }}
+                  >
+                    <TableCell>
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1,
+                        }}
+                      >
+                        <Typography sx={{ color: "#e2e8f0", fontSize: 14 }}>
+                          {run.productName || "—"}
+                        </Typography>
+                      </Box>
+                    </TableCell>
+                    <TableCell sx={{ color: "#cbd5e1", fontSize: 14 }}>
+                      {run.planName || `Plan #${run.planId}`}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{ color: "#cbd5e1", fontSize: 14 }}
+                    >
+                      {run.quantity}
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={formatStatus(run.status)}
+                        color={getStatusColor(run.status)}
+                        size="small"
+                        variant="outlined"
+                      />
+                    </TableCell>
+                    <TableCell sx={{ color: "#94a3b8", fontSize: 13 }}>
+                      {formatJobProgress(run)}
+                    </TableCell>
+                    <TableCell sx={{ color: "#94a3b8", fontSize: 13 }}>
+                      {new Date(run.createdAt).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell align="center">
+                      {run.status !== "completed" &&
+                        run.jobSummary &&
+                        run.jobSummary.planned > 0 && (
+                          <IconButton
+                            size="small"
+                            onClick={() => handleCancel(run.id)}
+                            sx={{ color: "#ef4444" }}
+                            title="Cancel planned jobs"
+                          >
+                            <CancelIcon fontSize="small" />
+                          </IconButton>
+                        )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </Container>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert
+          severity={snackbar.severity}
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/frontend/packages/components/industry/__tests__/PlanRunsList.test.tsx
+++ b/frontend/packages/components/industry/__tests__/PlanRunsList.test.tsx
@@ -1,0 +1,275 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { useSession } from 'next-auth/react';
+import PlanRunsList from '../PlanRunsList';
+import { PlanRun } from '@industry-tool/client/data/models';
+
+jest.mock('next-auth/react');
+jest.mock('../../Navbar', () => {
+  return function MockNavbar() {
+    return <div data-testid="navbar">Navbar</div>;
+  };
+});
+jest.mock('../../loading', () => {
+  return function MockLoading() {
+    return <div data-testid="loading">Loading...</div>;
+  };
+});
+
+const mockUseSession = useSession as jest.MockedFunction<typeof useSession>;
+
+const mockSession = {
+  data: {
+    providerAccountId: '1001',
+    expires: '2099-01-01',
+  },
+  status: 'authenticated' as const,
+  update: jest.fn(),
+};
+
+describe('PlanRunsList Component', () => {
+  beforeEach(() => {
+    mockUseSession.mockReturnValue(mockSession);
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it('should match snapshot while loading', async () => {
+    (global.fetch as jest.Mock).mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    const { container } = render(<PlanRunsList />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should match snapshot with empty runs', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    let container: HTMLElement;
+    await act(async () => {
+      const result = render(<PlanRunsList />);
+      container = result.container;
+    });
+
+    expect(container!).toMatchSnapshot();
+  });
+
+  it('should display empty message when no runs', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    await act(async () => {
+      render(<PlanRunsList />);
+    });
+
+    expect(screen.getByText(/No plan runs yet/)).toBeInTheDocument();
+  });
+
+  it('should match snapshot with runs', async () => {
+    const runs: PlanRun[] = [
+      {
+        id: 1,
+        planId: 5,
+        userId: 100,
+        quantity: 10,
+        createdAt: '2026-02-22T23:00:00Z',
+        planName: 'Rifter Plan',
+        productName: 'Rifter',
+        status: 'in_progress',
+        jobSummary: {
+          total: 5,
+          planned: 2,
+          active: 2,
+          completed: 1,
+          cancelled: 0,
+        },
+      },
+      {
+        id: 2,
+        planId: 8,
+        userId: 100,
+        quantity: 3,
+        createdAt: '2026-02-22T20:00:00Z',
+        planName: 'Slasher Plan',
+        productName: 'Slasher',
+        status: 'completed',
+        jobSummary: {
+          total: 3,
+          planned: 0,
+          active: 0,
+          completed: 3,
+          cancelled: 0,
+        },
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => runs,
+    });
+
+    let container: HTMLElement;
+    await act(async () => {
+      const result = render(<PlanRunsList />);
+      container = result.container;
+    });
+
+    expect(container!).toMatchSnapshot();
+  });
+
+  it('should display run details in table', async () => {
+    const runs: PlanRun[] = [
+      {
+        id: 1,
+        planId: 5,
+        userId: 100,
+        quantity: 10,
+        createdAt: '2026-02-22T23:00:00Z',
+        planName: 'Rifter Plan',
+        productName: 'Rifter',
+        status: 'in_progress',
+        jobSummary: {
+          total: 5,
+          planned: 2,
+          active: 2,
+          completed: 1,
+          cancelled: 0,
+        },
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => runs,
+    });
+
+    await act(async () => {
+      render(<PlanRunsList />);
+    });
+
+    expect(screen.getByText('Rifter')).toBeInTheDocument();
+    expect(screen.getByText('Rifter Plan')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+    expect(screen.getByText('1/5 done, 2 active')).toBeInTheDocument();
+  });
+
+  it('should show cancel button for runs with planned jobs', async () => {
+    const runs: PlanRun[] = [
+      {
+        id: 1,
+        planId: 5,
+        userId: 100,
+        quantity: 10,
+        createdAt: '2026-02-22T23:00:00Z',
+        planName: 'Rifter Plan',
+        productName: 'Rifter',
+        status: 'in_progress',
+        jobSummary: {
+          total: 5,
+          planned: 2,
+          active: 2,
+          completed: 1,
+          cancelled: 0,
+        },
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => runs,
+    });
+
+    await act(async () => {
+      render(<PlanRunsList />);
+    });
+
+    const cancelButton = screen.getByTitle('Cancel planned jobs');
+    expect(cancelButton).toBeInTheDocument();
+  });
+
+  it('should not show cancel button for completed runs', async () => {
+    const runs: PlanRun[] = [
+      {
+        id: 2,
+        planId: 8,
+        userId: 100,
+        quantity: 3,
+        createdAt: '2026-02-22T20:00:00Z',
+        planName: 'Slasher Plan',
+        productName: 'Slasher',
+        status: 'completed',
+        jobSummary: {
+          total: 3,
+          planned: 0,
+          active: 0,
+          completed: 3,
+          cancelled: 0,
+        },
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => runs,
+    });
+
+    await act(async () => {
+      render(<PlanRunsList />);
+    });
+
+    expect(screen.queryByTitle('Cancel planned jobs')).not.toBeInTheDocument();
+  });
+
+  it('should call cancel API when cancel is confirmed', async () => {
+    const runs: PlanRun[] = [
+      {
+        id: 1,
+        planId: 5,
+        userId: 100,
+        quantity: 10,
+        createdAt: '2026-02-22T23:00:00Z',
+        planName: 'Rifter Plan',
+        productName: 'Rifter',
+        status: 'pending',
+        jobSummary: {
+          total: 3,
+          planned: 3,
+          active: 0,
+          completed: 0,
+          cancelled: 0,
+        },
+      },
+    ];
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => runs })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: 'cancelled', jobsCancelled: 3 }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    window.confirm = jest.fn(() => true);
+
+    await act(async () => {
+      render(<PlanRunsList />);
+    });
+
+    const cancelButton = screen.getByTitle('Cancel planned jobs');
+
+    await act(async () => {
+      fireEvent.click(cancelButton);
+    });
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Are you sure you want to cancel all planned jobs for this run?',
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/industry/plans/runs/1/cancel',
+      { method: 'POST' },
+    );
+  });
+});

--- a/frontend/packages/components/industry/__tests__/__snapshots__/PlanRunsList.test.tsx.snap
+++ b/frontend/packages/components/industry/__tests__/__snapshots__/PlanRunsList.test.tsx.snap
@@ -1,0 +1,273 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`PlanRunsList Component should match snapshot while loading 1`] = `
+<div>
+  <div
+    data-testid="navbar"
+  >
+    Navbar
+  </div>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthXl css-lkiw04-MuiContainer-root"
+  >
+    <div
+      class="MuiBox-root css-1qm1lh"
+    >
+      <h5
+        class="MuiTypography-root MuiTypography-h5 css-119faas-MuiTypography-root"
+      >
+        Plan Runs
+      </h5>
+    </div>
+    <div
+      data-testid="loading"
+    >
+      Loading...
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PlanRunsList Component should match snapshot with empty runs 1`] = `
+<div>
+  <div
+    data-testid="navbar"
+  >
+    Navbar
+  </div>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthXl css-lkiw04-MuiContainer-root"
+  >
+    <div
+      class="MuiBox-root css-1qm1lh"
+    >
+      <h5
+        class="MuiTypography-root MuiTypography-h5 css-119faas-MuiTypography-root"
+      >
+        Plan Runs
+      </h5>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-57it44-MuiPaper-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1 css-1p2qead-MuiTypography-root"
+      >
+        No plan runs yet. Generate jobs from a production plan to create a run.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PlanRunsList Component should match snapshot with runs 1`] = `
+<div>
+  <div
+    data-testid="navbar"
+  >
+    Navbar
+  </div>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthXl css-lkiw04-MuiContainer-root"
+  >
+    <div
+      class="MuiBox-root css-1qm1lh"
+    >
+      <h5
+        class="MuiTypography-root MuiTypography-h5 css-119faas-MuiTypography-root"
+      >
+        Plan Runs
+      </h5>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root css-s09dh4-MuiPaper-root-MuiTableContainer-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <table
+        class="MuiTable-root css-1xwxv7r-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+        >
+          <tr
+            class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Product
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Plan
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+              scope="col"
+            >
+              Qty
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Status
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Jobs
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+              scope="col"
+            >
+              Created
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+              scope="col"
+            >
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root css-12jwrqf-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-axw7ok"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-28s2xz-MuiTypography-root"
+                >
+                  Rifter
+                </p>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1akr5kn-MuiTableCell-root"
+            >
+              Rifter Plan
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-1aqdq1-MuiTableCell-root"
+            >
+              10
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorWarning MuiChip-outlinedWarning css-1dw70sc-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+                >
+                  In Progress
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              1/5 done, 2 active
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              2/22/2026
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                title="Cancel planned jobs"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="CancelIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2m5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12z"
+                  />
+                </svg>
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-smtqgp-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiBox-root css-axw7ok"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-28s2xz-MuiTypography-root"
+                >
+                  Slasher
+                </p>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-1akr5kn-MuiTableCell-root"
+            >
+              Slasher Plan
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-1aqdq1-MuiTableCell-root"
+            >
+              3
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorDefault MuiChip-outlinedDefault css-8m2o99-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+                >
+                  Completed
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              3/3 done
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-vo16no-MuiTableCell-root"
+            >
+              2/22/2026
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+            />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/packages/pages/plan-runs.tsx
+++ b/frontend/packages/pages/plan-runs.tsx
@@ -1,0 +1,13 @@
+import { useSession } from "next-auth/react";
+import Loading from "@industry-tool/components/loading";
+import Unauthorized from "@industry-tool/components/unauthorized";
+import PlanRunsList from "@industry-tool/components/industry/PlanRunsList";
+
+export default function PlanRunsPage() {
+  const { status } = useSession();
+
+  if (status === "loading") return <Loading />;
+  if (status !== "authenticated") return <Unauthorized />;
+
+  return <PlanRunsList />;
+}

--- a/frontend/pages/api/industry/plans/runs.ts
+++ b/frontend/pages/api/industry/plans/runs.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (userId: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": userId,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    if (req.method === "GET") {
+      const response = await fetch(`${backend}v1/industry/plans/runs`, {
+        method: "GET",
+        headers: getHeaders(session.providerAccountId),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Plan runs API error:", error);
+    return res.status(500).json({ error: "Failed to get plan runs" });
+  }
+}

--- a/frontend/pages/api/industry/plans/runs/[runId]/cancel.ts
+++ b/frontend/pages/api/industry/plans/runs/[runId]/cancel.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (userId: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": userId,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { runId } = req.query;
+
+  try {
+    if (req.method === "POST") {
+      const response = await fetch(
+        `${backend}v1/industry/plans/runs/${runId}/cancel`,
+        {
+          method: "POST",
+          headers: getHeaders(session.providerAccountId),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+    } else {
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+  } catch (error) {
+    console.error("Cancel plan run API error:", error);
+    return res.status(500).json({ error: "Failed to cancel plan run" });
+  }
+}

--- a/frontend/pages/plan-runs.tsx
+++ b/frontend/pages/plan-runs.tsx
@@ -1,0 +1,2 @@
+import PlanRuns from "@industry-tool/pages/plan-runs";
+export default PlanRuns;


### PR DESCRIPTION
## Summary
- New `/plan-runs` page listing all runs across all plans with status chips, job progress, and created date
- Cancel action on runs with planned jobs — bulk-cancels only `planned` jobs via single UPDATE, leaving active/completed untouched
- New backend endpoints: `GET /v1/industry/plans/runs` and `POST /v1/industry/plans/runs/{runId}/cancel`
- Added "Runs" link to Navbar

## Test plan
- [ ] 37 production plan controller tests pass (5 new: GetAllRuns success/error, CancelPlanRun success/invalidID/error)
- [ ] 204 frontend tests pass, 40 snapshots pass (8 new PlanRunsList tests, 3 new snapshots, 1 updated Navbar snapshot)
- [ ] Repository integration tests pass with database (4 new: GetByUser, GetByUserEmpty, CancelPlannedJobs, CancelPlannedJobsNoneToCancel)
- [ ] `GET /plan-runs` page shows all runs with correct status and job progress
- [ ] Cancel button only appears for runs with planned jobs
- [ ] Cancel confirms, calls API, shows snackbar with count of cancelled jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)