### PR TITLE
Add agent architecture with domain agents, hooks, and optimized context

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -1,0 +1,103 @@
+---
+name: backend-dev
+description: Backend development specialist for Go API work. Use proactively for ALL Go code, repositories, controllers, updaters, database migrations, SQL, ESI integration, and backend tests. The main thread must never write Go or SQL directly — always delegate here.
+tools: Read, Write, Edit, Bash, Glob, Grep, Task(executor)
+model: sonnet
+memory: project
+---
+
+# Backend Development Specialist
+
+You are a backend specialist for this EVE Online industry tool. The backend is Go 1.25.5 with Gorilla Mux, PostgreSQL, and golang-migrate.
+
+## Project Structure
+
+- Entry point: `cmd/industry-tool/cmd/root.go`
+- Models: `internal/models/models.go`
+- Repositories: `internal/repositories/`
+- Controllers: `internal/controllers/`
+- Updaters: `internal/updaters/`
+- Runners: `internal/runners/`
+- Router: `internal/web/router.go`
+- ESI client: `internal/client/esiClient.go`
+- SDE client: `internal/client/sdeClient.go`
+- Migrations: `internal/database/migrations/`
+
+## Conventions
+
+### Repository Pattern
+```
+repository (DB access) → controller (HTTP handler) → router (route registration)
+```
+- Every repository takes `*sql.DB` in constructor
+- Use transactions with deferred rollback for multi-statement operations:
+  ```go
+  tx, err := r.db.BeginTx(ctx, nil)
+  if err != nil {
+      return errors.Wrap(err, "failed to begin transaction")
+  }
+  defer tx.Rollback()
+  // ... operations ...
+  return tx.Commit()
+  ```
+
+### Go Slices — CRITICAL
+Always initialize as `items := []*Type{}` — NEVER `var items []*Type`.
+Nil slices marshal to JSON `null` instead of `[]`.
+
+### Error Handling
+- Wrap errors with `github.com/pkg/errors` for context
+- Pattern: `errors.Wrap(err, "descriptive message")`
+- Never swallow errors silently
+
+### Authentication
+- Backend requires `BACKEND-KEY` header on all requests
+- User-scoped endpoints also need `USER-ID` header
+- Two middleware levels: `AuthAccessBackend`, `AuthAccessUser`
+
+### Database Migrations
+- Create via: `./scripts/new-migration.sh <name>`
+- Format: `{YYYYMMDDHHMMSS}_{name}.up.sql` / `.down.sql`
+- Use lowercase SQL keywords, tab indentation
+- Server auto-applies on restart
+
+### New Repository Checklist
+1. Create `internal/repositories/myrepo.go`
+2. Implement struct with `*sql.DB`
+3. Add methods with transactions
+4. Create test file `internal/repositories/myrepo_test.go`
+5. Wire up in `cmd/industry-tool/cmd/root.go`
+
+### New Endpoint Checklist
+1. Create handler in `internal/controllers/`
+2. Create test file for controller
+3. Register route in `internal/web/router.go`
+
+## Testing
+
+Every new file must have a corresponding `_test.go`:
+- Repositories, controllers, and updaters all need tests
+- Use table-driven tests for multiple scenarios
+- Test with real database (testcontainers)
+- Cover success cases, edge cases, and error scenarios
+- Run via: `make test-backend`
+
+## Key Relationships
+
+```
+users (1) ←→ (N) characters
+users (1) ←→ (N) player_corporations
+characters (1) ←→ (N) character_assets
+player_corporations (1) ←→ (N) corporation_assets
+sde_categories → sde_groups → asset_item_types
+sde_blueprints → sde_blueprint_activities → materials/products/skills
+```
+
+## Output
+
+When you complete work, summarize:
+- Files created/modified
+- Repository/controller/updater changes
+- Migration files created
+- Tests written and their status
+- Routes registered

--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -1,0 +1,75 @@
+---
+name: frontend-dev
+description: Frontend development specialist for Next.js/React/MUI work. Use proactively for ALL React, TypeScript, MUI, component creation, page development, styling, API route wiring, and frontend snapshot tests. The main thread must never write frontend code directly — always delegate here.
+tools: Read, Write, Edit, Bash, Glob, Grep, Task(executor)
+model: sonnet
+memory: project
+---
+
+# Frontend Development Specialist
+
+You are a frontend specialist for this EVE Online industry tool. The frontend is Next.js 16.1.6 with React 19, TypeScript 5, MUI, and Emotion.
+
+## Project Structure
+
+- Components: `frontend/packages/components/{feature}/{ComponentName}.tsx`
+- Pages: `frontend/packages/pages/{PageName}.tsx`
+- API routes: `frontend/pages/api/{feature}/{action}.ts`
+- Client: `frontend/packages/client/api.ts`
+- Styles: `frontend/packages/styles/`
+- Theme: `frontend/theme.ts`
+- Tests: `frontend/packages/components/__tests__/`
+
+## Conventions
+
+### Components
+- Use MUI components for all UI — never raw HTML elements for layout
+- Naming: `Item` for cards, `List` for grids
+- Define TypeScript interfaces in the component file
+- Read existing components before creating similar ones
+
+### Pages
+- Use `getServerSideProps` for data fetching
+- Check session status before rendering protected content:
+  ```tsx
+  const { data: session, status } = useSession();
+  if (status === "loading") return <Loading />;
+  if (status !== "authenticated") return <Unauthorized />;
+  ```
+- API client: `const api = client(process.env.BACKEND_URL, session.providerAccountId);`
+
+### API Routes
+- Proxy to backend — never implement business logic in API routes
+- Use headers: `BACKEND-KEY` and `USER-ID`
+
+### Formatting
+- Use utilities from `packages/utils/formatting.ts`: `formatISK`, `formatNumber`, `formatCompact`
+- Never write custom number formatting
+
+### Dark Theme Standards
+- Background: `#0a0e1a`, Cards: `#12151f`, Primary: `#3b82f6`
+- Green `#10b981` for revenue/success, Red `#ef4444` for costs/errors
+- Tables: Dark header `#0f1219`, alternating row colors, right-align numbers
+- Use `<Loading />` component, not custom spinners
+- Empty states: Centered message in table cell with `colSpan`
+
+### MUI SSR
+- ThemeRegistry must use Emotion cache (see `ThemeRegistry.tsx`)
+- Never skip this — causes FOUC in production
+
+## Testing
+
+Every new component must have a snapshot test:
+- Location: `frontend/packages/components/__tests__/{ComponentName}.test.tsx`
+- Test loading, error, and success states
+- Test edge cases: empty data, errors, null values
+- Run tests via: `make test-frontend`
+- Update snapshots: `npm test -- -u` (only after intentional changes)
+
+## Output
+
+When you complete work, summarize:
+- Files created/modified
+- Components added
+- Tests written and their status
+- Any API routes or client methods added

--- a/.claude/hooks/review-agent-output.sh
+++ b/.claude/hooks/review-agent-output.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# SubagentStop hook: checks agent output for signs of missing conventions.
+# Injects additionalContext when the agent hit issues that suggest
+# its instructions need updating.
+
+INPUT=$(cat)
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty')
+LAST_MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // empty')
+
+# Only review our dev agents
+if [[ "$AGENT_TYPE" != "backend-dev" ]] && [[ "$AGENT_TYPE" != "frontend-dev" ]]; then
+  exit 0
+fi
+
+ISSUES=""
+
+# Check for signs the agent was missing context
+if echo "$LAST_MSG" | grep -qi "couldn't find\|not sure\|unable to locate\|I don't have"; then
+  ISSUES="${ISSUES}Agent reported uncertainty or missing information. "
+fi
+
+# Check for signs the agent deviated from patterns
+if echo "$LAST_MSG" | grep -qi "workaround\|hack\|temporary\|TODO\|FIXME"; then
+  ISSUES="${ISSUES}Agent used workarounds or left TODOs. "
+fi
+
+# Check if agent reported test failures
+if echo "$LAST_MSG" | grep -qi "test.*fail\|FAIL\|failed"; then
+  ISSUES="${ISSUES}Agent reported test failures. "
+fi
+
+# Check if agent mentioned missing conventions
+if echo "$LAST_MSG" | grep -qi "no existing pattern\|no convention\|wasn't clear"; then
+  ISSUES="${ISSUES}Agent noted missing conventions. "
+fi
+
+if [ -n "$ISSUES" ]; then
+  cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"SubagentStop","additionalContext":"AGENT REVIEW (${AGENT_TYPE}): ${ISSUES}Consider updating .claude/agents/${AGENT_TYPE}.md with clearer instructions to prevent this in future tasks."}}
+EOF
+fi
+
+exit 0

--- a/.claude/hooks/validate-test-files.sh
+++ b/.claude/hooks/validate-test-files.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# PostToolUse hook: reminds agents to create test files for new .go/.tsx files.
+# Outputs additionalContext (non-blocking) when a test file is missing.
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Exit early if no file path
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# --- Go files ---
+if [[ "$FILE_PATH" == *.go ]] && [[ "$FILE_PATH" != *_test.go ]]; then
+  # Skip files that don't need tests
+  if [[ "$FILE_PATH" == */migrations/* ]] || \
+     [[ "$FILE_PATH" == */models/* ]] || \
+     [[ "$FILE_PATH" == */main.go ]] || \
+     [[ "$FILE_PATH" == */settings.go ]] || \
+     [[ "$FILE_PATH" == */router.go ]]; then
+    exit 0
+  fi
+
+  TEST_FILE="${FILE_PATH%.go}_test.go"
+  if [ ! -f "$TEST_FILE" ]; then
+    cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"WARNING: Created ${FILE_PATH} but no test file exists at ${TEST_FILE}. Every new .go file needs a corresponding _test.go file."}}
+EOF
+  fi
+  exit 0
+fi
+
+# --- React/TypeScript component files ---
+if [[ "$FILE_PATH" == *.tsx ]] && [[ "$FILE_PATH" != *.test.tsx ]]; then
+  # Skip API routes and pages — only components need snapshot tests
+  if [[ "$FILE_PATH" == */pages/api/* ]] || \
+     [[ "$FILE_PATH" == */pages/* && "$FILE_PATH" != */packages/* ]]; then
+    exit 0
+  fi
+
+  DIR=$(dirname "$FILE_PATH")
+  BASENAME=$(basename "$FILE_PATH" .tsx)
+  TEST_FILE="${DIR}/__tests__/${BASENAME}.test.tsx"
+
+  if [ ! -f "$TEST_FILE" ]; then
+    cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"WARNING: Created ${FILE_PATH} but no snapshot test exists at ${TEST_FILE}. Every new component needs a snapshot test."}}
+EOF
+  fi
+  exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,37 @@
 {
+    "model": "opusplan",
     "enabledPlugins": {
         "typescript-lsp@claude-plugins-official": true,
         "security-guidance@claude-plugins-official": true,
         "frontend-design@claude-plugins-official": true
     },
-    "permissions": {}
+    "permissions": {
+        "defaultMode": "plan"
+    },
+    "hooks": {
+        "PostToolUse": [
+            {
+                "matcher": "Write",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-test-files.sh",
+                        "timeout": 10
+                    }
+                ]
+            }
+        ],
+        "SubagentStop": [
+            {
+                "matcher": "backend-dev|frontend-dev",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/review-agent-output.sh",
+                        "timeout": 10
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/context.md
+++ b/context.md
@@ -4,8 +4,6 @@
 
 A full-stack web application for managing EVE Online player inventory and assets. Built with Go backend, Next.js frontend, and PostgreSQL database. Integrates with EVE Online ESI (EVE Swagger Interface) API for real-time game data.
 
-**Purpose**: Track and manage EVE Online characters, corporations, and their assets across multiple locations.
-
 ---
 
 ## Architecture
@@ -68,9 +66,7 @@ industry-tool/
 
 ---
 
-## Database Schema
-
-### Core Tables
+## Core Database Tables
 
 **Users & Authentication**
 - `users` - User accounts (id, name)
@@ -80,49 +76,8 @@ industry-tool/
 
 **Assets**
 - `character_assets` - Individual character assets
-- `character_asset_location_names` - Named container locations
 - `corporation_assets` - Corporate assets
-- `corporation_asset_location_names` - Named corp locations
-
-**EVE Universe (Static Data — populated from CCP SDE)**
-- `asset_item_types` - Item definitions (type_id, name, volume, group_id, mass, published, market_group_id, etc.)
-- `regions` - EVE regions
-- `constellations` - EVE constellations
-- `solar_systems` - EVE solar systems
-- `stations` - NPC stations (names come from seed data; SDE has no station names)
-
-**SDE Reference Data** (see `docs/features/sde-import.md` for full schema)
-- `sde_categories`, `sde_groups` - Item taxonomy (category → group → type)
-- `sde_market_groups` - Market browser hierarchy (self-referencing parent_group_id)
-- `sde_meta_groups` - Tech level classification (Tech I, Tech II, Faction, etc.)
-- `sde_icons`, `sde_graphics` - Visual asset references
-
-**SDE Blueprints & Industry**
-- `sde_blueprints` - Blueprint definitions (max_production_limit)
-- `sde_blueprint_activities` - Activity types per blueprint (manufacturing, reaction, invention, copying, etc.) with time
-- `sde_blueprint_materials` - Input materials per activity (blueprint + activity + type_id → quantity)
-- `sde_blueprint_products` - Output products per activity (includes probability for invention)
-- `sde_blueprint_skills` - Required skills per activity
-- `industry_cost_indices` - Per-system cost indices by activity (refreshed hourly from ESI)
-
-**SDE Dogma (Item Attributes & Effects)**
-- `sde_dogma_attributes`, `sde_dogma_attribute_categories` - Attribute definitions
-- `sde_dogma_effects` - Effect definitions
-- `sde_type_dogma_attributes` - Per-type attribute values (type_id + attribute_id → value)
-- `sde_type_dogma_effects` - Per-type effects
-
-**SDE NPC & Lore**
-- `sde_factions`, `sde_npc_corporations`, `sde_races`, `sde_bloodlines`, `sde_ancestries`
-- `sde_agents`, `sde_agents_in_space`
-
-**SDE Industry (PI & POS)**
-- `sde_planet_schematics`, `sde_planet_schematic_types` - Planetary interaction recipes
-- `sde_control_tower_resources` - POS fuel requirements
-
-**SDE Misc**
-- `sde_skins`, `sde_skin_licenses`, `sde_skin_materials` - Ship customization
-- `sde_certificates` - Certificate definitions
-- `sde_metadata` - Tracks SDE checksum for freshness detection
+- `asset_item_types` - Item definitions (type_id, name, volume, group_id)
 
 **Key Relationships**
 ```
@@ -130,256 +85,9 @@ users (1) ←→ (N) characters
 users (1) ←→ (N) player_corporations
 characters (1) ←→ (N) character_assets
 player_corporations (1) ←→ (N) corporation_assets
-player_corporations (1) ←→ (N) corporation_divisions
-
-sde_categories (1) ←→ (N) sde_groups (1) ←→ (N) asset_item_types
-sde_blueprints (1) ←→ (N) sde_blueprint_activities (1) ←→ (N) sde_blueprint_materials
-                                                    (1) ←→ (N) sde_blueprint_products
-                                                    (1) ←→ (N) sde_blueprint_skills
-asset_item_types (1) ←→ (N) sde_type_dogma_attributes
-asset_item_types (1) ←→ (N) sde_type_dogma_effects
 ```
 
----
-
-## API Endpoints
-
-### Backend REST API (Port 8081)
-
-**Characters**
-- `GET /v1/characters/` - List user's characters
-- `POST /v1/characters/` - Add character
-- `GET /v1/characters/{id}` - Get character details
-
-**Corporations**
-- `GET /v1/corporations` - List user's corporations
-- `POST /v1/corporations` - Add corporation
-
-**Assets**
-- `GET /v1/assets/` - Get aggregated assets by location
-
-**Utilities**
-- `GET /v1/users/refreshAssets` - Refresh from ESI
-- `GET /v1/static/update` - Trigger SDE refresh
-
-**Authentication Headers**
-- `BACKEND-KEY` - Backend auth key (required)
-- `USER-ID` - User identifier (for user-scoped endpoints)
-
-### Frontend API Routes
-
-- `/api/auth/[...nextauth]` - NextAuth EVE OAuth
-- `/api/characters/add` - Initiate character OAuth flow
-- `/api/characters/refreshAssets` - Trigger asset refresh
-- `/api/corporations/add` - Initiate corp OAuth flow
-- `/api/corporations/refreshAssets` - Trigger corp refresh
-- `/api/assets/get` - Fetch user assets
-- `/api/static/update` - Trigger SDE refresh
-
----
-
-## Authentication Flow
-
-### User Login (EVE Online OAuth)
-1. User clicks "Sign In" → Redirected to EVE Online OAuth
-2. User authorizes → Callback with OAuth token
-3. NextAuth extracts `providerAccountId` (EVE character ID)
-4. Backend checks if user exists via `/v1/users/{id}`
-5. Creates user if new, otherwise loads existing
-6. Session created with `providerAccountId` in JWT
-
-### Adding Characters/Corporations
-1. User initiates add flow → `/api/characters/add` or `/api/corporations/add`
-2. Redirected to EVE OAuth with specific scopes
-3. Callback receives access/refresh tokens
-4. Tokens stored in database with expiry
-5. Backend can now call ESI on behalf of character/corp
-
-### Backend Authentication
-- `BACKEND-KEY` header validates all requests
-- `USER-ID` header identifies user for scoped operations
-- Two middleware levels: `AuthAccessBackend`, `AuthAccessUser`
-
----
-
-## ESI Integration
-
-**EVE Swagger Interface Client** (`internal/client/esiClient.go`)
-
-### Authenticated Methods (require OAuth tokens)
-- `GetCharacterAssets()` - Fetch character assets
-- `GetCharacterAssetNames()` - Get container names
-- `GetCorporationAssets()` - Fetch corp assets
-- `GetCorporationAssetNames()` - Get corp container names
-- `GetCorporationDivisions()` - Get hangar/wallet divisions
-
-### Public Methods (no auth required)
-- `GetCcpMarketPrices()` - CCP adjusted/average prices per type (for industry job cost calculations)
-- `GetIndustryCostIndices()` - Per-system cost indices by activity (manufacturing, reaction, etc.)
-
-### OAuth Token Management
-- Tokens stored per character/corporation
-- Auto-refresh when expired (using refresh token)
-- ESI rate limiting handled
-
-### Location Flags
-- `Hangar` - Personal hangar
-- `OfficeFolder` - Corporation office
-- `CorpSAG1-7` - Corporation hangar divisions
-- `Deliveries` - Items in transit
-- `AssetSafety` - Items in asset safety
-
----
-
-## SDE (Static Data Export) Integration
-
-**SDE Client** (`internal/client/sdeClient.go`) — Downloads and parses CCP's official EVE static data.
-
-### Methods
-- `GetChecksum(ctx)` - Fetch build number from CCP (for freshness check)
-- `DownloadSDE(ctx)` - Download `sde.zip` (~84MB) to temp file
-- `ParseSDE(zipPath)` - Parse all YAML files from ZIP into `SdeData` struct
-
-### Data Refresh (Background Runners)
-| Runner | Interval | Source | Description |
-|--------|----------|--------|-------------|
-| SDE Runner | 24h | CCP SDE ZIP | Full static data refresh (types, blueprints, dogma, universe, etc.) |
-| CCP Prices Runner | 1h | ESI `/markets/prices/` | Adjusted prices for job cost calculations |
-| Cost Indices Runner | 1h | ESI `/industry/systems/` | Per-system manufacturing/reaction cost indices |
-
-All runners execute immediately on startup, then repeat at their interval. The SDE runner skips if the checksum hasn't changed.
-
-### SDE Update Flow
-1. Fetch checksum from CCP → compare with `sde_metadata["checksum"]`
-2. If unchanged → skip (already current)
-3. Download ZIP → parse all YAML files → `SdeData` struct
-4. Upsert to existing tables: `asset_item_types`, `regions`, `constellations`, `solar_systems`, `stations`
-5. Upsert to all `sde_*` tables
-6. Store new checksum in `sde_metadata`
-
-### Gotchas
-- `npcStations.yaml` has **no station names** — station upsert preserves existing names when SDE provides empty ones
-- Some YAML fields use mixed formats (plain string vs localized `{en: "...", de: "..."}` maps) — handled by `localizedString` custom unmarshaler
-- Blueprint activities include: `manufacturing`, `reaction`, `invention`, `copying`, `researching_material_efficiency`, `researching_time_efficiency`
-
----
-
-## Frontend Architecture
-
-### Routing
-- **App Router**: `/app/` (layout, home page)
-- **Pages Router**: `/pages/` (characters, inventory, API routes)
-- Hybrid approach during migration
-
-### Components Structure
-
-**Packages** (`/packages/components/`)
-- `ThemeRegistry.tsx` - MUI theme provider
-- `Navbar.tsx` - Top navigation bar
-- `Loading.tsx` - Loading state indicator
-- `Unauthorized.tsx` - Auth required page
-- `characters/` - Character-specific components
-  - `item.tsx` - Character card
-  - `list.tsx` - Character grid layout
-
-### State Management
-- Server-side props via `getServerSideProps`
-- NextAuth session state via `useSession` hook
-- No global client state (using server props)
-
-### Styling
-- MUI theme: Dark mode (#0a0e1a background, #3b82f6 primary)
-- Responsive grid layouts
-- Emotion for CSS-in-JS
-- Custom formatting utilities in `packages/utils/formatting.ts`
-
----
-
-## Data Flow
-
-### Asset Refresh Flow
-```
-1. User → /api/characters/refreshAssets
-2. Frontend → Backend /v1/users/refreshAssets
-3. Backend → ESI API (per character/corp)
-4. ESI returns assets → Backend stores in DB
-5. Backend aggregates by location → Returns response
-```
-
-### Asset Aggregation
-Assets organized by location with nested structure:
-```typescript
-{
-  structures: [
-    {
-      id: station_id,
-      name: "Jita IV - Moon 4 - Caldari Navy Assembly Plant",
-      solarSystem: "Jita",
-      region: "The Forge",
-      hangarAssets: [...],        // Character items
-      hangarContainers: [...],    // Character containers
-      corporationHangers: [       // Corp divisions
-        {
-          id: 1,
-          name: "Corp Hangar",
-          assets: [...],
-          hangarContainers: [...]
-        }
-      ]
-    }
-  ]
-}
-```
-
----
-
-## Code Pattern Examples
-
-### Repository Pattern
-```go
-type CharacterAssets struct {
-    db *sql.DB
-}
-
-func NewCharacterAssets(db *sql.DB) *CharacterAssets {
-    return &CharacterAssets{db: db}
-}
-
-func (r *CharacterAssets) UpdateAssets(ctx context.Context, characterID, userID int64, assets []*models.EveAsset) error {
-    tx, err := r.db.BeginTx(ctx, nil)
-    if err != nil {
-        return errors.Wrap(err, "failed to begin transaction")
-    }
-    defer tx.Rollback()
-    // ...
-    return tx.Commit()
-}
-```
-
-### Frontend Components
-```typescript
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getSession(context);
-  if (!session) {
-    return { props: {} };
-  }
-  const api = client(process.env.BACKEND_URL, session.providerAccountId);
-  const response = await api.getCharacters();
-  return { props: { characters: response.data } };
-};
-
-export default function Page(props: PageProps) {
-  const { data: session, status } = useSession();
-  if (status === "loading") return <Loading />;
-  if (status !== "authenticated") return <Unauthorized />;
-  return <List items={props.items} />;
-}
-```
-
-### Error Handling
-- Backend: Wrap errors with `github.com/pkg/errors`
-- Frontend: Return error kinds (`success`, `error`, `not-found`)
-- HTTP: Standard status codes (200, 401, 404, 500)
+For feature-specific tables, see the relevant feature doc below.
 
 ---
 
@@ -407,32 +115,67 @@ NEXTAUTH_URL=http://localhost:3000
 
 ---
 
-## Key Constraints & Design Decisions
-
-1. **Corporation Assets**: Filtered by `OfficeFolder` location flag to identify corp offices
-2. **Division Extraction**: `CorpSAG{N}` → Division number from substring position 8
-3. **Asset Organization**: By station/structure, then by type (hangar, container, corp division)
-4. **Token Storage**: ESI OAuth tokens stored per character/corporation with auto-refresh
-5. **Monorepo**: Frontend uses Yarn workspaces for shared packages
-6. **Authentication**: Two-level (backend key + user ID) for security
-7. **Static Data**: Auto-refreshed from CCP SDE (24h) and ESI public endpoints (1h)
-
----
-
 ## External Resources
 
 - **EVE Online ESI**: https://esi.evetech.net/
 - **EVE Image Server**: https://image.eveonline.com/
-- **CCP SDE**: https://developers.eveonline.com/static-data/
-- **Next.js Docs**: https://nextjs.org/docs
-- **MUI Docs**: https://mui.com/material-ui/
-
----
-
-## Notes
-
 - **EVE Character Images**: `https://image.eveonline.com/Character/{id}_128.jpg`
 - **Corporation Logos**: `https://images.evetech.net/corporations/{id}/logo`
 - **Item Icons**: `https://images.evetech.net/types/{type_id}/icon`
-- **Test Data**: See E2E test users in `docs/features/e2e-testing.md`; Jita station ID: 60003760
-- **Division Types**: `hangar` and `wallet` stored separately in `corporation_divisions`
+- **CCP SDE**: https://developers.eveonline.com/static-data/
+
+---
+
+## Feature Index
+
+Read the relevant doc before working on a feature. Each doc contains schema, API endpoints, key decisions, and file paths.
+
+### Core Systems
+| Feature | Doc | Summary |
+|---------|-----|---------|
+| Characters | `docs/features/characters.md` | ESI OAuth, token storage, character asset refresh |
+| Corporations | `docs/features/corporations.md` | Corp management, divisions, corp asset refresh |
+| SDE Import | `docs/features/sde-import.md` | Static data pipeline, all `sde_*` tables, background runners |
+| Authentication | `docs/features/consolidate-oauth.md` | OAuth consolidation, scopes, single callback |
+| Background Updates | `docs/features/background-asset-updates.md` | Asset refresh runners (1h), concurrency |
+| NPC Station Names | `docs/features/npc-station-names.md` | Station name resolution via ESI bulk endpoint |
+| Landing Page | `docs/features/landing-page.md` | Hero section, asset value metrics |
+
+### Market & Pricing
+| Feature | Doc | Summary |
+|---------|-----|---------|
+| Jita Market Pricing | `docs/features/jita-market-pricing.md` | Market orders, asset valuation |
+| Stockpile Markers | `docs/features/stockpile-markers.md` | Stockpile targets, deficit tracking, inventory UI |
+| Stockpile Multibuy | `docs/features/stockpile-multibuy.md` | Shopping lists, delta calculation, bulk ops |
+
+### Social & Marketplace
+| Feature | Doc | Summary |
+|---------|-----|---------|
+| Contact Marketplace | `docs/features/contact-marketplace.md` | Contacts, permissions, for-sale marketplace |
+| Contact Rules | `docs/features/contact-rules.md` | Auto-create contacts, cascade cleanup |
+| Discord Notifications | `docs/features/discord-notifications.md` | Discord bot, OAuth linking, event notifications |
+
+### Purchase & Trade
+| Feature | Doc | Summary |
+|---------|-----|---------|
+| Purchases | `docs/features/purchases/` | Purchase transactions, contract workflow |
+| Buy Orders | `docs/features/buy-orders/` | Demand tracking, seller demand endpoints |
+| Auto-Sell Containers | `docs/features/auto-sell-containers.md` | Auto-sell config, Jita pricing, for-sale sync |
+| Auto-Buy | `docs/features/auto-buy.md` | Auto-buy config, buy order management |
+| Auto-Fulfill | `docs/features/auto-fulfill.md` | Match buy orders to for-sale listings |
+| Contract Sync | `docs/features/contract-sync.md` | ESI contract polling, auto-complete |
+| Contract Notifications | `docs/features/contract-created-notification.md` | Discord alerts on contract creation |
+
+### Industry
+| Feature | Doc | Summary |
+|---------|-----|---------|
+| Industry Job Manager | `docs/features/industry-job-manager/` | Skills sync, job tracking, manufacturing calc, job queue |
+| Reactions Calculator | `docs/features/reactions-calculator.md` | Moon reactions, batch ME, shopping list |
+| Planetary Industry | `docs/features/planetary-industry.md` | PI data, stall detection, profit calc |
+| Transportation | `docs/features/transportation.md` | Transport profiles, JF routes, cost calc |
+
+### Infrastructure
+| Feature | Doc | Summary |
+|---------|-----|---------|
+| E2E Testing | `docs/features/e2e-testing.md` | Mock ESI, Playwright, test users |
+| Railway Deployment | `docs/features/railway-deployment.md` | PostgreSQL, backend, frontend deployment |


### PR DESCRIPTION
## Summary
- Configures `opusplan` model routing: Opus for planning, Sonnet for execution, Haiku for command/web agents
- Adds `backend-dev` and `frontend-dev` domain agents with project-specific conventions, enforced via Critical Rule 10
- Adds `PostToolUse` hook that validates test files exist when `.go`/`.tsx` files are written
- Adds `SubagentStop` hook that reviews agent output and flags improvement opportunities
- Trims `CLAUDE.md` from 149→76 lines and `context.md` from 358→160 lines by moving domain rules into agents and replacing feature sections with a Feature Index
- Adds self-improving agent loop: main thread reviews agent output and updates agent instructions

## Files changed
- `.claude/settings.json` — opusplan model, plan default mode, hooks
- `.claude/agents/backend-dev.md` — Go/SQL domain agent (Sonnet)
- `.claude/agents/frontend-dev.md` — React/MUI domain agent (Sonnet)
- `.claude/hooks/validate-test-files.sh` — PostToolUse test file checker
- `.claude/hooks/review-agent-output.sh` — SubagentStop agent reviewer
- `CLAUDE.md` — Trimmed, added Rule 10 + Agent Improvement section
- `context.md` — Trimmed, added Feature Index

## Test plan
- [ ] Verify `opusplan` uses Opus in plan mode and Sonnet for execution
- [ ] Verify backend-dev agent spawns for Go tasks
- [ ] Verify frontend-dev agent spawns for React tasks
- [ ] Verify PostToolUse hook warns when test files are missing
- [ ] Verify SubagentStop hook flags agent issues
- [ ] Verify Feature Index links point to correct docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)