### PR TITLE
Fix job queue ordering for plan-generated jobs

### DIFF
--- a/internal/repositories/jobQueue.go
+++ b/internal/repositories/jobQueue.go
@@ -96,7 +96,7 @@ func (r *JobQueue) GetByUser(ctx context.Context, userID int64) ([]*models.Indus
 		LEFT JOIN esi_industry_jobs j ON j.job_id = q.esi_job_id
 		LEFT JOIN characters installer ON installer.id = j.installer_id
 		WHERE q.user_id = $1
-		ORDER BY q.created_at DESC
+		ORDER BY q.created_at ASC
 	`
 
 	return r.queryEntries(ctx, query, userID)


### PR DESCRIPTION
## Summary
- Changed `GetByUser` query ordering from `created_at DESC` to `created_at ASC` in `jobQueue.go`
- Plan-generated jobs are created bottom-up (materials first, final product last) but `DESC` ordering reversed this, showing the final product at the top
- `ASC` preserves the correct manufacturing order and provides natural FIFO queue behavior

## Test plan
- [x] `make test-backend` — all tests pass
- [x] `make test-frontend` — all 204 tests pass, 40 snapshots match
- [ ] Verify job queue page shows materials before final product after generating from a plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)