### PR TITLE
Add Transportation Phase 2: enrichment, ordering, merging, locations

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -164,13 +164,13 @@ var rootCmd = &cobra.Command{
 		controllers.NewPi(router, piPlanetsRepository, piTaxConfigRepository, sdeDataRepository, charactersRepository, systemRepository, itemTypesRepository, marketPricesRepository, piLaunchpadLabelsRepository, stockpileMarkersRepository)
 		controllers.NewIndustry(router, industryJobsRepository, jobQueueRepository, sdeDataRepository, marketPricesRepository, industryCostIndicesRepository)
 		userStationsRepository := repositories.NewUserStations(db)
-		controllers.NewProductionPlans(router, productionPlansRepository, sdeDataRepository, jobQueueRepository, marketPricesRepository, industryCostIndicesRepository, charactersRepository, playerCorporationRepostiory, userStationsRepository, planRunsRepository)
-		controllers.NewUserStations(router, userStationsRepository)
-
 		transportProfilesRepo := repositories.NewTransportProfiles(db)
 		jfRoutesRepo := repositories.NewJFRoutes(db)
 		transportJobsRepo := repositories.NewTransportJobs(db)
 		triggerConfigRepo := repositories.NewTransportTriggerConfig(db)
+		controllers.NewProductionPlans(router, productionPlansRepository, sdeDataRepository, jobQueueRepository, marketPricesRepository, industryCostIndicesRepository, charactersRepository, playerCorporationRepostiory, userStationsRepository, planRunsRepository, transportJobsRepo, transportProfilesRepo, jfRoutesRepo, esiClient)
+		controllers.NewUserStations(router, userStationsRepository)
+
 		controllers.NewTransportation(router, transportProfilesRepo, jfRoutesRepo, transportJobsRepo, triggerConfigRepo, jobQueueRepository, marketPricesRepository, systemRepository, esiClient)
 
 		group.Go(router.Run(ctx))

--- a/docs/features/transportation.md
+++ b/docs/features/transportation.md
@@ -1,6 +1,6 @@
 # Transportation System
 
-## Status: Phase 1 — Implemented
+## Status: Phase 2 — Implemented
 
 ## Overview
 
@@ -134,9 +134,65 @@ cost = (volume × ratePerM3) + (collateral × collateralRate)
 5. **Status machine**: planned → in_transit → delivered, or planned/in_transit → cancelled
 6. **Collateral price basis**: buy, sell, or split — same pattern as reactions calculator
 
+## Phase 2: Production Plan Integration — Implemented
+
+Auto-generates transport jobs when running `GenerateJobs` on a production plan, if steps span multiple stations.
+
+### Plan-Level Transport Settings
+
+Each production plan stores its own transport preferences:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| transport_fulfillment | text (nullable) | self_haul, courier_contract, contact_haul — NULL = transport disabled |
+| transport_method | text (nullable) | freighter, jump_freighter, dst, blockade_runner (self_haul only) |
+| transport_profile_id | bigint (nullable) | FK to transport_profiles |
+| courier_rate_per_m3 | numeric(12,2) | Courier flat rate per m3 |
+| courier_collateral_rate | numeric(6,4) | Courier collateral percentage |
+
+### How It Works
+
+1. **Opt-in**: Transport generation only runs if `transport_fulfillment` is set on the plan
+2. **Station resolution**: Each plan step's `user_station_id` is resolved to a physical `station_id` via `user_stations`
+3. **Cross-station detection**: For each child→parent step edge, if `child.station_id != parent.station_id`, a transport need is recorded
+4. **Batching by route**: Items going to the same origin→destination are grouped into a single transport job
+5. **Cost calculation**: Uses the same cost formulas as Phase 1, based on the plan's fulfillment type:
+   - **Self haul + gate**: ESI route lookup → `CalculateGateTransportCost`
+   - **Self haul + JF**: `FindBySystemPair` → `CalculateJFTransportCost`
+   - **Courier/Contact**: `CalculateCourierCost` with plan's courier rates
+6. **Graceful degradation**: ESI/route failures create jobs with `jumps=0, estimatedCost=0`
+7. **Queue integration**: Each transport job creates a corresponding queue entry with `activity=transport`
+8. **Depth-based ordering**: Manufacturing jobs are ordered by dependency depth (deepest/leaf steps first), transport jobs interleave between the manufacturing steps they connect (sort_order = childDepth * 2 - 1)
+9. **Job merging**: Identical manufacturing/reaction jobs (same blueprint, activity, ME, TE, tax) are merged by summing runs, costs, durations
+10. **Transport items enrichment**: Queue entries display what items are being transported via `string_agg` subquery on `transport_job_items`
+11. **Station & location context**: Queue entries store station name, input location, and output location from the plan step for easy in-game reference
+
+### Frontend UI
+
+- **Transport tab** on the plan editor: Configure fulfillment type, transport method, profile, and courier rates
+- **Generate result dialog**: Shows transport jobs alongside manufacturing jobs after generation
+- **Job Queue table**: 16 columns including Station, Input, Output for plan-generated jobs; transport rows show route, items summary, method, jumps, volume, fulfillment
+
+### Migrations
+
+- `20260224205134_add_plan_transport_settings` — adds 5 columns to `production_plans`
+- `20260224222923_add_sort_order_to_job_queue` — adds `sort_order`, `station_name`, `input_location`, `output_location` to `industry_job_queue`
+
+### Key Files (Phase 2)
+
+| File | Change |
+|------|--------|
+| `internal/controllers/productionPlans.go` | Transport interfaces, deps, `generateTransportJobs` method, depth-based ordering, job merging |
+| `internal/repositories/productionPlans.go` | CRUD with transport fields |
+| `internal/repositories/jobQueue.go` | Transport enrichment JOINs, `string_agg` subquery, `sort_order` ordering |
+| `internal/repositories/jfRoutes.go` | `FindBySystemPair` method |
+| `internal/repositories/userStations.go` | `SolarSystemID` in SELECT/Scan |
+| `internal/models/models.go` | `IndustryJobQueueEntry` transport + location fields |
+| `frontend/packages/components/industry/ProductionPlanEditor.tsx` | Transport settings tab + generate result |
+| `frontend/packages/components/industry/JobQueue.tsx` | Station/Input/Output columns, transport items display |
+
 ## Future Phases
 
-- Phase 2: Production plan integration (auto-generate transport jobs from plans)
 - Phase 3: Contract tracking and cost reconciliation
 - Phase 4: Multi-leg route optimization
 - Phase 5: Fleet coordination and scheduling

--- a/frontend/packages/client/data/models.ts
+++ b/frontend/packages/client/data/models.ts
@@ -407,6 +407,10 @@ export type IndustryJobQueueEntry = {
   estimatedCost?: number;
   estimatedDuration?: number;
   notes?: string;
+  sortOrder: number;
+  stationName?: string;
+  inputLocation?: string;
+  outputLocation?: string;
   createdAt: string;
   updatedAt: string;
   blueprintName?: string;
@@ -415,6 +419,14 @@ export type IndustryJobQueueEntry = {
   systemName?: string;
   esiJobEndDate?: string;
   esiJobSource?: string;
+  transportJobId?: number;
+  transportOriginName?: string;
+  transportDestName?: string;
+  transportMethod?: string;
+  transportFulfillment?: string;
+  transportVolumeM3?: number;
+  transportJumps?: number;
+  transportItemsSummary?: string;
 };
 
 export type ManufacturingCalcResult = {
@@ -463,6 +475,11 @@ export type ProductionPlan = {
   notes?: string;
   defaultManufacturingStationId?: number;
   defaultReactionStationId?: number;
+  transportFulfillment?: string;
+  transportMethod?: string;
+  transportProfileId?: number;
+  courierRatePerM3: number;
+  courierCollateralRate: number;
   createdAt: string;
   updatedAt: string;
   productName?: string;
@@ -533,10 +550,24 @@ export type PlanMaterial = {
   isProduced: boolean;
 };
 
+export type GenerateJobsTransportJob = {
+  id: number;
+  originStationName?: string;
+  destinationStationName?: string;
+  transportMethod: string;
+  fulfillmentType: string;
+  totalVolumeM3: number;
+  totalCollateral: number;
+  estimatedCost: number;
+  jumps: number;
+  items: { typeId: number; typeName?: string; quantity: number; volumeM3: number; estimatedValue: number }[];
+};
+
 export type GenerateJobsResult = {
   run: PlanRun;
   created: IndustryJobQueueEntry[];
   skipped: GenerateJobSkipped[];
+  transportJobs: GenerateJobsTransportJob[];
 };
 
 export type PlanRunJobSummary = {

--- a/frontend/packages/components/industry/JobQueue.tsx
+++ b/frontend/packages/components/industry/JobQueue.tsx
@@ -22,6 +22,8 @@ type Props = {
   onCancel: (id: number) => void;
 };
 
+const headerStyle = { color: "#94a3b8", fontWeight: 600 };
+
 function getStatusColor(status: string): "success" | "warning" | "info" | "error" | "default" {
   switch (status) {
     case "planned": return "info";
@@ -29,6 +31,25 @@ function getStatusColor(status: string): "success" | "warning" | "info" | "error
     case "completed": return "default";
     case "cancelled": return "error";
     default: return "default";
+  }
+}
+
+function formatTransportMethod(method: string): string {
+  switch (method) {
+    case "freighter": return "Freighter";
+    case "jump_freighter": return "Jump Freighter";
+    case "dst": return "DST";
+    case "blockade_runner": return "Blockade Runner";
+    default: return method;
+  }
+}
+
+function formatFulfillment(type: string): string {
+  switch (type) {
+    case "self_haul": return "Self Haul";
+    case "courier_contract": return "Courier Contract";
+    case "contact_haul": return "Contact Haul";
+    default: return type;
   }
 }
 
@@ -90,25 +111,28 @@ export default function JobQueue({ entries, loading, onCancel }: Props) {
       <Table size="small">
         <TableHead>
           <TableRow sx={{ backgroundColor: "#0f1219" }}>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Blueprint</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Product</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Activity</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Runs</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">ME/TE</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Character</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="right">Est. Cost</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Est. Duration</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Finishes</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="center">Source</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Status</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }}>Notes</TableCell>
-            <TableCell sx={{ color: "#94a3b8", fontWeight: 600 }} align="center">Actions</TableCell>
+            <TableCell sx={headerStyle}>Blueprint</TableCell>
+            <TableCell sx={headerStyle}>Product</TableCell>
+            <TableCell sx={headerStyle}>Activity</TableCell>
+            <TableCell sx={headerStyle} align="right">Runs</TableCell>
+            <TableCell sx={headerStyle} align="right">ME/TE</TableCell>
+            <TableCell sx={headerStyle}>Station</TableCell>
+            <TableCell sx={headerStyle}>Input</TableCell>
+            <TableCell sx={headerStyle}>Output</TableCell>
+            <TableCell sx={headerStyle}>Character</TableCell>
+            <TableCell sx={headerStyle} align="right">Est. Cost</TableCell>
+            <TableCell sx={headerStyle}>Duration</TableCell>
+            <TableCell sx={headerStyle}>Finishes</TableCell>
+            <TableCell sx={headerStyle} align="center">Source</TableCell>
+            <TableCell sx={headerStyle}>Status</TableCell>
+            <TableCell sx={headerStyle}>Notes</TableCell>
+            <TableCell sx={headerStyle} align="center">Actions</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {entries.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={13} align="center" sx={{ py: 4, color: "#64748b" }}>
+              <TableCell colSpan={16} align="center" sx={{ py: 4, color: "#64748b" }}>
                 No jobs in queue
               </TableCell>
             </TableRow>
@@ -121,73 +145,152 @@ export default function JobQueue({ entries, loading, onCancel }: Props) {
                   "&:nth-of-type(even)": { backgroundColor: "#12151f" },
                 }}
               >
-                <TableCell>
-                  <Typography variant="body2" sx={{ color: "#e2e8f0" }}>
-                    {entry.blueprintName || `Type ${entry.blueprintTypeId}`}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
-                    {entry.productName || "-"}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ color: "#cbd5e1", textTransform: "capitalize" }}>
-                    {entry.activity}
-                  </Typography>
-                </TableCell>
-                <TableCell align="right">
-                  <Typography variant="body2" sx={{ color: "#e2e8f0" }}>
-                    {formatNumber(entry.runs)}
-                  </Typography>
-                </TableCell>
-                <TableCell align="right">
-                  <Typography variant="body2" sx={{ color: "#94a3b8" }}>
-                    {entry.meLevel}/{entry.teLevel}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ color: "#94a3b8" }}>
-                    {entry.characterName || "-"}
-                  </Typography>
-                </TableCell>
-                <TableCell align="right">
-                  <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
-                    {entry.estimatedCost ? formatISK(entry.estimatedCost) : "-"}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ color: "#94a3b8" }}>
-                    {entry.estimatedDuration ? formatDuration(entry.estimatedDuration) : "-"}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  {entry.esiJobEndDate ? (
-                    <Box>
-                      <Typography variant="body2" sx={{ color: "#3b82f6", fontFamily: "monospace", fontWeight: 600 }}>
-                        {formatTimeRemaining(entry.esiJobEndDate)}
+                {entry.activity === "transport" ? (
+                  <>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#e2e8f0" }}>
+                        {entry.transportOriginName && entry.transportDestName
+                          ? `${entry.transportOriginName} → ${entry.transportDestName}`
+                          : "-"}
                       </Typography>
-                      <Typography variant="caption" sx={{ color: "#64748b" }}>
-                        {formatEndDate(entry.esiJobEndDate)}
+                    </TableCell>
+                    <TableCell>
+                      <Tooltip title={entry.transportItemsSummary || ""} placement="top">
+                        <Typography variant="body2" sx={{ color: "#cbd5e1", maxWidth: 200, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                          {entry.transportItemsSummary || "-"}
+                        </Typography>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
+                        {entry.transportMethod ? formatTransportMethod(entry.transportMethod) : "Transport"}
                       </Typography>
-                    </Box>
-                  ) : (
-                    <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
-                  )}
-                </TableCell>
-                <TableCell align="center">
-                  {entry.esiJobSource ? (
-                    <Tooltip title={entry.esiJobSource === "corporation" ? "Corporation Job" : "Character Job"}>
-                      {entry.esiJobSource === "corporation" ? (
-                        <CorporateFareIcon sx={{ color: "#f59e0b", fontSize: 18 }} />
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                        {entry.transportJumps ? `${formatNumber(entry.transportJumps)} jumps` : "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                        {entry.transportVolumeM3 ? `${formatNumber(entry.transportVolumeM3)} m³` : "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                        {entry.transportFulfillment ? formatFulfillment(entry.transportFulfillment) : "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
+                        {entry.estimatedCost ? formatISK(entry.estimatedCost) : "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
+                    </TableCell>
+                    <TableCell align="center">
+                      <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
+                    </TableCell>
+                  </>
+                ) : (
+                  <>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#e2e8f0" }}>
+                        {entry.blueprintName || `Type ${entry.blueprintTypeId}`}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
+                        {entry.productName || "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#cbd5e1", textTransform: "capitalize" }}>
+                        {entry.activity}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2" sx={{ color: "#e2e8f0" }}>
+                        {formatNumber(entry.runs)}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                        {entry.meLevel}/{entry.teLevel}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                        {entry.stationName || "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                        {entry.inputLocation || "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                        {entry.outputLocation || "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                        {entry.characterName || "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2" sx={{ color: "#cbd5e1" }}>
+                        {entry.estimatedCost ? formatISK(entry.estimatedCost) : "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ color: "#94a3b8" }}>
+                        {entry.estimatedDuration ? formatDuration(entry.estimatedDuration) : "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      {entry.esiJobEndDate ? (
+                        <Box>
+                          <Typography variant="body2" sx={{ color: "#3b82f6", fontFamily: "monospace", fontWeight: 600 }}>
+                            {formatTimeRemaining(entry.esiJobEndDate)}
+                          </Typography>
+                          <Typography variant="caption" sx={{ color: "#64748b" }}>
+                            {formatEndDate(entry.esiJobEndDate)}
+                          </Typography>
+                        </Box>
                       ) : (
-                        <PersonIcon sx={{ color: "#94a3b8", fontSize: 18 }} />
+                        <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
                       )}
-                    </Tooltip>
-                  ) : (
-                    <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
-                  )}
-                </TableCell>
+                    </TableCell>
+                    <TableCell align="center">
+                      {entry.esiJobSource ? (
+                        <Tooltip title={entry.esiJobSource === "corporation" ? "Corporation Job" : "Character Job"}>
+                          {entry.esiJobSource === "corporation" ? (
+                            <CorporateFareIcon sx={{ color: "#f59e0b", fontSize: 18 }} />
+                          ) : (
+                            <PersonIcon sx={{ color: "#94a3b8", fontSize: 18 }} />
+                          )}
+                        </Tooltip>
+                      ) : (
+                        <Typography variant="body2" sx={{ color: "#64748b" }}>-</Typography>
+                      )}
+                    </TableCell>
+                  </>
+                )}
                 <TableCell>
                   <Chip
                     label={entry.status}

--- a/frontend/packages/components/industry/__tests__/JobQueue.test.tsx
+++ b/frontend/packages/components/industry/__tests__/JobQueue.test.tsx
@@ -47,6 +47,7 @@ describe('JobQueue Component', () => {
         teLevel: 20,
         facilityTax: 1.0,
         status: 'planned',
+        sortOrder: 2,
         estimatedCost: 5000000,
         estimatedDuration: 3600,
         createdAt: '2026-02-22T00:00:00Z',
@@ -54,6 +55,9 @@ describe('JobQueue Component', () => {
         blueprintName: 'Rifter Blueprint',
         productName: 'Rifter',
         notes: 'Test note',
+        stationName: 'Jita IV - Moon 4 - Caldari Navy Assembly Plant',
+        inputLocation: 'CharOwner > Big Container',
+        outputLocation: 'CorpOwner > Hangar 1',
       },
       {
         id: 2,
@@ -65,6 +69,7 @@ describe('JobQueue Component', () => {
         teLevel: 0,
         facilityTax: 0.25,
         status: 'active',
+        sortOrder: 4,
         esiJobId: 12345,
         createdAt: '2026-02-22T00:00:00Z',
         updatedAt: '2026-02-22T00:00:00Z',
@@ -79,7 +84,7 @@ describe('JobQueue Component', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should display entry details', () => {
+  it('should display entry details with station and locations', () => {
     const entries: IndustryJobQueueEntry[] = [
       {
         id: 1,
@@ -91,9 +96,13 @@ describe('JobQueue Component', () => {
         teLevel: 20,
         facilityTax: 1.0,
         status: 'planned',
+        sortOrder: 0,
         createdAt: '2026-02-22T00:00:00Z',
         updatedAt: '2026-02-22T00:00:00Z',
         blueprintName: 'Rifter Blueprint',
+        stationName: 'Jita IV - Moon 4 - Caldari Navy Assembly Plant',
+        inputLocation: 'MyCharacter > Ammo Box',
+        outputLocation: 'MyCorp > Division 1',
       },
     ];
 
@@ -101,6 +110,9 @@ describe('JobQueue Component', () => {
     expect(screen.getByText('Rifter Blueprint')).toBeInTheDocument();
     expect(screen.getByText('planned')).toBeInTheDocument();
     expect(screen.getByText('10/20')).toBeInTheDocument();
+    expect(screen.getByText('Jita IV - Moon 4 - Caldari Navy Assembly Plant')).toBeInTheDocument();
+    expect(screen.getByText('MyCharacter > Ammo Box')).toBeInTheDocument();
+    expect(screen.getByText('MyCorp > Division 1')).toBeInTheDocument();
   });
 
   it('should call onCancel when cancel button is clicked', () => {
@@ -115,6 +127,7 @@ describe('JobQueue Component', () => {
         teLevel: 20,
         facilityTax: 1.0,
         status: 'planned',
+        sortOrder: 0,
         createdAt: '2026-02-22T00:00:00Z',
         updatedAt: '2026-02-22T00:00:00Z',
       },
@@ -138,6 +151,7 @@ describe('JobQueue Component', () => {
         teLevel: 20,
         facilityTax: 1.0,
         status: 'active',
+        sortOrder: 0,
         esiJobId: 99999,
         esiJobEndDate: '2026-02-26T04:33:00Z',
         createdAt: '2026-02-22T00:00:00Z',
@@ -148,6 +162,73 @@ describe('JobQueue Component', () => {
 
     render(<JobQueue entries={entries} loading={false} onCancel={mockOnCancel} />);
     expect(screen.getByText('2026.02.26 04:33')).toBeInTheDocument();
+  });
+
+  it('should match snapshot with transport entry', () => {
+    const entries: IndustryJobQueueEntry[] = [
+      {
+        id: 20,
+        userId: 100,
+        blueprintTypeId: 0,
+        activity: 'transport',
+        runs: 0,
+        meLevel: 0,
+        teLevel: 0,
+        facilityTax: 0,
+        status: 'planned',
+        sortOrder: 3,
+        estimatedCost: 12500000,
+        createdAt: '2026-02-22T00:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+        transportJobId: 5,
+        transportOriginName: 'Jita IV - Moon 4 - Caldari Navy Assembly Plant',
+        transportDestName: 'Amarr VIII - Oris - Emperor Family Academy',
+        transportMethod: 'jump_freighter',
+        transportFulfillment: 'self_haul',
+        transportVolumeM3: 125000,
+        transportJumps: 12,
+        transportItemsSummary: 'Hydrogen Fuel Block x500, Oxygen Fuel Block x300',
+      },
+    ];
+
+    const { container } = render(
+      <JobQueue entries={entries} loading={false} onCancel={mockOnCancel} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display transport route, items, and method', () => {
+    const entries: IndustryJobQueueEntry[] = [
+      {
+        id: 21,
+        userId: 100,
+        blueprintTypeId: 0,
+        activity: 'transport',
+        runs: 0,
+        meLevel: 0,
+        teLevel: 0,
+        facilityTax: 0,
+        status: 'planned',
+        sortOrder: 1,
+        createdAt: '2026-02-22T00:00:00Z',
+        updatedAt: '2026-02-22T00:00:00Z',
+        transportOriginName: 'Jita IV - Moon 4 - Caldari Navy Assembly Plant',
+        transportDestName: 'Amarr VIII - Oris - Emperor Family Academy',
+        transportMethod: 'freighter',
+        transportFulfillment: 'courier_contract',
+        transportVolumeM3: 50000,
+        transportJumps: 15,
+        transportItemsSummary: 'Tritanium x10000, Pyerite x5000',
+      },
+    ];
+
+    render(<JobQueue entries={entries} loading={false} onCancel={mockOnCancel} />);
+    expect(screen.getByText(/Jita IV.*→.*Amarr VIII/)).toBeInTheDocument();
+    expect(screen.getByText('Freighter')).toBeInTheDocument();
+    expect(screen.getByText('15 jumps')).toBeInTheDocument();
+    expect(screen.getByText('50,000 m³')).toBeInTheDocument();
+    expect(screen.getByText('Courier Contract')).toBeInTheDocument();
+    expect(screen.getByText('Tritanium x10000, Pyerite x5000')).toBeInTheDocument();
   });
 
   it('should not show cancel button for completed entries', () => {
@@ -162,6 +243,7 @@ describe('JobQueue Component', () => {
         teLevel: 20,
         facilityTax: 1.0,
         status: 'completed',
+        sortOrder: 0,
         createdAt: '2026-02-22T00:00:00Z',
         updatedAt: '2026-02-22T00:00:00Z',
       },

--- a/frontend/packages/components/industry/__tests__/ProductionPlanEditor.test.tsx
+++ b/frontend/packages/components/industry/__tests__/ProductionPlanEditor.test.tsx
@@ -68,6 +68,22 @@ const mockMaterials: PlanMaterial[] = [
   },
 ];
 
+// URL-based fetch mock to handle concurrent requests from multiple useEffects
+function mockFetchForPlan(plan: ProductionPlan | null, materials?: PlanMaterial[]) {
+  (global.fetch as jest.Mock).mockImplementation((url: string, opts?: any) => {
+    if (url === `/api/industry/plans/${plan?.id ?? 1}`) {
+      return Promise.resolve({ ok: true, json: async () => plan });
+    }
+    if (url === '/api/transport/profiles') {
+      return Promise.resolve({ ok: true, json: async () => [] });
+    }
+    if (url.includes('/materials') && materials) {
+      return Promise.resolve({ ok: true, json: async () => materials });
+    }
+    return Promise.resolve({ ok: true, json: async () => [] });
+  });
+}
+
 describe('ProductionPlanEditor Component', () => {
   beforeEach(() => {
     (global.fetch as jest.Mock).mockClear();
@@ -92,15 +108,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should match snapshot with loaded plan', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     let container: HTMLElement;
     await act(async () => {
@@ -112,15 +120,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should display plan name and product info', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -131,15 +131,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should display root step with details', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -152,15 +144,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should display materials when root step is auto-expanded', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -172,15 +156,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should show produce toggle for materials with blueprints', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -191,15 +167,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should show Buy chip for non-produced materials', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -210,15 +178,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should have Generate Jobs button', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -228,15 +188,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should open generate dialog when Generate Jobs is clicked', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -248,15 +200,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should open edit dialog when edit button is clicked', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -275,10 +219,7 @@ describe('ProductionPlanEditor Component', () => {
       steps: [],
     };
 
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => emptyPlan,
-    });
+    mockFetchForPlan(emptyPlan);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -317,26 +258,7 @@ describe('ProductionPlanEditor Component', () => {
       { ...mockMaterials[2], isProduced: true },
     ];
 
-    const childMaterials: PlanMaterial[] = [
-      {
-        typeId: 16634,
-        typeName: 'Chromium',
-        quantity: 100,
-        volume: 0.16,
-        hasBlueprint: false,
-        isProduced: false,
-      },
-    ];
-
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => multiStepPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => materialsWithProduced,
-      });
+    mockFetchForPlan(multiStepPlan, materialsWithProduced);
 
     let container: HTMLElement;
     await act(async () => {
@@ -348,15 +270,7 @@ describe('ProductionPlanEditor Component', () => {
   });
 
   it('should fetch plan on mount', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -365,16 +279,18 @@ describe('ProductionPlanEditor Component', () => {
     expect(global.fetch).toHaveBeenCalledWith('/api/industry/plans/1');
   });
 
+  it('should fetch transport profiles on mount', async () => {
+    mockFetchForPlan(mockPlan, mockMaterials);
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/transport/profiles');
+  });
+
   it('should fetch materials for root step on load', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockPlan,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockMaterials,
-      });
+    mockFetchForPlan(mockPlan, mockMaterials);
 
     await act(async () => {
       render(<ProductionPlanEditor planId={1} />);
@@ -383,5 +299,15 @@ describe('ProductionPlanEditor Component', () => {
     expect(global.fetch).toHaveBeenCalledWith(
       '/api/industry/plans/1/steps/10/materials',
     );
+  });
+
+  it('should show Transport tab', async () => {
+    mockFetchForPlan(mockPlan, mockMaterials);
+
+    await act(async () => {
+      render(<ProductionPlanEditor planId={1} />);
+    });
+
+    expect(screen.getByText('Transport')).toBeInTheDocument();
   });
 });

--- a/frontend/packages/components/industry/__tests__/__snapshots__/JobQueue.test.tsx.snap
+++ b/frontend/packages/components/industry/__tests__/__snapshots__/JobQueue.test.tsx.snap
@@ -76,6 +76,24 @@ exports[`JobQueue Component should match snapshot with empty queue 1`] = `
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
             scope="col"
           >
+            Station
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Input
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Output
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
             Character
           </th>
           <th
@@ -88,7 +106,7 @@ exports[`JobQueue Component should match snapshot with empty queue 1`] = `
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
             scope="col"
           >
-            Est. Duration
+            Duration
           </th>
           <th
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
@@ -130,7 +148,7 @@ exports[`JobQueue Component should match snapshot with empty queue 1`] = `
         >
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1btjunt-MuiTableCell-root"
-            colspan="13"
+            colspan="16"
           >
             No jobs in queue
           </td>
@@ -189,6 +207,24 @@ exports[`JobQueue Component should match snapshot with entries 1`] = `
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
             scope="col"
           >
+            Station
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Input
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Output
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
             Character
           </th>
           <th
@@ -201,7 +237,7 @@ exports[`JobQueue Component should match snapshot with entries 1`] = `
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
             scope="col"
           >
-            Est. Duration
+            Duration
           </th>
           <th
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
@@ -286,6 +322,33 @@ exports[`JobQueue Component should match snapshot with entries 1`] = `
               10
               /
               20
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              Jita IV - Moon 4 - Caldari Navy Assembly Plant
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              CharOwner &gt; Big Container
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              CorpOwner &gt; Hangar 1
             </p>
           </td>
           <td
@@ -438,6 +501,33 @@ exports[`JobQueue Component should match snapshot with entries 1`] = `
             </p>
           </td>
           <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
           >
             <p
@@ -492,6 +582,294 @@ exports[`JobQueue Component should match snapshot with entries 1`] = `
                 class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
               >
                 active
+              </span>
+            </div>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-1vbssuc-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-bm3ath-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              title="Cancel job"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="CancelIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2m5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12z"
+                />
+              </svg>
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`JobQueue Component should match snapshot with transport entry 1`] = `
+<div>
+  <div
+    class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+  >
+    <table
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
+    >
+      <thead
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head css-26wbf9-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Blueprint
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Product
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Activity
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Runs
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            ME/TE
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Station
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Input
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Output
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Character
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-14ucdea-MuiTableCell-root"
+            scope="col"
+          >
+            Est. Cost
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Duration
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Finishes
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+            scope="col"
+          >
+            Source
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Status
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-fb16f1-MuiTableCell-root"
+            scope="col"
+          >
+            Notes
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1p4g5cl-MuiTableCell-root"
+            scope="col"
+          >
+            Actions
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root css-ky2cy3-MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-yaetr5-MuiTypography-root"
+            >
+              Jita IV - Moon 4 - Caldari Navy Assembly Plant → Amarr VIII - Oris - Emperor Family Academy
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              aria-label="Hydrogen Fuel Block x500, Oxygen Fuel Block x300"
+              class="MuiTypography-root MuiTypography-body2 css-1se5ddy-MuiTypography-root"
+              data-mui-internal-clone-element="true"
+            >
+              Hydrogen Fuel Block x500, Oxygen Fuel Block x300
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              Jump Freighter
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              12 jumps
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              125,000 m³
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-595iqm-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-595iqm-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-595iqm-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-rfztis-MuiTypography-root"
+            >
+              Self Haul
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeSmall css-17j8okc-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-16mz89a-MuiTypography-root"
+            >
+              12.50M ISK
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-595iqm-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-595iqm-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-wsxt5g-MuiTableCell-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-595iqm-MuiTypography-root"
+            >
+              -
+            </p>
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorInfo MuiChip-outlinedInfo css-mr7bkj-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+              >
+                planned
               </span>
             </div>
           </td>

--- a/frontend/packages/components/industry/__tests__/__snapshots__/ProductionPlanEditor.test.tsx.snap
+++ b/frontend/packages/components/industry/__tests__/__snapshots__/ProductionPlanEditor.test.tsx.snap
@@ -124,6 +124,26 @@ exports[`ProductionPlanEditor Component should match snapshot with loaded plan 1
             >
               Batch Configure
             </button>
+            <button
+              aria-selected="false"
+              class="MuiButtonBase-root MuiTab-root MuiTab-labelIcon MuiTab-textColorPrimary css-iypnj4-MuiButtonBase-root-MuiTab-root"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTab-iconWrapper MuiTab-icon css-6dq5bp-MuiSvgIcon-root"
+                data-testid="LocalShippingIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5zM6 18.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5m13.5-9 1.96 2.5H17V9.5zm-1.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5"
+                />
+              </svg>
+              Transport
+            </button>
           </div>
           <span
             class="MuiTabs-indicator css-1qltlow-MuiTabs-indicator"
@@ -578,6 +598,26 @@ exports[`ProductionPlanEditor Component should match snapshot with multi-step pl
               type="button"
             >
               Batch Configure
+            </button>
+            <button
+              aria-selected="false"
+              class="MuiButtonBase-root MuiTab-root MuiTab-labelIcon MuiTab-textColorPrimary css-iypnj4-MuiButtonBase-root-MuiTab-root"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTab-iconWrapper MuiTab-icon css-6dq5bp-MuiSvgIcon-root"
+                data-testid="LocalShippingIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5zM6 18.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5m13.5-9 1.96 2.5H17V9.5zm-1.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5"
+                />
+              </svg>
+              Transport
             </button>
           </div>
           <span

--- a/frontend/packages/pages/industry.tsx
+++ b/frontend/packages/pages/industry.tsx
@@ -97,7 +97,7 @@ export default function Industry() {
   return (
     <>
       <Navbar />
-      <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
+      <Container maxWidth={false} sx={{ mt: 2, mb: 4 }}>
         <Typography variant="h5" sx={{ color: "#e2e8f0", mb: 2, fontWeight: 600 }}>
           Industry Jobs
         </Typography>

--- a/internal/database/migrations/20260224205134_add_plan_transport_settings.down.sql
+++ b/internal/database/migrations/20260224205134_add_plan_transport_settings.down.sql
@@ -1,0 +1,9 @@
+-- Migration: add_plan_transport_settings
+-- Created: Tue Feb 24 08:51:34 PM PST 2026
+
+alter table production_plans
+	drop column transport_fulfillment,
+	drop column transport_method,
+	drop column transport_profile_id,
+	drop column courier_rate_per_m3,
+	drop column courier_collateral_rate;

--- a/internal/database/migrations/20260224205134_add_plan_transport_settings.up.sql
+++ b/internal/database/migrations/20260224205134_add_plan_transport_settings.up.sql
@@ -1,0 +1,9 @@
+-- Migration: add_plan_transport_settings
+-- Created: Tue Feb 24 08:51:34 PM PST 2026
+
+alter table production_plans
+	add column transport_fulfillment text,
+	add column transport_method text,
+	add column transport_profile_id bigint references transport_profiles(id) on delete set null,
+	add column courier_rate_per_m3 numeric(12,2) not null default 0,
+	add column courier_collateral_rate numeric(6,4) not null default 0;

--- a/internal/database/migrations/20260224222923_add_sort_order_to_job_queue.down.sql
+++ b/internal/database/migrations/20260224222923_add_sort_order_to_job_queue.down.sql
@@ -1,0 +1,6 @@
+-- Migration: add_sort_order_to_job_queue (rollback)
+
+alter table industry_job_queue drop column sort_order;
+alter table industry_job_queue drop column station_name;
+alter table industry_job_queue drop column input_location;
+alter table industry_job_queue drop column output_location;

--- a/internal/database/migrations/20260224222923_add_sort_order_to_job_queue.up.sql
+++ b/internal/database/migrations/20260224222923_add_sort_order_to_job_queue.up.sql
@@ -1,0 +1,7 @@
+-- Migration: add_sort_order_to_job_queue
+-- Adds sort_order for depth-based ordering, and location fields for job execution context
+
+alter table industry_job_queue add column sort_order int not null default 0;
+alter table industry_job_queue add column station_name text not null default '';
+alter table industry_job_queue add column input_location text not null default '';
+alter table industry_job_queue add column output_location text not null default '';

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -826,15 +826,27 @@ type IndustryJobQueueEntry struct {
 	PlanRunID         *int64     `json:"planRunId,omitempty"`
 	PlanStepID        *int64     `json:"planStepId,omitempty"`
 	TransportJobID    *int64     `json:"transportJobId,omitempty"`
+	SortOrder         int        `json:"sortOrder"`
+	StationName       string     `json:"stationName,omitempty"`
+	InputLocation     string     `json:"inputLocation,omitempty"`
+	OutputLocation    string     `json:"outputLocation,omitempty"`
 	CreatedAt         time.Time  `json:"createdAt"`
 	UpdatedAt         time.Time  `json:"updatedAt"`
-	// Enriched fields
-	BlueprintName string     `json:"blueprintName,omitempty"`
-	ProductName   string     `json:"productName,omitempty"`
-	CharacterName string     `json:"characterName,omitempty"`
-	SystemName    string     `json:"systemName,omitempty"`
-	EsiJobEndDate *time.Time `json:"esiJobEndDate,omitempty"`
-	EsiJobSource  string     `json:"esiJobSource,omitempty"`
+	// Enriched fields (joined from other tables)
+	BlueprintName        string     `json:"blueprintName,omitempty"`
+	ProductName          string     `json:"productName,omitempty"`
+	CharacterName        string     `json:"characterName,omitempty"`
+	SystemName           string     `json:"systemName,omitempty"`
+	EsiJobEndDate        *time.Time `json:"esiJobEndDate,omitempty"`
+	EsiJobSource         string     `json:"esiJobSource,omitempty"`
+	// Transport enriched fields
+	TransportOriginName   string  `json:"transportOriginName,omitempty"`
+	TransportDestName     string  `json:"transportDestName,omitempty"`
+	TransportMethod       string  `json:"transportMethod,omitempty"`
+	TransportFulfillment  string  `json:"transportFulfillment,omitempty"`
+	TransportVolumeM3     float64 `json:"transportVolumeM3,omitempty"`
+	TransportJumps        int     `json:"transportJumps,omitempty"`
+	TransportItemsSummary string  `json:"transportItemsSummary,omitempty"`
 }
 
 type ManufacturingCalcResult struct {
@@ -875,6 +887,11 @@ type ProductionPlan struct {
 	Notes                         *string   `json:"notes"`
 	DefaultManufacturingStationID *int64    `json:"defaultManufacturingStationId"`
 	DefaultReactionStationID      *int64    `json:"defaultReactionStationId"`
+	TransportFulfillment          *string   `json:"transportFulfillment"`
+	TransportMethod               *string   `json:"transportMethod"`
+	TransportProfileID            *int64    `json:"transportProfileId"`
+	CourierRatePerM3              float64   `json:"courierRatePerM3"`
+	CourierCollateralRate         float64   `json:"courierCollateralRate"`
 	CreatedAt                     time.Time `json:"createdAt"`
 	UpdatedAt                     time.Time `json:"updatedAt"`
 	// Enriched
@@ -940,9 +957,10 @@ type PlanMaterial struct {
 }
 
 type GenerateJobsResult struct {
-	Run     *ProductionPlanRun       `json:"run"`
-	Created []*IndustryJobQueueEntry `json:"created"`
-	Skipped []*GenerateJobSkipped    `json:"skipped"`
+	Run            *ProductionPlanRun       `json:"run"`
+	Created        []*IndustryJobQueueEntry `json:"created"`
+	Skipped        []*GenerateJobSkipped    `json:"skipped"`
+	TransportJobs  []*TransportJob          `json:"transportJobs"`
 }
 
 type GenerateJobSkipped struct {
@@ -987,6 +1005,7 @@ type UserStation struct {
 	UpdatedAt   time.Time `json:"updatedAt"`
 	// Enriched
 	StationName     string               `json:"stationName,omitempty"`
+	SolarSystemID   int64                `json:"solarSystemId,omitempty"`
 	SolarSystemName string               `json:"solarSystemName,omitempty"`
 	SecurityStatus  float64              `json:"securityStatus,omitempty"`
 	Security        string               `json:"security,omitempty"`

--- a/internal/repositories/userStations.go
+++ b/internal/repositories/userStations.go
@@ -22,6 +22,7 @@ func (r *UserStations) GetByUser(ctx context.Context, userID int64) ([]*models.U
 		SELECT us.id, us.user_id, us.station_id, us.structure, us.facility_tax,
 		       us.created_at, us.updated_at,
 		       COALESCE(st.name, '') as station_name,
+		       ss.solar_system_id,
 		       COALESCE(ss.name, '') as solar_system_name,
 		       COALESCE(ss.security, 0) as security_status,
 		       CASE
@@ -51,7 +52,7 @@ func (r *UserStations) GetByUser(ctx context.Context, userID int64) ([]*models.U
 		err := rows.Scan(
 			&s.ID, &s.UserID, &s.StationID, &s.Structure, &s.FacilityTax,
 			&s.CreatedAt, &s.UpdatedAt,
-			&s.StationName, &s.SolarSystemName, &s.SecurityStatus, &s.Security,
+			&s.StationName, &s.SolarSystemID, &s.SolarSystemName, &s.SecurityStatus, &s.Security,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to scan user station")
@@ -84,6 +85,7 @@ func (r *UserStations) GetByID(ctx context.Context, id, userID int64) (*models.U
 		SELECT us.id, us.user_id, us.station_id, us.structure, us.facility_tax,
 		       us.created_at, us.updated_at,
 		       COALESCE(st.name, '') as station_name,
+		       ss.solar_system_id,
 		       COALESCE(ss.name, '') as solar_system_name,
 		       COALESCE(ss.security, 0) as security_status,
 		       CASE
@@ -101,7 +103,7 @@ func (r *UserStations) GetByID(ctx context.Context, id, userID int64) (*models.U
 	err := r.db.QueryRowContext(ctx, stationQuery, id, userID).Scan(
 		&s.ID, &s.UserID, &s.StationID, &s.Structure, &s.FacilityTax,
 		&s.CreatedAt, &s.UpdatedAt,
-		&s.StationName, &s.SolarSystemName, &s.SecurityStatus, &s.Security,
+		&s.StationName, &s.SolarSystemID, &s.SolarSystemName, &s.SecurityStatus, &s.Security,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil

--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ generate:
 	go generate ./internal/...
 
 # Test targets
-test-backend:
+test-backend: test-clean
 	@echo "Running backend tests with coverage..."
 	@mkdir -p artifacts/coverage/backend
 	$(DOCKER_COMPOSE) -f docker-compose.test.yaml run --rm backend-test \
@@ -66,7 +66,7 @@ test-backend-sde-integration:
 		sh -c "SDE_INTEGRATION_TEST=1 go test -v -run Test_SdeClient_Integration -timeout 300s ./internal/client/"
 	@echo "✓ SDE integration test passed"
 
-test-frontend:
+test-frontend: test-clean
 	@echo "Running frontend tests with coverage..."
 	@mkdir -p artifacts/coverage/frontend
 	$(DOCKER_COMPOSE) -f docker-compose.test.yaml run --rm frontend-test \


### PR DESCRIPTION
## Summary

- Transport queue entries now show route, items being transported, method, volume, jumps, and fulfillment type
- Jobs ordered by dependency depth (deepest/leaf builds first) with transport jobs interleaved between the manufacturing steps they connect
- Identical manufacturing/reaction jobs are merged (same blueprint + settings = combined runs)
- Activity-aware blueprint lookups fix reaction blueprint resolution (was hardcoded to manufacturing)
- Queue entries store station name, input location, and output location from plan steps as dedicated columns
- Cancelled/completed entries hidden from queue view
- Full-width container on Industry Jobs page to accommodate 16 columns

## Test plan

- [x] `make test-backend` — all packages pass
- [x] `make test-frontend` — all 233 tests pass, snapshots updated
- [ ] Manual: generate jobs from a multi-station plan → verify queue shows correct depth ordering with transport interleaved
- [ ] Manual: verify transport rows show items summary in Product column
- [ ] Manual: verify Station, Input, Output columns populated for plan-generated jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)