### PR TITLE
Add auto-production: stockpile-driven production plan runs

### DIFF
--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -31,6 +31,15 @@ You are a frontend specialist for this EVE Online industry tool. The frontend is
 - Define TypeScript interfaces in the component file
 - Read existing components before creating similar ones
 
+### Paired Create/Edit Dialogs — IMPORTANT
+
+Some entities have **separate** create and edit dialogs in different files. When adding or modifying fields on one dialog, always search for the other and update both.
+
+Known pairs:
+- **Stockpile markers**: `AddStockpileDialog.tsx` (create new) + inline edit dialog in `AssetsList.tsx` (edit existing, search for "Stockpile Marker" in DialogTitle)
+
+When asked to add fields to a dialog, **grep for the entity name** (e.g., "Stockpile Marker") across all `.tsx` files to find all dialogs that manage it.
+
 ### Pages
 
 - Use `getServerSideProps` for data fetching

--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -238,6 +238,23 @@ var rootCmd = &cobra.Command{
 			return blueprintsRunner.Run(ctx)
 		})
 
+		// Start auto-production runner (configurable, default 30m)
+		autoProductionUpdater := updaters.NewAutoProductionUpdater(
+			stockpileMarkersRepository,
+			assetsRepository,
+			productionPlansRepository,
+			planRunsRepository,
+			marketPricesRepository,
+			jobQueueRepository,
+			charactersRepository,
+			characterSkillsRepository,
+			sdeDataRepository,
+		)
+		autoProductionRunner := runners.NewAutoProductionRunner(autoProductionUpdater, time.Duration(settings.AutoProductionIntervalSec)*time.Second)
+		group.Go(func() error {
+			return autoProductionRunner.Run(ctx)
+		})
+
 		log.Info("services started")
 
 		eventChan := make(chan os.Signal, 1)

--- a/cmd/industry-tool/cmd/settings.go
+++ b/cmd/industry-tool/cmd/settings.go
@@ -25,6 +25,7 @@ type Settings struct {
 	SkillsUpdateIntervalSec          int
 	IndustryJobsUpdateIntervalSec    int
 	BlueprintsUpdateIntervalSec      int
+	AutoProductionIntervalSec        int
 }
 
 func GetSettings() (*Settings, error) {
@@ -110,6 +111,15 @@ func GetSettings() (*Settings, error) {
 		}
 	} else {
 		settings.BlueprintsUpdateIntervalSec = 3600 // 1 hour
+	}
+
+	if s := os.Getenv("AUTO_PRODUCTION_INTERVAL_SEC"); s != "" {
+		settings.AutoProductionIntervalSec, err = strconv.Atoi(s)
+		if err != nil {
+			return nil, errors.Wrapf(err, "AUTO_PRODUCTION_INTERVAL_SEC '%s' is not a number", s)
+		}
+	} else {
+		settings.AutoProductionIntervalSec = 1800 // 30 minutes
 	}
 
 	return settings, nil

--- a/docs/features/auto-production.md
+++ b/docs/features/auto-production.md
@@ -1,0 +1,97 @@
+# Auto-Production for Stockpile Deficits
+
+## Overview
+
+Auto-Production links stockpile markers to production plans so a background runner automatically generates production plan runs to fill stockpile deficits. When a stockpile item falls below its desired quantity, the runner calculates the net deficit (gross deficit minus pending/active production output) and generates plan runs to cover it.
+
+## Status
+
+- **Phase**: Implementation
+- **Branch**: `feature/auto-production`
+
+## Key Decisions
+
+1. **Net deficit dedup prevents over-production** — Before generating runs, the runner subtracts pending/active job output for the linked plan so already-in-progress production is not double-counted.
+2. **Runner does NOT run on startup** — Waits for the first tick so asset and price data is populated before any plan runs are generated.
+3. **Auto-buy exclusion at SQL level** — Markers with `auto_production_enabled = TRUE` are excluded from `GetStockpileDeficitsForConfig` to prevent double-sourcing the same deficit via both auto-buy and auto-production.
+4. **Service extraction pattern** — Shared job generation logic lives in `internal/services/jobGeneration.go` to avoid circular dependencies between the updater and controller packages.
+5. **Grouping by (userID, planID)** — Markers sharing the same user and plan are grouped; deficits are summed and `MAX(parallelism)` is used for character slot assignment.
+6. **Cooldown guard** — The runner skips a plan if it was triggered within the current runner interval to prevent rapid re-queuing.
+7. **ON DELETE SET NULL** — If a production plan is deleted, `plan_id` goes to NULL on all linked markers; no orphan references, auto-production silently disables itself.
+
+## Schema
+
+### `stockpile_markers` (MODIFIED)
+
+Three new columns added via migration `20260225205355_auto_production`:
+
+```sql
+ALTER TABLE stockpile_markers ADD COLUMN plan_id BIGINT REFERENCES production_plans(id) ON DELETE SET NULL;
+ALTER TABLE stockpile_markers ADD COLUMN auto_production_parallelism INT DEFAULT 0;
+ALTER TABLE stockpile_markers ADD COLUMN auto_production_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE INDEX idx_stockpile_markers_auto_production ON stockpile_markers(user_id) WHERE auto_production_enabled = TRUE;
+```
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `plan_id` | BIGINT (nullable) | Foreign key to the linked production plan |
+| `auto_production_parallelism` | INT | Max parallel character slots for job assignment (0 = unlimited) |
+| `auto_production_enabled` | BOOLEAN | Whether auto-production is active for this marker |
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/industry/plans/by-product/{typeId}` | Returns production plans for a given product type (used by frontend plan selector) |
+| POST | `/v1/stockpiles` | Existing upsert endpoint — now accepts `planId`, `autoProductionParallelism`, `autoProductionEnabled` fields |
+
+## Runner Logic
+
+1. Query all stockpile markers where `auto_production_enabled = TRUE`
+2. Group markers by `(user_id, plan_id)`
+3. For each group:
+   a. Sum gross deficits across all markers in the group
+   b. Query `GetPendingOutputForPlan` — subtract in-progress production output
+   c. Skip if net deficit <= 0
+   d. Skip if last auto-production for this plan was within the runner interval (cooldown)
+   e. Call job generation service with net deficit and `MAX(parallelism)` from the group
+4. Runner interval is configurable via `AUTO_PRODUCTION_INTERVAL_SEC` (default 1800 = 30 minutes)
+
+## Safety Mechanisms
+
+1. **Net deficit dedup** — Always subtract pending/active output before generating runs
+2. **Cooldown** — Skip if last auto-production for this plan was within the runner interval
+3. **No startup run** — Runner waits for first tick (assets and prices must be populated first)
+4. **Enabled flag** — Users can disable per-marker without unlinking the plan
+5. **ON DELETE SET NULL** — If a plan is deleted, `plan_id` goes to NULL; no orphan references
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTO_PRODUCTION_INTERVAL_SEC` | `1800` | Runner interval in seconds (30 minutes) |
+
+## File Structure
+
+### Backend
+
+- `internal/database/migrations/20260225205355_auto_production.up.sql` — Schema migration (add columns + index)
+- `internal/database/migrations/20260225205355_auto_production.down.sql` — Rollback migration
+- `internal/models/models.go` — `StockpileMarker` struct with 3 new fields (`PlanID`, `AutoProductionParallelism`, `AutoProductionEnabled`)
+- `internal/repositories/stockpileMarkers.go` — `GetAutoProductionMarkers` method
+- `internal/repositories/planRuns.go` — `GetPendingOutputForPlan` method
+- `internal/repositories/productionPlans.go` — `GetByProductTypeAndUser` method
+- `internal/repositories/autoBuyConfigs.go` — `auto_production_enabled` filter in `GetStockpileDeficitsForConfig`
+- `internal/services/jobGeneration.go` — Extracted shared job generation logic
+- `internal/updaters/autoProduction.go` — Core deficit-to-runs logic
+- `internal/runners/autoProduction.go` — Background tick runner
+- `internal/controllers/productionPlans.go` — `GetPlansByProduct` handler
+- `cmd/industry-tool/cmd/settings.go` — `AutoProductionIntervalSec` setting
+- `cmd/industry-tool/cmd/root.go` — Runner and service wiring
+
+### Frontend
+
+- `frontend/packages/client/data/models.ts` — `StockpileMarker` type with 3 new fields (`planId`, `autoProductionParallelism`, `autoProductionEnabled`)
+- `frontend/pages/api/industry/plans/by-product/[typeId].ts` — API proxy route for plan selector
+- `frontend/packages/components/assets/AddStockpileDialog.tsx` — Auto-production toggle, plan selector dropdown, parallelism input
+- `frontend/packages/components/stockpiles/StockpilesList.tsx` — Auto-production status column

--- a/frontend/packages/client/data/models.ts
+++ b/frontend/packages/client/data/models.ts
@@ -67,6 +67,9 @@ export type StockpileMarker = {
   divisionNumber?: number;
   desiredQuantity: number;
   notes?: string;
+  planId?: number;
+  autoProductionParallelism?: number;
+  autoProductionEnabled?: boolean;
 };
 
 // Item Type Search Result (Go struct has no json tags -> PascalCase)

--- a/frontend/packages/components/stockpiles/StockpilesList.tsx
+++ b/frontend/packages/components/stockpiles/StockpilesList.tsx
@@ -40,6 +40,10 @@ export type StockpileItem = {
   solarSystem: string;
   region: string;
   containerName?: string;
+  planId?: number;
+  planName?: string;
+  autoProductionEnabled?: boolean;
+  autoProductionParallelism?: number;
 };
 
 export type StockpilesResponse = {
@@ -316,6 +320,7 @@ export default function StockpilesList() {
                       <TableCell align="right">Target</TableCell>
                       <TableCell align="right">Deficit</TableCell>
                       <TableCell align="right">Cost (ISK)</TableCell>
+                      <TableCell>Auto-Production</TableCell>
                       <TableCell>Owner</TableCell>
                     </TableRow>
                   </TableHead>
@@ -346,6 +351,15 @@ export default function StockpilesList() {
                           <Typography variant="body2" sx={{ color: 'error.main', fontWeight: 600 }}>
                             {item.deficitValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}
                           </Typography>
+                        </TableCell>
+                        <TableCell>
+                          {item.autoProductionEnabled ? (
+                            <Typography variant="body2" sx={{ color: 'success.main', fontWeight: 600 }}>
+                              {item.planName || 'Linked'}
+                            </Typography>
+                          ) : (
+                            <Typography variant="body2" color="text.secondary">—</Typography>
+                          )}
                         </TableCell>
                         <TableCell>{item.ownerName}</TableCell>
                       </TableRow>

--- a/frontend/pages/api/industry/plans/by-product/[typeId].ts
+++ b/frontend/pages/api/industry/plans/by-product/[typeId].ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../auth/[...nextauth]";
+
+const backend = process.env.BACKEND_URL as string;
+const backendKey = process.env.BACKEND_KEY as string;
+
+const getHeaders = (id: string) => ({
+  "Content-Type": "application/json",
+  "USER-ID": id,
+  "BACKEND-KEY": backendKey,
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { typeId } = req.query;
+
+  try {
+    const response = await fetch(`${backend}v1/industry/plans/by-product/${typeId}`, {
+      method: "GET",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: errorText });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error("Plans by product API error:", error);
+    return res.status(500).json({ error: "Failed to fetch plans by product" });
+  }
+}

--- a/internal/controllers/productionPlans.go
+++ b/internal/controllers/productionPlans.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
-	"sort"
-	"strings"
 
 	"github.com/annymsMthd/industry-tool/internal/calculator"
 	"github.com/annymsMthd/industry-tool/internal/models"
 	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/services"
 	"github.com/annymsMthd/industry-tool/internal/web"
 	"github.com/pkg/errors"
 )
@@ -27,6 +25,7 @@ type ProductionPlansRepository interface {
 	DeleteStep(ctx context.Context, stepID, planID, userID int64) error
 	GetStepMaterials(ctx context.Context, stepID, planID, userID int64) ([]*models.PlanMaterial, error)
 	GetContainersAtStation(ctx context.Context, userID, stationID int64) ([]*models.StationContainer, error)
+	GetByProductTypeAndUser(ctx context.Context, productTypeID, userID int64) ([]*models.ProductionPlan, error)
 }
 
 type ProductionPlansCharacterRepository interface {
@@ -151,6 +150,7 @@ func NewProductionPlans(
 	router.RegisterRestAPIRoute("/v1/industry/plans/hangars", web.AuthAccessUser, c.GetHangars, "GET")
 	router.RegisterRestAPIRoute("/v1/industry/plans/runs", web.AuthAccessUser, c.GetAllRuns, "GET")
 	router.RegisterRestAPIRoute("/v1/industry/plans/runs/{runId}/cancel", web.AuthAccessUser, c.CancelPlanRun, "POST")
+	router.RegisterRestAPIRoute("/v1/industry/plans/by-product/{typeId}", web.AuthAccessUser, c.GetPlansByProduct, "GET")
 	router.RegisterRestAPIRoute("/v1/industry/plans/{id}", web.AuthAccessUser, c.GetPlan, "GET")
 	router.RegisterRestAPIRoute("/v1/industry/plans/{id}", web.AuthAccessUser, c.UpdatePlan, "PUT")
 	router.RegisterRestAPIRoute("/v1/industry/plans/{id}", web.AuthAccessUser, c.DeletePlan, "DELETE")
@@ -174,6 +174,21 @@ func (c *ProductionPlans) GetPlans(args *web.HandlerArgs) (any, *web.HttpError) 
 	if err != nil {
 		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get production plans")}
 	}
+	return plans, nil
+}
+
+// GetPlansByProduct returns production plans that produce a specific item type.
+func (c *ProductionPlans) GetPlansByProduct(args *web.HandlerArgs) (any, *web.HttpError) {
+	typeID, err := parseID(args.Params["typeId"])
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid type ID")}
+	}
+
+	plans, err := c.plansRepo.GetByProductTypeAndUser(args.Request.Context(), typeID, *args.User)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get plans by product type")}
+	}
+
 	return plans, nil
 }
 
@@ -707,298 +722,6 @@ type generateJobsRequest struct {
 	Parallelism int `json:"parallelism"`
 }
 
-type stepProductionData struct {
-	productTypeID int64
-	productName   string
-	totalQuantity int
-	productVolume float64
-}
-
-// pendingJob is a job ready to be persisted or simulated, with tree metadata.
-type pendingJob struct {
-	entry         *models.IndustryJobQueueEntry
-	blueprintName string
-	productName   string
-	depth         int
-	// Fields for per-character TE recalculation in preview
-	baseBlueprintTime int    // base seconds from SDE blueprint
-	activity          string // "manufacturing" or "reaction"
-	structure         string
-	rig               string
-	security          string
-	blueprintTE       int
-}
-
-// mergeKey identifies jobs that can be merged (same blueprint, settings).
-type mergeKey struct {
-	BlueprintTypeID int64
-	Activity        string
-	MELevel         int
-	TELevel         int
-	FacilityTax     float64
-}
-
-// walkResult is the output of walkAndMergeSteps.
-type walkResult struct {
-	mergedJobs     []*pendingJob
-	stepProduction map[int64]*stepProductionData
-	stepDepths     map[int64]int
-	skipped        []*models.GenerateJobSkipped
-}
-
-// formatLocation builds a human-readable location string from owner/division/container names.
-func formatLocation(ownerName, divisionName, containerName string) string {
-	parts := []string{}
-	if ownerName != "" {
-		parts = append(parts, ownerName)
-	}
-	if divisionName != "" {
-		parts = append(parts, divisionName)
-	}
-	if containerName != "" {
-		parts = append(parts, containerName)
-	}
-	if len(parts) == 0 {
-		return ""
-	}
-	return strings.Join(parts, " > ")
-}
-
-// walkAndMergeSteps walks the production plan tree and returns merged pending jobs.
-// It is shared by GenerateJobs and PreviewPlan.
-func (c *ProductionPlans) walkAndMergeSteps(
-	ctx context.Context,
-	plan *models.ProductionPlan,
-	quantity int,
-	jitaPrices map[int64]*models.MarketPrice,
-	adjustedPrices map[int64]float64,
-) (*walkResult, error) {
-	if len(plan.Steps) == 0 {
-		return nil, errors.New("plan has no steps")
-	}
-
-	// Build step index and find root
-	stepsByID := make(map[int64]*models.ProductionPlanStep)
-	childStepsByParent := make(map[int64][]*models.ProductionPlanStep)
-	var rootStep *models.ProductionPlanStep
-
-	for _, step := range plan.Steps {
-		stepsByID[step.ID] = step
-		if step.ParentStepID == nil {
-			rootStep = step
-		} else {
-			childStepsByParent[*step.ParentStepID] = append(childStepsByParent[*step.ParentStepID], step)
-		}
-	}
-
-	if rootStep == nil {
-		return nil, errors.New("plan has no root step")
-	}
-
-	wr := &walkResult{
-		stepProduction: make(map[int64]*stepProductionData),
-		stepDepths:     make(map[int64]int),
-		skipped:        []*models.GenerateJobSkipped{},
-	}
-
-	pendingJobs := []*pendingJob{}
-
-	// Walk the tree depth-first, collect jobs by depth level
-	var walkStep func(step *models.ProductionPlanStep, qty int, depth int)
-	walkStep = func(step *models.ProductionPlanStep, qty int, depth int) {
-		// Record depth for this step (used by transport ordering)
-		wr.stepDepths[step.ID] = depth
-
-		// Look up blueprint to get product quantity per run (activity-aware)
-		bp, err := c.sdeRepo.GetBlueprintForActivity(ctx, step.BlueprintTypeID, step.Activity)
-		if err != nil || bp == nil {
-			wr.skipped = append(wr.skipped, &models.GenerateJobSkipped{
-				TypeID:   step.ProductTypeID,
-				TypeName: step.ProductName,
-				Reason:   "blueprint data not found",
-			})
-			return
-		}
-
-		// Calculate runs needed
-		runs := int(math.Ceil(float64(qty) / float64(bp.ProductQuantity)))
-		if runs <= 0 {
-			runs = 1
-		}
-
-		// Record production data for transport generation
-		totalProduced := runs * bp.ProductQuantity
-		wr.stepProduction[step.ID] = &stepProductionData{
-			productTypeID: step.ProductTypeID,
-			productName:   bp.ProductName,
-			totalQuantity: totalProduced,
-			productVolume: bp.ProductVolume,
-		}
-
-		// Get materials for this step to calculate child needs
-		materials, err := c.sdeRepo.GetBlueprintMaterialsForActivity(ctx, step.BlueprintTypeID, step.Activity)
-		if err != nil {
-			wr.skipped = append(wr.skipped, &models.GenerateJobSkipped{
-				TypeID:   step.ProductTypeID,
-				TypeName: step.ProductName,
-				Reason:   "failed to get materials",
-			})
-			return
-		}
-
-		// Calculate ME factor for batch quantity calculation
-		meFactor := calculator.ComputeManufacturingME(step.MELevel, step.Structure, step.Rig, step.Security)
-
-		// Process child steps (materials that are produced)
-		children := childStepsByParent[step.ID]
-		childProductTypeIDs := make(map[int64]*models.ProductionPlanStep)
-		for _, child := range children {
-			childProductTypeIDs[child.ProductTypeID] = child
-		}
-
-		for _, mat := range materials {
-			if childStep, ok := childProductTypeIDs[mat.TypeID]; ok {
-				// This material is produced — calculate needed quantity
-				batchQty := calculator.ComputeBatchQty(runs, mat.Quantity, meFactor)
-				walkStep(childStep, int(batchQty), depth+1)
-			}
-		}
-
-		// Calculate cost and duration for manufacturing and reaction steps
-		var estimatedCost *float64
-		var estimatedDuration *int
-
-		if step.Activity == "manufacturing" || step.Activity == "reaction" {
-			params := &calculator.ManufacturingParams{
-				BlueprintME:      step.MELevel,
-				BlueprintTE:      step.TELevel,
-				Runs:             runs,
-				Structure:        step.Structure,
-				Rig:              step.Rig,
-				Security:         step.Security,
-				IndustrySkill:    step.IndustrySkill,
-				AdvIndustrySkill: step.AdvIndustrySkill,
-				FacilityTax:      step.FacilityTax,
-			}
-
-			data := &calculator.ManufacturingData{
-				Blueprint:      bp,
-				Materials:      materials,
-				CostIndex:      0,
-				AdjustedPrices: adjustedPrices,
-				JitaPrices:     jitaPrices,
-			}
-
-			calcResult := calculator.CalculateManufacturingJob(params, data)
-			estimatedCost = &calcResult.TotalCost
-			estimatedDuration = &calcResult.TotalDuration
-
-			// For reaction steps, override the duration using the reactions TE formula.
-			// Reactions use only the Reactions skill (4% per level) with no blueprint TE
-			// and no Advanced Industry skill reduction. step.IndustrySkill holds the
-			// Reactions skill level when activity == "reaction".
-			if step.Activity == "reaction" {
-				reactionTEFactor := calculator.ComputeTEFactor(step.IndustrySkill, step.Structure, step.Rig, step.Security)
-				secsPerRun := calculator.ComputeSecsPerRun(bp.Time, reactionTEFactor)
-				totalDuration := secsPerRun * runs
-				estimatedDuration = &totalDuration
-			}
-		}
-
-		// Build location context from plan step
-		stationName := ""
-		if step.StationName != nil {
-			stationName = *step.StationName
-		}
-		inputLoc := formatLocation(step.SourceOwnerName, step.SourceDivisionName, step.SourceContainerName)
-		outputLoc := formatLocation(step.OutputOwnerName, step.OutputDivisionName, step.OutputContainerName)
-
-		productTypeID := step.ProductTypeID
-		pendingJobs = append(pendingJobs, &pendingJob{
-			entry: &models.IndustryJobQueueEntry{
-				BlueprintTypeID:   step.BlueprintTypeID,
-				Activity:          step.Activity,
-				Runs:              runs,
-				MELevel:           step.MELevel,
-				TELevel:           step.TELevel,
-				FacilityTax:       step.FacilityTax,
-				ProductTypeID:     &productTypeID,
-				EstimatedCost:     estimatedCost,
-				EstimatedDuration: estimatedDuration,
-				SortOrder:         depth * 2,
-				StationName:       stationName,
-				InputLocation:     inputLoc,
-				OutputLocation:    outputLoc,
-			},
-			blueprintName:     step.BlueprintName,
-			productName:       bp.ProductName,
-			depth:             depth,
-			baseBlueprintTime: bp.Time,
-			activity:          step.Activity,
-			structure:         step.Structure,
-			rig:               step.Rig,
-			security:          step.Security,
-			blueprintTE:       step.TELevel,
-		})
-	}
-
-	walkStep(rootStep, quantity, 0)
-
-	// Merge pending jobs with identical blueprint + settings into combined entries
-	merged := make(map[mergeKey]*pendingJob)
-	mergeOrder := []mergeKey{}
-	for _, pj := range pendingJobs {
-		key := mergeKey{
-			BlueprintTypeID: pj.entry.BlueprintTypeID,
-			Activity:        pj.entry.Activity,
-			MELevel:         pj.entry.MELevel,
-			TELevel:         pj.entry.TELevel,
-			FacilityTax:     pj.entry.FacilityTax,
-		}
-		if existing, ok := merged[key]; ok {
-			existing.entry.Runs += pj.entry.Runs
-			if pj.entry.EstimatedCost != nil {
-				if existing.entry.EstimatedCost == nil {
-					cost := *pj.entry.EstimatedCost
-					existing.entry.EstimatedCost = &cost
-				} else {
-					*existing.entry.EstimatedCost += *pj.entry.EstimatedCost
-				}
-			}
-			if pj.entry.EstimatedDuration != nil {
-				if existing.entry.EstimatedDuration == nil {
-					dur := *pj.entry.EstimatedDuration
-					existing.entry.EstimatedDuration = &dur
-				} else {
-					*existing.entry.EstimatedDuration += *pj.entry.EstimatedDuration
-				}
-			}
-			// Keep the deeper depth for ordering
-			if pj.depth > existing.depth {
-				existing.depth = pj.depth
-				existing.entry.SortOrder = pj.entry.SortOrder
-			}
-		} else {
-			merged[key] = pj
-			mergeOrder = append(mergeOrder, key)
-		}
-	}
-
-	// Collect merged jobs preserving insertion order
-	mergedJobs := make([]*pendingJob, 0, len(mergeOrder))
-	for _, key := range mergeOrder {
-		mergedJobs = append(mergedJobs, merged[key])
-	}
-
-	// Sort merged jobs by depth descending (deepest first = leaves before parents)
-	sort.Slice(mergedJobs, func(i, j int) bool {
-		return mergedJobs[i].depth > mergedJobs[j].depth
-	})
-
-	wr.mergedJobs = mergedJobs
-	return wr, nil
-}
-
 // GenerateJobs creates job queue entries from a production plan for a given quantity.
 func (c *ProductionPlans) GenerateJobs(args *web.HandlerArgs) (any, *web.HttpError) {
 	ctx := args.Request.Context()
@@ -1039,7 +762,7 @@ func (c *ProductionPlans) GenerateJobs(args *web.HandlerArgs) (any, *web.HttpErr
 	}
 
 	// Walk the tree and merge jobs
-	wr, err := c.walkAndMergeSteps(ctx, plan, req.Quantity, jitaPrices, adjustedPrices)
+	wr, err := services.WalkAndMergeSteps(ctx, c.sdeRepo, plan, req.Quantity, jitaPrices, adjustedPrices)
 	if err != nil {
 		return nil, &web.HttpError{StatusCode: 400, Error: err}
 	}
@@ -1047,7 +770,7 @@ func (c *ProductionPlans) GenerateJobs(args *web.HandlerArgs) (any, *web.HttpErr
 	// Character assignment (when parallelism >= 1)
 	var characterAssignments map[int64]string
 	var unassignedCount int
-	var assignedJobs []*assignedJob
+	var assignedJobs []*services.AssignedJob
 
 	if req.Parallelism >= 1 {
 		characterNames, err := c.characterRepo.GetNames(ctx, *args.User)
@@ -1082,12 +805,12 @@ func (c *ProductionPlans) GenerateJobs(args *web.HandlerArgs) (any, *web.HttpErr
 
 		capacities := calculator.BuildCharacterCapacities(characterNames, skillsByCharacter, slotUsage)
 
-		assignedJobs, unassignedCount = simulateAssignment(wr.mergedJobs, capacities, req.Parallelism)
+		assignedJobs, unassignedCount = services.SimulateAssignment(wr.MergedJobs, capacities, req.Parallelism)
 
 		characterAssignments = make(map[int64]string)
 		for _, aj := range assignedJobs {
-			if aj.characterID != 0 {
-				characterAssignments[aj.characterID] = characterNames[aj.characterID]
+			if aj.CharacterID != 0 {
+				characterAssignments[aj.CharacterID] = characterNames[aj.CharacterID]
 			}
 		}
 	}
@@ -1105,7 +828,7 @@ func (c *ProductionPlans) GenerateJobs(args *web.HandlerArgs) (any, *web.HttpErr
 	result := &models.GenerateJobsResult{
 		Run:                  run,
 		Created:              []*models.IndustryJobQueueEntry{},
-		Skipped:              wr.skipped,
+		Skipped:              wr.Skipped,
 		TransportJobs:        []*models.TransportJob{},
 		CharacterAssignments: characterAssignments,
 		UnassignedCount:      unassignedCount,
@@ -1124,39 +847,39 @@ func (c *ProductionPlans) GenerateJobs(args *web.HandlerArgs) (any, *web.HttpErr
 	// Determine the list of jobs to persist.
 	// When parallelism >= 1, we use the assigned job fragments (each carrying a
 	// character assignment and a recalculated duration).  Otherwise we fall back
-	// to the merged jobs produced by walkAndMergeSteps.
+	// to the merged jobs produced by WalkAndMergeSteps.
 	note := "Generated from plan: " + plan.Name
 
 	if req.Parallelism >= 1 && len(assignedJobs) > 0 {
 		for _, aj := range assignedJobs {
-			orig := aj.original
-			origEntry := orig.entry
+			orig := aj.Original
+			origEntry := orig.Entry
 
 			// Build the queue entry from the assigned fragment
 			productTypeID := origEntry.ProductTypeID
-			dur := aj.durationSec
+			dur := aj.DurationSec
 
-			// characterID=0 means no eligible character was found; persist the
+			// CharacterID=0 means no eligible character was found; persist the
 			// entry without a character assignment so the job is not silently dropped.
 			var charIDPtr *int64
-			if aj.characterID != 0 {
-				cid := aj.characterID
+			if aj.CharacterID != 0 {
+				cid := aj.CharacterID
 				charIDPtr = &cid
 			}
 
 			var estimatedCost *float64
 			if origEntry.EstimatedCost != nil && origEntry.Runs > 0 {
-				cost := *origEntry.EstimatedCost * float64(aj.runs) / float64(origEntry.Runs)
+				cost := *origEntry.EstimatedCost * float64(aj.Runs) / float64(origEntry.Runs)
 				estimatedCost = &cost
 			}
 
-			entryNote := fmt.Sprintf("%s x%d", orig.productName, aj.runs)
+			entryNote := fmt.Sprintf("%s x%d", orig.ProductName, aj.Runs)
 			newEntry := &models.IndustryJobQueueEntry{
 				UserID:            *args.User,
 				CharacterID:       charIDPtr,
 				BlueprintTypeID:   origEntry.BlueprintTypeID,
-				Activity:          aj.activity,
-				Runs:              aj.runs,
+				Activity:          aj.Activity,
+				Runs:              aj.Runs,
 				MELevel:           origEntry.MELevel,
 				TELevel:           origEntry.TELevel,
 				FacilityTax:       origEntry.FacilityTax,
@@ -1176,42 +899,42 @@ func (c *ProductionPlans) GenerateJobs(args *web.HandlerArgs) (any, *web.HttpErr
 			if err != nil {
 				result.Skipped = append(result.Skipped, &models.GenerateJobSkipped{
 					TypeID:   *origEntry.ProductTypeID,
-					TypeName: orig.productName,
+					TypeName: orig.ProductName,
 					Reason:   "failed to create queue entry: " + err.Error(),
 				})
 				continue
 			}
 
-			created.BlueprintName = orig.blueprintName
-			created.ProductName = orig.productName
+			created.BlueprintName = orig.BlueprintName
+			created.ProductName = orig.ProductName
 			result.Created = append(result.Created, created)
 		}
 	} else {
 		// No assignment — create one entry per merged job (original behaviour)
-		for _, pj := range wr.mergedJobs {
-			pj.entry.UserID = *args.User
-			pj.entry.Notes = &note
-			pj.entry.PlanRunID = &run.ID
+		for _, pj := range wr.MergedJobs {
+			pj.Entry.UserID = *args.User
+			pj.Entry.Notes = &note
+			pj.Entry.PlanRunID = &run.ID
 
-			created, err := c.queueRepo.Create(ctx, pj.entry)
+			created, err := c.queueRepo.Create(ctx, pj.Entry)
 			if err != nil {
 				result.Skipped = append(result.Skipped, &models.GenerateJobSkipped{
-					TypeID:   *pj.entry.ProductTypeID,
-					TypeName: pj.productName,
+					TypeID:   *pj.Entry.ProductTypeID,
+					TypeName: pj.ProductName,
 					Reason:   "failed to create queue entry: " + err.Error(),
 				})
 				continue
 			}
 
-			created.BlueprintName = pj.blueprintName
-			created.ProductName = pj.productName
+			created.BlueprintName = pj.BlueprintName
+			created.ProductName = pj.ProductName
 			result.Created = append(result.Created, created)
 		}
 	}
 
 	// Phase 2: Generate transport jobs if plan has transport settings
 	if plan.TransportFulfillment != nil {
-		c.generateTransportJobs(ctx, plan, stepsByID, childStepsByParent, wr.stepProduction, wr.stepDepths, jitaPrices, run, *args.User, result)
+		c.generateTransportJobs(ctx, plan, stepsByID, childStepsByParent, wr.StepProduction, wr.StepDepths, jitaPrices, run, *args.User, result)
 	}
 
 	return result, nil
@@ -1223,7 +946,7 @@ func (c *ProductionPlans) generateTransportJobs(
 	plan *models.ProductionPlan,
 	stepsByID map[int64]*models.ProductionPlanStep,
 	childStepsByParent map[int64][]*models.ProductionPlanStep,
-	stepProduction map[int64]*stepProductionData,
+	stepProduction map[int64]*services.StepProductionData,
 	stepDepths map[int64]int,
 	jitaPrices map[int64]*models.MarketPrice,
 	run *models.ProductionPlanRun,
@@ -1282,8 +1005,8 @@ func (c *ProductionPlans) generateTransportJobs(
 
 			// Calculate item value from Jita prices
 			estimatedValue := 0.0
-			if p, ok := jitaPrices[prod.productTypeID]; ok && p.SellPrice != nil {
-				estimatedValue = *p.SellPrice * float64(prod.totalQuantity)
+			if p, ok := jitaPrices[prod.ProductTypeID]; ok && p.SellPrice != nil {
+				estimatedValue = *p.SellPrice * float64(prod.TotalQuantity)
 			}
 
 			key := fmt.Sprintf("%d-%d", childStation.StationID, parentStation.StationID)
@@ -1299,9 +1022,9 @@ func (c *ProductionPlans) generateTransportJobs(
 				needsByRoute[key].maxChildDepth = d
 			}
 			needsByRoute[key].items = append(needsByRoute[key].items, &models.TransportJobItem{
-				TypeID:         prod.productTypeID,
-				Quantity:       prod.totalQuantity,
-				VolumeM3:       prod.productVolume * float64(prod.totalQuantity),
+				TypeID:         prod.ProductTypeID,
+				Quantity:       prod.TotalQuantity,
+				VolumeM3:       prod.ProductVolume * float64(prod.TotalQuantity),
 				EstimatedValue: estimatedValue,
 			})
 		}
@@ -1645,7 +1368,7 @@ func (c *ProductionPlans) PreviewPlan(args *web.HandlerArgs) (any, *web.HttpErro
 	}
 
 	// Walk and merge steps
-	wr, err := c.walkAndMergeSteps(ctx, plan, req.Quantity, jitaPrices, adjustedPrices)
+	wr, err := services.WalkAndMergeSteps(ctx, c.sdeRepo, plan, req.Quantity, jitaPrices, adjustedPrices)
 	if err != nil {
 		return nil, &web.HttpError{StatusCode: 400, Error: err}
 	}
@@ -1683,25 +1406,25 @@ func (c *ProductionPlans) PreviewPlan(args *web.HandlerArgs) (any, *web.HttpErro
 	result := &models.PlanPreviewResult{
 		Options:            []*models.PlanPreviewOption{},
 		EligibleCharacters: len(capacities),
-		TotalJobs:          len(wr.mergedJobs),
+		TotalJobs:          len(wr.MergedJobs),
 	}
 
-	if len(capacities) == 0 || len(wr.mergedJobs) == 0 {
+	if len(capacities) == 0 || len(wr.MergedJobs) == 0 {
 		return result, nil
 	}
 
 	// Generate one option per parallelism level
 	for p := 1; p <= len(capacities); p++ {
-		assigned, _ := simulateAssignment(wr.mergedJobs, capacities, p)
-		wallClock := estimateWallClock(assigned, capacities[:p])
+		assigned, _ := services.SimulateAssignment(wr.MergedJobs, capacities, p)
+		wallClock := services.EstimateWallClock(assigned, capacities[:p])
 
 		// Build per-character info
 		charJobCount := make(map[int64]int)
 		charDuration := make(map[int64]int)
 		for _, aj := range assigned {
-			charJobCount[aj.characterID]++
-			if aj.durationSec > charDuration[aj.characterID] {
-				charDuration[aj.characterID] = aj.durationSec
+			charJobCount[aj.CharacterID]++
+			if aj.DurationSec > charDuration[aj.CharacterID] {
+				charDuration[aj.CharacterID] = aj.DurationSec
 			}
 		}
 
@@ -1730,273 +1453,3 @@ func (c *ProductionPlans) PreviewPlan(args *web.HandlerArgs) (any, *web.HttpErro
 	return result, nil
 }
 
-// assignedJob is a single job fragment assigned to a character during simulation.
-type assignedJob struct {
-	original    *pendingJob // reference to the originating merged job
-	activity    string
-	runs        int
-	durationSec int
-	depth       int
-	characterID int64
-}
-
-// simulateAssignment distributes merged jobs across up to parallelism characters.
-// It clones capacity state so the originals are not mutated.
-// Returns the list of assigned job fragments and count of unassigned runs.
-//
-// Jobs with no eligible character are still appended to the returned slice with
-// characterID=0 so they are not silently dropped from queue creation.
-//
-// Slot availability resets at each depth level: children must finish before
-// parents start, so a slot used at depth N is free again at depth N-1.
-func simulateAssignment(
-	mergedJobs []*pendingJob,
-	capacities []*calculator.CharacterCapacity,
-	parallelism int,
-) ([]*assignedJob, int) {
-	if parallelism > len(capacities) {
-		parallelism = len(capacities)
-	}
-	pool := capacities[:parallelism]
-
-	// Record initial available slots (capacity minus already-running ESI jobs).
-	// These are reset whenever the depth level changes.
-	initialMfg := make([]int, parallelism)
-	initialReact := make([]int, parallelism)
-	for i, cap := range pool {
-		initialMfg[i] = calculator.MfgSlotsAvailable(cap)
-		initialReact[i] = calculator.ReactSlotsAvailable(cap)
-	}
-
-	// Working copies reset at each new depth level.
-	mfgAvail := make([]int, parallelism)
-	reactAvail := make([]int, parallelism)
-	copy(mfgAvail, initialMfg)
-	copy(reactAvail, initialReact)
-
-	assigned := []*assignedJob{}
-	unassigned := 0
-	currentDepth := -1
-
-	for _, pj := range mergedJobs {
-		// Jobs are sorted deepest-first. When we move to a shallower depth, the
-		// previous depth's jobs are done and all slots are free again.
-		jobDepth := pj.depth
-		if currentDepth == -1 {
-			currentDepth = jobDepth
-		} else if jobDepth != currentDepth {
-			currentDepth = jobDepth
-			copy(mfgAvail, initialMfg)
-			copy(reactAvail, initialReact)
-		}
-
-		activity := pj.activity
-		if activity == "" {
-			activity = pj.entry.Activity
-		}
-		if activity != "manufacturing" && activity != "reaction" {
-			continue
-		}
-
-		// Collect characters with available slots for this activity
-		type eligibleChar struct {
-			idx int
-			cap *calculator.CharacterCapacity
-		}
-		eligible := []eligibleChar{}
-		for i, cap := range pool {
-			if activity == "manufacturing" && mfgAvail[i] > 0 {
-				eligible = append(eligible, eligibleChar{idx: i, cap: cap})
-			} else if activity == "reaction" && reactAvail[i] > 0 {
-				eligible = append(eligible, eligibleChar{idx: i, cap: cap})
-			}
-		}
-
-		if len(eligible) == 0 {
-			// No slot available — still persist the job so it appears in the queue
-			// without a character assignment (characterID=0 signals unassigned).
-			var dur int
-			if pj.entry.EstimatedDuration != nil {
-				dur = *pj.entry.EstimatedDuration
-			}
-			assigned = append(assigned, &assignedJob{
-				original:    pj,
-				activity:    activity,
-				runs:        pj.entry.Runs,
-				durationSec: dur,
-				depth:       jobDepth,
-				characterID: 0,
-			})
-			unassigned += pj.entry.Runs
-			continue
-		}
-
-		totalRuns := pj.entry.Runs
-		numChars := len(eligible)
-		runsPerChar := int(math.Ceil(float64(totalRuns) / float64(numChars)))
-
-		for j, ec := range eligible {
-			runsForThis := runsPerChar
-			// Last character gets the remainder
-			if j == numChars-1 {
-				runsForThis = totalRuns - runsPerChar*(numChars-1)
-				if runsForThis <= 0 {
-					break
-				}
-			}
-
-			// Recalculate duration with this character's actual skills
-			var durationSec int
-			bpTime := pj.baseBlueprintTime
-			if bpTime <= 0 {
-				// Fall back to stored estimated duration if base time is missing
-				if pj.entry.EstimatedDuration != nil {
-					durationSec = *pj.entry.EstimatedDuration * runsForThis
-					if pj.entry.Runs > 0 {
-						durationSec = (*pj.entry.EstimatedDuration * runsForThis) / pj.entry.Runs
-					}
-				}
-			} else if activity == "manufacturing" {
-				teFactor := calculator.ComputeManufacturingTE(
-					pj.blueprintTE,
-					ec.cap.IndustrySkill,
-					ec.cap.AdvIndustrySkill,
-					pj.structure, pj.rig, pj.security,
-				)
-				secsPerRun := calculator.ComputeSecsPerRun(bpTime, teFactor)
-				durationSec = secsPerRun * runsForThis
-			} else { // reaction
-				teFactor := calculator.ComputeTEFactor(
-					ec.cap.ReactionsSkill,
-					pj.structure, pj.rig, pj.security,
-				)
-				secsPerRun := calculator.ComputeSecsPerRun(bpTime, teFactor)
-				durationSec = secsPerRun * runsForThis
-			}
-
-			assigned = append(assigned, &assignedJob{
-				original:    pj,
-				activity:    activity,
-				runs:        runsForThis,
-				durationSec: durationSec,
-				depth:       jobDepth,
-				characterID: ec.cap.CharacterID,
-			})
-
-			// Consume one slot
-			if activity == "manufacturing" {
-				mfgAvail[ec.idx]--
-			} else {
-				reactAvail[ec.idx]--
-			}
-		}
-	}
-
-	return assigned, unassigned
-}
-
-// estimateWallClock returns the total wall-clock seconds for all assigned jobs,
-// using a depth-aware LPT (Longest Processing Time) scheduling model.
-// Depths are processed sequentially (deepest first); within each depth, characters
-// run in parallel across their slots using LPT lane assignment.
-func estimateWallClock(jobs []*assignedJob, capacities []*calculator.CharacterCapacity) int {
-	if len(jobs) == 0 {
-		return 0
-	}
-
-	// Gather unique depth levels (descending order = deepest/leaves first)
-	depthSet := make(map[int]bool)
-	for _, aj := range jobs {
-		depthSet[aj.depth] = true
-	}
-	depths := make([]int, 0, len(depthSet))
-	for d := range depthSet {
-		depths = append(depths, d)
-	}
-	sort.Slice(depths, func(i, j int) bool { return depths[i] > depths[j] })
-
-	// Build capacity lookup: characterID → CharacterCapacity
-	capByChar := make(map[int64]*calculator.CharacterCapacity, len(capacities))
-	for _, cap := range capacities {
-		capByChar[cap.CharacterID] = cap
-	}
-
-	total := 0
-
-	for _, depth := range depths {
-		// Collect jobs at this depth, grouped by character
-		charJobs := make(map[int64][]*assignedJob)
-		for _, aj := range jobs {
-			if aj.depth == depth {
-				charJobs[aj.CharacterID()] = append(charJobs[aj.CharacterID()], aj)
-			}
-		}
-
-		depthTime := 0
-
-		for charID, cjobs := range charJobs {
-			cap := capByChar[charID]
-
-			// Determine slot count for this activity type
-			// (all jobs for this character at this depth share the same activity)
-			activity := ""
-			if len(cjobs) > 0 {
-				activity = cjobs[0].activity
-			}
-
-			var numSlots int
-			if cap == nil {
-				numSlots = 1
-			} else if activity == "manufacturing" {
-				numSlots = cap.MfgSlotsMax
-				if numSlots <= 0 {
-					numSlots = 1
-				}
-			} else {
-				numSlots = cap.ReactSlotsMax
-				if numSlots <= 0 {
-					numSlots = 1
-				}
-			}
-
-			// LPT: sort jobs by duration descending
-			sort.Slice(cjobs, func(i, j int) bool {
-				return cjobs[i].durationSec > cjobs[j].durationSec
-			})
-
-			// Assign jobs to lanes (one lane = one slot)
-			lanes := make([]int, numSlots)
-			for _, aj := range cjobs {
-				// Find lane with least total time
-				minIdx := 0
-				for k := 1; k < numSlots; k++ {
-					if lanes[k] < lanes[minIdx] {
-						minIdx = k
-					}
-				}
-				lanes[minIdx] += aj.durationSec
-			}
-
-			// Character completion time = max lane time
-			charTime := 0
-			for _, lt := range lanes {
-				if lt > charTime {
-					charTime = lt
-				}
-			}
-
-			if charTime > depthTime {
-				depthTime = charTime
-			}
-		}
-
-		total += depthTime
-	}
-
-	return total
-}
-
-// CharacterID is a helper accessor for assignedJob to work with the map grouping.
-func (aj *assignedJob) CharacterID() int64 {
-	return aj.characterID
-}

--- a/internal/database/migrations/20260225205355_auto_production.down.sql
+++ b/internal/database/migrations/20260225205355_auto_production.down.sql
@@ -1,0 +1,7 @@
+-- Migration: auto_production
+-- Created: Wed Feb 25 08:53:55 PM PST 2026
+
+DROP INDEX IF EXISTS idx_stockpile_markers_auto_production;
+ALTER TABLE stockpile_markers DROP COLUMN IF EXISTS auto_production_enabled;
+ALTER TABLE stockpile_markers DROP COLUMN IF EXISTS auto_production_parallelism;
+ALTER TABLE stockpile_markers DROP COLUMN IF EXISTS plan_id;

--- a/internal/database/migrations/20260225205355_auto_production.up.sql
+++ b/internal/database/migrations/20260225205355_auto_production.up.sql
@@ -1,0 +1,7 @@
+-- Migration: auto_production
+-- Created: Wed Feb 25 08:53:55 PM PST 2026
+
+ALTER TABLE stockpile_markers ADD COLUMN plan_id BIGINT REFERENCES production_plans(id) ON DELETE SET NULL;
+ALTER TABLE stockpile_markers ADD COLUMN auto_production_parallelism INT DEFAULT 0;
+ALTER TABLE stockpile_markers ADD COLUMN auto_production_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE INDEX idx_stockpile_markers_auto_production ON stockpile_markers(user_id) WHERE auto_production_enabled = TRUE;

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -75,17 +75,20 @@ type CorporationDivisions struct {
 }
 
 type StockpileMarker struct {
-	UserID          int64    `json:"userId"`
-	TypeID          int64    `json:"typeId"`
-	OwnerType       string   `json:"ownerType"`
-	OwnerID         int64    `json:"ownerId"`
-	LocationID      int64    `json:"locationId"`
-	ContainerID     *int64   `json:"containerId"`
-	DivisionNumber  *int     `json:"divisionNumber"`
-	DesiredQuantity int64    `json:"desiredQuantity"`
-	Notes           *string  `json:"notes"`
-	PriceSource     *string  `json:"priceSource"`
-	PricePercentage *float64 `json:"pricePercentage"`
+	UserID                    int64    `json:"userId"`
+	TypeID                    int64    `json:"typeId"`
+	OwnerType                 string   `json:"ownerType"`
+	OwnerID                   int64    `json:"ownerId"`
+	LocationID                int64    `json:"locationId"`
+	ContainerID               *int64   `json:"containerId"`
+	DivisionNumber            *int     `json:"divisionNumber"`
+	DesiredQuantity           int64    `json:"desiredQuantity"`
+	Notes                     *string  `json:"notes"`
+	PriceSource               *string  `json:"priceSource"`
+	PricePercentage           *float64 `json:"pricePercentage"`
+	PlanID                    *int64   `json:"planId"`
+	AutoProductionParallelism int      `json:"autoProductionParallelism"`
+	AutoProductionEnabled     bool     `json:"autoProductionEnabled"`
 }
 
 type MarketPrice struct {

--- a/internal/repositories/autoBuyConfigs.go
+++ b/internal/repositories/autoBuyConfigs.go
@@ -203,6 +203,7 @@ func (r *AutoBuyConfigs) GetStockpileDeficitsForConfig(ctx context.Context, conf
 					AND sm.location_id = $4
 					AND COALESCE(sm.container_id, 0::bigint) = COALESCE($5::bigint, 0::bigint)
 					AND COALESCE(sm.division_number, 0) = COALESCE($6, 0)
+					AND sm.auto_production_enabled = FALSE
 				GROUP BY sm.type_id, sm.desired_quantity, sm.price_source, sm.price_percentage
 			`
 		} else {
@@ -226,6 +227,7 @@ func (r *AutoBuyConfigs) GetStockpileDeficitsForConfig(ctx context.Context, conf
 					AND sm.location_id = $4
 					AND COALESCE(sm.container_id, 0::bigint) = COALESCE($5::bigint, 0::bigint)
 					AND COALESCE(sm.division_number, 0) = COALESCE($6, 0)
+					AND sm.auto_production_enabled = FALSE
 				GROUP BY sm.type_id, sm.desired_quantity, sm.price_source, sm.price_percentage
 			`
 		}
@@ -253,6 +255,7 @@ func (r *AutoBuyConfigs) GetStockpileDeficitsForConfig(ctx context.Context, conf
 					AND sm.location_id = $4
 					AND sm.container_id IS NULL
 					AND COALESCE(sm.division_number, 0) = COALESCE($5, 0)
+					AND sm.auto_production_enabled = FALSE
 				GROUP BY sm.type_id, sm.desired_quantity, sm.price_source, sm.price_percentage
 			`
 		} else {
@@ -286,6 +289,7 @@ func (r *AutoBuyConfigs) GetStockpileDeficitsForConfig(ctx context.Context, conf
 					AND sm.location_id = $4
 					AND sm.container_id IS NULL
 					AND COALESCE(sm.division_number, 0) = COALESCE($5, 0)
+					AND sm.auto_production_enabled = FALSE
 				GROUP BY sm.type_id, sm.desired_quantity, sm.price_source, sm.price_percentage
 			`
 		}

--- a/internal/runners/autoProduction.go
+++ b/internal/runners/autoProduction.go
@@ -1,0 +1,56 @@
+package runners
+
+import (
+	"context"
+	"time"
+
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+)
+
+type AutoProductionUpdaterInterface interface {
+	RunAll(ctx context.Context) error
+}
+
+type AutoProductionRunner struct {
+	updater       AutoProductionUpdaterInterface
+	interval      time.Duration
+	tickerFactory TickerFactory
+}
+
+func NewAutoProductionRunner(updater AutoProductionUpdaterInterface, interval time.Duration) *AutoProductionRunner {
+	return &AutoProductionRunner{
+		updater:  updater,
+		interval: interval,
+		tickerFactory: func(d time.Duration) Ticker {
+			return &realTicker{time.NewTicker(d)}
+		},
+	}
+}
+
+// WithTickerFactory allows injecting a custom ticker factory for testing.
+func (r *AutoProductionRunner) WithTickerFactory(factory TickerFactory) *AutoProductionRunner {
+	r.tickerFactory = factory
+	return r
+}
+
+// Run waits for the first scheduled tick before running. This avoids triggering
+// auto-production before asset data has been populated after startup.
+func (r *AutoProductionRunner) Run(ctx context.Context) error {
+	ticker := r.tickerFactory(r.interval)
+	defer ticker.Stop()
+
+	// Do NOT run on startup — wait for asset data to be populated first
+	log.Info("auto-production: waiting for first scheduled tick")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C():
+			log.Info("auto-production: running (scheduled)")
+			if err := r.updater.RunAll(ctx); err != nil {
+				log.Error("auto-production: failed", "error", err)
+			}
+		}
+	}
+}

--- a/internal/runners/autoProduction_test.go
+++ b/internal/runners/autoProduction_test.go
@@ -1,0 +1,173 @@
+package runners_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/annymsMthd/industry-tool/internal/runners"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockAutoProductionUpdater mocks the AutoProductionUpdaterInterface
+type MockAutoProductionUpdater struct {
+	mock.Mock
+}
+
+func (m *MockAutoProductionUpdater) RunAll(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func Test_AutoProductionRunner_DoesNotRunOnStartup(t *testing.T) {
+	mockUpdater := new(MockAutoProductionUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewAutoProductionRunner(mockUpdater, 30*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	// No calls expected — runner does not run on startup
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runner.Run(ctx)
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t)
+}
+
+func Test_AutoProductionRunner_RunsOnScheduledTick(t *testing.T) {
+	mockUpdater := new(MockAutoProductionUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewAutoProductionRunner(mockUpdater, 30*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	// One scheduled call expected
+	mockUpdater.On("RunAll", mock.Anything).Return(nil).Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	mockTicker.Tick()
+	time.Sleep(10 * time.Millisecond)
+
+	cancel()
+	err := <-done
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t)
+}
+
+func Test_AutoProductionRunner_RunsMultipleTicks(t *testing.T) {
+	mockUpdater := new(MockAutoProductionUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewAutoProductionRunner(mockUpdater, 30*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	// Two scheduled calls expected
+	mockUpdater.On("RunAll", mock.Anything).Return(nil).Times(2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	mockTicker.Tick()
+	time.Sleep(10 * time.Millisecond)
+	mockTicker.Tick()
+	time.Sleep(10 * time.Millisecond)
+
+	cancel()
+	err := <-done
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t)
+}
+
+func Test_AutoProductionRunner_ContinuesOnError(t *testing.T) {
+	mockUpdater := new(MockAutoProductionUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewAutoProductionRunner(mockUpdater, 30*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	// First tick errors, second tick succeeds
+	mockUpdater.On("RunAll", mock.Anything).Return(errors.New("transient error")).Once()
+	mockUpdater.On("RunAll", mock.Anything).Return(nil).Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	mockTicker.Tick()
+	time.Sleep(10 * time.Millisecond)
+	mockTicker.Tick()
+	time.Sleep(10 * time.Millisecond)
+
+	cancel()
+	err := <-done
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t)
+}
+
+func Test_AutoProductionRunner_StopsOnContextCancellation(t *testing.T) {
+	mockUpdater := new(MockAutoProductionUpdater)
+	mockTicker := NewMockTicker()
+
+	runner := runners.NewAutoProductionRunner(mockUpdater, 30*time.Minute).
+		WithTickerFactory(func(d time.Duration) runners.Ticker {
+			return mockTicker
+		})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	err := <-done
+
+	assert.NoError(t, err)
+	mockUpdater.AssertExpectations(t) // zero calls expected
+}
+
+func Test_AutoProductionRunner_Constructor(t *testing.T) {
+	mockUpdater := new(MockAutoProductionUpdater)
+	interval := 30 * time.Minute
+
+	runner := runners.NewAutoProductionRunner(mockUpdater, interval)
+
+	assert.NotNil(t, runner)
+}

--- a/internal/services/jobGeneration.go
+++ b/internal/services/jobGeneration.go
@@ -1,0 +1,586 @@
+package services
+
+import (
+	"context"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/annymsMthd/industry-tool/internal/calculator"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/pkg/errors"
+)
+
+// JobGenSdeRepository is the SDE interface required by WalkAndMergeSteps.
+type JobGenSdeRepository interface {
+	GetBlueprintForActivity(ctx context.Context, blueprintTypeID int64, activity string) (*repositories.ManufacturingBlueprintRow, error)
+	GetBlueprintMaterialsForActivity(ctx context.Context, blueprintTypeID int64, activity string) ([]*repositories.ManufacturingMaterialRow, error)
+}
+
+// StepProductionData holds production output data for a single plan step,
+// used when generating transport jobs.
+type StepProductionData struct {
+	ProductTypeID int64
+	ProductName   string
+	TotalQuantity int
+	ProductVolume float64
+}
+
+// PendingJob is a job ready to be persisted or simulated, with tree metadata.
+type PendingJob struct {
+	Entry         *models.IndustryJobQueueEntry
+	BlueprintName string
+	ProductName   string
+	Depth         int
+	// Fields for per-character TE recalculation in preview
+	BaseBlueprintTime int    // base seconds from SDE blueprint
+	Activity          string // "manufacturing" or "reaction"
+	Structure         string
+	Rig               string
+	Security          string
+	BlueprintTE       int
+}
+
+// MergeKey identifies jobs that can be merged (same blueprint, settings).
+type MergeKey struct {
+	BlueprintTypeID int64
+	Activity        string
+	MELevel         int
+	TELevel         int
+	FacilityTax     float64
+}
+
+// WalkResult is the output of WalkAndMergeSteps.
+type WalkResult struct {
+	MergedJobs     []*PendingJob
+	StepProduction map[int64]*StepProductionData
+	StepDepths     map[int64]int
+	Skipped        []*models.GenerateJobSkipped
+}
+
+// AssignedJob is a single job fragment assigned to a character during simulation.
+type AssignedJob struct {
+	Original    *PendingJob // reference to the originating merged job
+	Activity    string
+	Runs        int
+	DurationSec int
+	Depth       int
+	CharacterID int64
+}
+
+// GetCharacterID is a helper accessor for AssignedJob to work with map grouping.
+// CharacterID is also a field name, so the accessor is named GetCharacterID.
+func (aj *AssignedJob) GetCharacterID() int64 {
+	return aj.CharacterID
+}
+
+// FormatLocation builds a human-readable location string from owner/division/container names.
+func FormatLocation(ownerName, divisionName, containerName string) string {
+	parts := []string{}
+	if ownerName != "" {
+		parts = append(parts, ownerName)
+	}
+	if divisionName != "" {
+		parts = append(parts, divisionName)
+	}
+	if containerName != "" {
+		parts = append(parts, containerName)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " > ")
+}
+
+// WalkAndMergeSteps walks the production plan tree and returns merged pending jobs.
+// It is shared by GenerateJobs and PreviewPlan.
+func WalkAndMergeSteps(
+	ctx context.Context,
+	sdeRepo JobGenSdeRepository,
+	plan *models.ProductionPlan,
+	quantity int,
+	jitaPrices map[int64]*models.MarketPrice,
+	adjustedPrices map[int64]float64,
+) (*WalkResult, error) {
+	if len(plan.Steps) == 0 {
+		return nil, errors.New("plan has no steps")
+	}
+
+	// Build step index and find root
+	stepsByID := make(map[int64]*models.ProductionPlanStep)
+	childStepsByParent := make(map[int64][]*models.ProductionPlanStep)
+	var rootStep *models.ProductionPlanStep
+
+	for _, step := range plan.Steps {
+		stepsByID[step.ID] = step
+		if step.ParentStepID == nil {
+			rootStep = step
+		} else {
+			childStepsByParent[*step.ParentStepID] = append(childStepsByParent[*step.ParentStepID], step)
+		}
+	}
+
+	if rootStep == nil {
+		return nil, errors.New("plan has no root step")
+	}
+
+	wr := &WalkResult{
+		StepProduction: make(map[int64]*StepProductionData),
+		StepDepths:     make(map[int64]int),
+		Skipped:        []*models.GenerateJobSkipped{},
+	}
+
+	pendingJobs := []*PendingJob{}
+
+	// Walk the tree depth-first, collect jobs by depth level
+	var walkStep func(step *models.ProductionPlanStep, qty int, depth int)
+	walkStep = func(step *models.ProductionPlanStep, qty int, depth int) {
+		// Record depth for this step (used by transport ordering)
+		wr.StepDepths[step.ID] = depth
+
+		// Look up blueprint to get product quantity per run (activity-aware)
+		bp, err := sdeRepo.GetBlueprintForActivity(ctx, step.BlueprintTypeID, step.Activity)
+		if err != nil || bp == nil {
+			wr.Skipped = append(wr.Skipped, &models.GenerateJobSkipped{
+				TypeID:   step.ProductTypeID,
+				TypeName: step.ProductName,
+				Reason:   "blueprint data not found",
+			})
+			return
+		}
+
+		// Calculate runs needed
+		runs := int(math.Ceil(float64(qty) / float64(bp.ProductQuantity)))
+		if runs <= 0 {
+			runs = 1
+		}
+
+		// Record production data for transport generation
+		totalProduced := runs * bp.ProductQuantity
+		wr.StepProduction[step.ID] = &StepProductionData{
+			ProductTypeID: step.ProductTypeID,
+			ProductName:   bp.ProductName,
+			TotalQuantity: totalProduced,
+			ProductVolume: bp.ProductVolume,
+		}
+
+		// Get materials for this step to calculate child needs
+		materials, err := sdeRepo.GetBlueprintMaterialsForActivity(ctx, step.BlueprintTypeID, step.Activity)
+		if err != nil {
+			wr.Skipped = append(wr.Skipped, &models.GenerateJobSkipped{
+				TypeID:   step.ProductTypeID,
+				TypeName: step.ProductName,
+				Reason:   "failed to get materials",
+			})
+			return
+		}
+
+		// Calculate ME factor for batch quantity calculation
+		meFactor := calculator.ComputeManufacturingME(step.MELevel, step.Structure, step.Rig, step.Security)
+
+		// Process child steps (materials that are produced)
+		children := childStepsByParent[step.ID]
+		childProductTypeIDs := make(map[int64]*models.ProductionPlanStep)
+		for _, child := range children {
+			childProductTypeIDs[child.ProductTypeID] = child
+		}
+
+		for _, mat := range materials {
+			if childStep, ok := childProductTypeIDs[mat.TypeID]; ok {
+				// This material is produced — calculate needed quantity
+				batchQty := calculator.ComputeBatchQty(runs, mat.Quantity, meFactor)
+				walkStep(childStep, int(batchQty), depth+1)
+			}
+		}
+
+		// Calculate cost and duration for manufacturing and reaction steps
+		var estimatedCost *float64
+		var estimatedDuration *int
+
+		if step.Activity == "manufacturing" || step.Activity == "reaction" {
+			params := &calculator.ManufacturingParams{
+				BlueprintME:      step.MELevel,
+				BlueprintTE:      step.TELevel,
+				Runs:             runs,
+				Structure:        step.Structure,
+				Rig:              step.Rig,
+				Security:         step.Security,
+				IndustrySkill:    step.IndustrySkill,
+				AdvIndustrySkill: step.AdvIndustrySkill,
+				FacilityTax:      step.FacilityTax,
+			}
+
+			data := &calculator.ManufacturingData{
+				Blueprint:      bp,
+				Materials:      materials,
+				CostIndex:      0,
+				AdjustedPrices: adjustedPrices,
+				JitaPrices:     jitaPrices,
+			}
+
+			calcResult := calculator.CalculateManufacturingJob(params, data)
+			estimatedCost = &calcResult.TotalCost
+			estimatedDuration = &calcResult.TotalDuration
+
+			// For reaction steps, override the duration using the reactions TE formula.
+			// Reactions use only the Reactions skill (4% per level) with no blueprint TE
+			// and no Advanced Industry skill reduction. step.IndustrySkill holds the
+			// Reactions skill level when activity == "reaction".
+			if step.Activity == "reaction" {
+				reactionTEFactor := calculator.ComputeTEFactor(step.IndustrySkill, step.Structure, step.Rig, step.Security)
+				secsPerRun := calculator.ComputeSecsPerRun(bp.Time, reactionTEFactor)
+				totalDuration := secsPerRun * runs
+				estimatedDuration = &totalDuration
+			}
+		}
+
+		// Build location context from plan step
+		stationName := ""
+		if step.StationName != nil {
+			stationName = *step.StationName
+		}
+		inputLoc := FormatLocation(step.SourceOwnerName, step.SourceDivisionName, step.SourceContainerName)
+		outputLoc := FormatLocation(step.OutputOwnerName, step.OutputDivisionName, step.OutputContainerName)
+
+		productTypeID := step.ProductTypeID
+		pendingJobs = append(pendingJobs, &PendingJob{
+			Entry: &models.IndustryJobQueueEntry{
+				BlueprintTypeID:   step.BlueprintTypeID,
+				Activity:          step.Activity,
+				Runs:              runs,
+				MELevel:           step.MELevel,
+				TELevel:           step.TELevel,
+				FacilityTax:       step.FacilityTax,
+				ProductTypeID:     &productTypeID,
+				EstimatedCost:     estimatedCost,
+				EstimatedDuration: estimatedDuration,
+				SortOrder:         depth * 2,
+				StationName:       stationName,
+				InputLocation:     inputLoc,
+				OutputLocation:    outputLoc,
+			},
+			BlueprintName:     step.BlueprintName,
+			ProductName:       bp.ProductName,
+			Depth:             depth,
+			BaseBlueprintTime: bp.Time,
+			Activity:          step.Activity,
+			Structure:         step.Structure,
+			Rig:               step.Rig,
+			Security:          step.Security,
+			BlueprintTE:       step.TELevel,
+		})
+	}
+
+	walkStep(rootStep, quantity, 0)
+
+	// Merge pending jobs with identical blueprint + settings into combined entries
+	merged := make(map[MergeKey]*PendingJob)
+	mergeOrder := []MergeKey{}
+	for _, pj := range pendingJobs {
+		key := MergeKey{
+			BlueprintTypeID: pj.Entry.BlueprintTypeID,
+			Activity:        pj.Entry.Activity,
+			MELevel:         pj.Entry.MELevel,
+			TELevel:         pj.Entry.TELevel,
+			FacilityTax:     pj.Entry.FacilityTax,
+		}
+		if existing, ok := merged[key]; ok {
+			existing.Entry.Runs += pj.Entry.Runs
+			if pj.Entry.EstimatedCost != nil {
+				if existing.Entry.EstimatedCost == nil {
+					cost := *pj.Entry.EstimatedCost
+					existing.Entry.EstimatedCost = &cost
+				} else {
+					*existing.Entry.EstimatedCost += *pj.Entry.EstimatedCost
+				}
+			}
+			if pj.Entry.EstimatedDuration != nil {
+				if existing.Entry.EstimatedDuration == nil {
+					dur := *pj.Entry.EstimatedDuration
+					existing.Entry.EstimatedDuration = &dur
+				} else {
+					*existing.Entry.EstimatedDuration += *pj.Entry.EstimatedDuration
+				}
+			}
+			// Keep the deeper depth for ordering
+			if pj.Depth > existing.Depth {
+				existing.Depth = pj.Depth
+				existing.Entry.SortOrder = pj.Entry.SortOrder
+			}
+		} else {
+			merged[key] = pj
+			mergeOrder = append(mergeOrder, key)
+		}
+	}
+
+	// Collect merged jobs preserving insertion order
+	mergedJobs := make([]*PendingJob, 0, len(mergeOrder))
+	for _, key := range mergeOrder {
+		mergedJobs = append(mergedJobs, merged[key])
+	}
+
+	// Sort merged jobs by depth descending (deepest first = leaves before parents)
+	sort.Slice(mergedJobs, func(i, j int) bool {
+		return mergedJobs[i].Depth > mergedJobs[j].Depth
+	})
+
+	wr.MergedJobs = mergedJobs
+	return wr, nil
+}
+
+// SimulateAssignment distributes merged jobs across up to parallelism characters.
+// It clones capacity state so the originals are not mutated.
+// Returns the list of assigned job fragments and count of unassigned runs.
+//
+// Jobs with no eligible character are still appended to the returned slice with
+// CharacterID=0 so they are not silently dropped from queue creation.
+//
+// Slot availability resets at each depth level: children must finish before
+// parents start, so a slot used at depth N is free again at depth N-1.
+func SimulateAssignment(
+	mergedJobs []*PendingJob,
+	capacities []*calculator.CharacterCapacity,
+	parallelism int,
+) ([]*AssignedJob, int) {
+	if parallelism > len(capacities) {
+		parallelism = len(capacities)
+	}
+	pool := capacities[:parallelism]
+
+	// Record initial available slots (capacity minus already-running ESI jobs).
+	// These are reset whenever the depth level changes.
+	initialMfg := make([]int, parallelism)
+	initialReact := make([]int, parallelism)
+	for i, cap := range pool {
+		initialMfg[i] = calculator.MfgSlotsAvailable(cap)
+		initialReact[i] = calculator.ReactSlotsAvailable(cap)
+	}
+
+	// Working copies reset at each new depth level.
+	mfgAvail := make([]int, parallelism)
+	reactAvail := make([]int, parallelism)
+	copy(mfgAvail, initialMfg)
+	copy(reactAvail, initialReact)
+
+	assigned := []*AssignedJob{}
+	unassigned := 0
+	currentDepth := -1
+
+	for _, pj := range mergedJobs {
+		// Jobs are sorted deepest-first. When we move to a shallower depth, the
+		// previous depth's jobs are done and all slots are free again.
+		jobDepth := pj.Depth
+		if currentDepth == -1 {
+			currentDepth = jobDepth
+		} else if jobDepth != currentDepth {
+			currentDepth = jobDepth
+			copy(mfgAvail, initialMfg)
+			copy(reactAvail, initialReact)
+		}
+
+		activity := pj.Activity
+		if activity == "" {
+			activity = pj.Entry.Activity
+		}
+		if activity != "manufacturing" && activity != "reaction" {
+			continue
+		}
+
+		// Collect characters with available slots for this activity
+		type eligibleChar struct {
+			idx int
+			cap *calculator.CharacterCapacity
+		}
+		eligible := []eligibleChar{}
+		for i, cap := range pool {
+			if activity == "manufacturing" && mfgAvail[i] > 0 {
+				eligible = append(eligible, eligibleChar{idx: i, cap: cap})
+			} else if activity == "reaction" && reactAvail[i] > 0 {
+				eligible = append(eligible, eligibleChar{idx: i, cap: cap})
+			}
+		}
+
+		if len(eligible) == 0 {
+			// No slot available — still persist the job so it appears in the queue
+			// without a character assignment (CharacterID=0 signals unassigned).
+			var dur int
+			if pj.Entry.EstimatedDuration != nil {
+				dur = *pj.Entry.EstimatedDuration
+			}
+			assigned = append(assigned, &AssignedJob{
+				Original:    pj,
+				Activity:    activity,
+				Runs:        pj.Entry.Runs,
+				DurationSec: dur,
+				Depth:       jobDepth,
+				CharacterID: 0,
+			})
+			unassigned += pj.Entry.Runs
+			continue
+		}
+
+		totalRuns := pj.Entry.Runs
+		numChars := len(eligible)
+		runsPerChar := int(math.Ceil(float64(totalRuns) / float64(numChars)))
+
+		for j, ec := range eligible {
+			runsForThis := runsPerChar
+			// Last character gets the remainder
+			if j == numChars-1 {
+				runsForThis = totalRuns - runsPerChar*(numChars-1)
+				if runsForThis <= 0 {
+					break
+				}
+			}
+
+			// Recalculate duration with this character's actual skills
+			var durationSec int
+			bpTime := pj.BaseBlueprintTime
+			if bpTime <= 0 {
+				// Fall back to stored estimated duration if base time is missing
+				if pj.Entry.EstimatedDuration != nil {
+					durationSec = *pj.Entry.EstimatedDuration * runsForThis
+					if pj.Entry.Runs > 0 {
+						durationSec = (*pj.Entry.EstimatedDuration * runsForThis) / pj.Entry.Runs
+					}
+				}
+			} else if activity == "manufacturing" {
+				teFactor := calculator.ComputeManufacturingTE(
+					pj.BlueprintTE,
+					ec.cap.IndustrySkill,
+					ec.cap.AdvIndustrySkill,
+					pj.Structure, pj.Rig, pj.Security,
+				)
+				secsPerRun := calculator.ComputeSecsPerRun(bpTime, teFactor)
+				durationSec = secsPerRun * runsForThis
+			} else { // reaction
+				teFactor := calculator.ComputeTEFactor(
+					ec.cap.ReactionsSkill,
+					pj.Structure, pj.Rig, pj.Security,
+				)
+				secsPerRun := calculator.ComputeSecsPerRun(bpTime, teFactor)
+				durationSec = secsPerRun * runsForThis
+			}
+
+			assigned = append(assigned, &AssignedJob{
+				Original:    pj,
+				Activity:    activity,
+				Runs:        runsForThis,
+				DurationSec: durationSec,
+				Depth:       jobDepth,
+				CharacterID: ec.cap.CharacterID,
+			})
+
+			// Consume one slot
+			if activity == "manufacturing" {
+				mfgAvail[ec.idx]--
+			} else {
+				reactAvail[ec.idx]--
+			}
+		}
+	}
+
+	return assigned, unassigned
+}
+
+// EstimateWallClock returns the total wall-clock seconds for all assigned jobs,
+// using a depth-aware LPT (Longest Processing Time) scheduling model.
+// Depths are processed sequentially (deepest first); within each depth, characters
+// run in parallel across their slots using LPT lane assignment.
+func EstimateWallClock(jobs []*AssignedJob, capacities []*calculator.CharacterCapacity) int {
+	if len(jobs) == 0 {
+		return 0
+	}
+
+	// Gather unique depth levels (descending order = deepest/leaves first)
+	depthSet := make(map[int]bool)
+	for _, aj := range jobs {
+		depthSet[aj.Depth] = true
+	}
+	depths := make([]int, 0, len(depthSet))
+	for d := range depthSet {
+		depths = append(depths, d)
+	}
+	sort.Slice(depths, func(i, j int) bool { return depths[i] > depths[j] })
+
+	// Build capacity lookup: CharacterID → CharacterCapacity
+	capByChar := make(map[int64]*calculator.CharacterCapacity, len(capacities))
+	for _, cap := range capacities {
+		capByChar[cap.CharacterID] = cap
+	}
+
+	total := 0
+
+	for _, depth := range depths {
+		// Collect jobs at this depth, grouped by character
+		charJobs := make(map[int64][]*AssignedJob)
+		for _, aj := range jobs {
+			if aj.Depth == depth {
+				charJobs[aj.GetCharacterID()] = append(charJobs[aj.GetCharacterID()], aj)
+			}
+		}
+
+		depthTime := 0
+
+		for charID, cjobs := range charJobs {
+			cap := capByChar[charID]
+
+			// Determine slot count for this activity type
+			// (all jobs for this character at this depth share the same activity)
+			activity := ""
+			if len(cjobs) > 0 {
+				activity = cjobs[0].Activity
+			}
+
+			var numSlots int
+			if cap == nil {
+				numSlots = 1
+			} else if activity == "manufacturing" {
+				numSlots = cap.MfgSlotsMax
+				if numSlots <= 0 {
+					numSlots = 1
+				}
+			} else {
+				numSlots = cap.ReactSlotsMax
+				if numSlots <= 0 {
+					numSlots = 1
+				}
+			}
+
+			// LPT: sort jobs by duration descending
+			sort.Slice(cjobs, func(i, j int) bool {
+				return cjobs[i].DurationSec > cjobs[j].DurationSec
+			})
+
+			// Assign jobs to lanes (one lane = one slot)
+			lanes := make([]int, numSlots)
+			for _, aj := range cjobs {
+				// Find lane with least total time
+				minIdx := 0
+				for k := 1; k < numSlots; k++ {
+					if lanes[k] < lanes[minIdx] {
+						minIdx = k
+					}
+				}
+				lanes[minIdx] += aj.DurationSec
+			}
+
+			// Character completion time = max lane time
+			charTime := 0
+			for _, lt := range lanes {
+				if lt > charTime {
+					charTime = lt
+				}
+			}
+
+			if charTime > depthTime {
+				depthTime = charTime
+			}
+		}
+
+		total += depthTime
+	}
+
+	return total
+}

--- a/internal/services/jobGeneration_test.go
+++ b/internal/services/jobGeneration_test.go
@@ -1,0 +1,906 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/calculator"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockJobGenSdeRepository implements JobGenSdeRepository for testing.
+type MockJobGenSdeRepository struct {
+	mock.Mock
+}
+
+func (m *MockJobGenSdeRepository) GetBlueprintForActivity(ctx context.Context, blueprintTypeID int64, activity string) (*repositories.ManufacturingBlueprintRow, error) {
+	args := m.Called(ctx, blueprintTypeID, activity)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repositories.ManufacturingBlueprintRow), args.Error(1)
+}
+
+func (m *MockJobGenSdeRepository) GetBlueprintMaterialsForActivity(ctx context.Context, blueprintTypeID int64, activity string) ([]*repositories.ManufacturingMaterialRow, error) {
+	args := m.Called(ctx, blueprintTypeID, activity)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*repositories.ManufacturingMaterialRow), args.Error(1)
+}
+
+// ---------------------------------------------------------------------------
+// FormatLocation tests
+// ---------------------------------------------------------------------------
+
+func Test_FormatLocation(t *testing.T) {
+	tests := []struct {
+		name          string
+		ownerName     string
+		divisionName  string
+		containerName string
+		expected      string
+	}{
+		{
+			name:          "all three parts provided",
+			ownerName:     "My Corp",
+			divisionName:  "Hangar 1",
+			containerName: "Big Box",
+			expected:      "My Corp > Hangar 1 > Big Box",
+		},
+		{
+			name:          "only owner provided",
+			ownerName:     "My Corp",
+			divisionName:  "",
+			containerName: "",
+			expected:      "My Corp",
+		},
+		{
+			name:          "owner and division no container",
+			ownerName:     "My Corp",
+			divisionName:  "Hangar 2",
+			containerName: "",
+			expected:      "My Corp > Hangar 2",
+		},
+		{
+			name:          "owner and container no division",
+			ownerName:     "My Corp",
+			divisionName:  "",
+			containerName: "Small Box",
+			expected:      "My Corp > Small Box",
+		},
+		{
+			name:          "all empty strings",
+			ownerName:     "",
+			divisionName:  "",
+			containerName: "",
+			expected:      "",
+		},
+		{
+			name:          "only container provided",
+			ownerName:     "",
+			divisionName:  "",
+			containerName: "Container",
+			expected:      "Container",
+		},
+		{
+			name:          "only division provided",
+			ownerName:     "",
+			divisionName:  "Division",
+			containerName: "",
+			expected:      "Division",
+		},
+		{
+			name:          "division and container no owner",
+			ownerName:     "",
+			divisionName:  "Hangar",
+			containerName: "Crate",
+			expected:      "Hangar > Crate",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := FormatLocation(tc.ownerName, tc.divisionName, tc.containerName)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SimulateAssignment tests
+// ---------------------------------------------------------------------------
+
+func makePendingJob(blueprintTypeID int64, activity string, runs int, duration int, depth int) *PendingJob {
+	return &PendingJob{
+		Entry: &models.IndustryJobQueueEntry{
+			BlueprintTypeID:   blueprintTypeID,
+			Activity:          activity,
+			Runs:              runs,
+			EstimatedDuration: &duration,
+		},
+		Activity:          activity,
+		BaseBlueprintTime: 3600, // 1 hour base time
+		BlueprintTE:       0,
+		Structure:         "station",
+		Rig:               "none",
+		Security:          "high",
+		Depth:             depth,
+	}
+}
+
+func makeCapacity(charID int64, mfgSlots, reactSlots, industrySkill, advSkill, reactSkill int) *calculator.CharacterCapacity {
+	return &calculator.CharacterCapacity{
+		CharacterID:      charID,
+		CharacterName:    "Character",
+		MfgSlotsMax:      mfgSlots,
+		MfgSlotsUsed:     0,
+		ReactSlotsMax:    reactSlots,
+		ReactSlotsUsed:   0,
+		IndustrySkill:    industrySkill,
+		AdvIndustrySkill: advSkill,
+		ReactionsSkill:   reactSkill,
+	}
+}
+
+func Test_SimulateAssignment(t *testing.T) {
+	t.Run("empty jobs list returns empty result", func(t *testing.T) {
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 5, 0, 5, 5, 0),
+		}
+		assigned, unassigned := SimulateAssignment([]*PendingJob{}, caps, 5)
+		assert.Empty(t, assigned)
+		assert.Equal(t, 0, unassigned)
+	})
+
+	t.Run("single job single character with capacity", func(t *testing.T) {
+		job := makePendingJob(1, "manufacturing", 10, 36000, 0)
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 5, 0, 5, 5, 0),
+		}
+		assigned, unassigned := SimulateAssignment([]*PendingJob{job}, caps, 1)
+		assert.Equal(t, 0, unassigned)
+		assert.Len(t, assigned, 1)
+		assert.Equal(t, int64(1001), assigned[0].CharacterID)
+		assert.Equal(t, 10, assigned[0].Runs)
+		assert.Equal(t, "manufacturing", assigned[0].Activity)
+	})
+
+	t.Run("multiple jobs distributed across multiple characters", func(t *testing.T) {
+		// Two manufacturing jobs at depth 0, two characters each with 2 slots.
+		// job1 is split across both characters (1 slot each consumed), job2 also
+		// sees 2 eligible chars and is split across them too.
+		job1 := makePendingJob(1, "manufacturing", 10, 36000, 0)
+		job2 := makePendingJob(2, "manufacturing", 4, 18000, 0)
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 2, 0, 5, 5, 0),
+			makeCapacity(1002, 2, 0, 5, 5, 0),
+		}
+		assigned, unassigned := SimulateAssignment([]*PendingJob{job1, job2}, caps, 2)
+		assert.Equal(t, 0, unassigned)
+		// job1 splits → 2 entries; job2 splits → 2 entries → 4 total
+		assert.Len(t, assigned, 4)
+		charIDs := map[int64]bool{}
+		for _, aj := range assigned {
+			assert.NotEqual(t, int64(0), aj.CharacterID)
+			charIDs[aj.CharacterID] = true
+		}
+		// Both characters should be used
+		assert.Len(t, charIDs, 2)
+	})
+
+	t.Run("parallelism=1 limits to single character", func(t *testing.T) {
+		job := makePendingJob(1, "manufacturing", 10, 36000, 0)
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 5, 0, 5, 5, 0),
+			makeCapacity(1002, 5, 0, 5, 5, 0),
+		}
+		assigned, unassigned := SimulateAssignment([]*PendingJob{job}, caps, 1)
+		assert.Equal(t, 0, unassigned)
+		assert.Len(t, assigned, 1)
+		// Only character 1001 should be used (first in pool)
+		assert.Equal(t, int64(1001), assigned[0].CharacterID)
+	})
+
+	t.Run("jobs exceeding total capacity get CharacterID=0", func(t *testing.T) {
+		// Two jobs at depth 0 but only one character with one slot — second job is unassigned
+		job1 := makePendingJob(1, "manufacturing", 10, 36000, 0)
+		job2 := makePendingJob(2, "manufacturing", 5, 18000, 0)
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 1, 0, 5, 5, 0), // only 1 mfg slot
+		}
+		assigned, unassigned := SimulateAssignment([]*PendingJob{job1, job2}, caps, 1)
+		// Second job should have CharacterID=0 and unassigned runs counted
+		assert.Len(t, assigned, 2)
+		assignedCount := 0
+		unassignedCount := 0
+		for _, aj := range assigned {
+			if aj.CharacterID == 0 {
+				unassignedCount++
+			} else {
+				assignedCount++
+			}
+		}
+		assert.Equal(t, 1, assignedCount)
+		assert.Equal(t, 1, unassignedCount)
+		assert.Greater(t, unassigned, 0)
+	})
+
+	t.Run("reaction jobs assigned to character with reaction slots", func(t *testing.T) {
+		job := makePendingJob(10, "reaction", 5, 54000, 0)
+		caps := []*calculator.CharacterCapacity{
+			// First char has only manufacturing slots
+			makeCapacity(1001, 5, 0, 5, 5, 0),
+			// Second char has reaction slots
+			makeCapacity(1002, 0, 5, 0, 0, 5),
+		}
+		assigned, unassigned := SimulateAssignment([]*PendingJob{job}, caps, 2)
+		assert.Equal(t, 0, unassigned)
+		assert.Len(t, assigned, 1)
+		// Should be assigned to char with reaction slots
+		assert.Equal(t, int64(1002), assigned[0].CharacterID)
+	})
+
+	t.Run("mixed manufacturing and reaction jobs", func(t *testing.T) {
+		mfgJob := makePendingJob(1, "manufacturing", 10, 36000, 0)
+		reactJob := makePendingJob(10, "reaction", 5, 54000, 0)
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 5, 5, 5, 5, 5), // both activities
+		}
+		assigned, unassigned := SimulateAssignment([]*PendingJob{mfgJob, reactJob}, caps, 1)
+		assert.Equal(t, 0, unassigned)
+		assert.Len(t, assigned, 2)
+		activities := map[string]bool{}
+		for _, aj := range assigned {
+			activities[aj.Activity] = true
+			assert.Equal(t, int64(1001), aj.CharacterID)
+		}
+		assert.True(t, activities["manufacturing"])
+		assert.True(t, activities["reaction"])
+	})
+
+	t.Run("slot resets between depth levels", func(t *testing.T) {
+		// Jobs at depth 1 (deeper) followed by depth 0 (shallower)
+		// With sorted order deepest-first: depth1 first, depth0 second
+		// Character has 1 slot — after depth1 job finishes, slot should reset for depth0
+		deepJob := makePendingJob(1, "manufacturing", 5, 18000, 1)
+		shallowJob := makePendingJob(2, "manufacturing", 10, 36000, 0)
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 1, 0, 5, 5, 0),
+		}
+		// Jobs must be passed in deepest-first order (as WalkAndMergeSteps produces)
+		assigned, unassigned := SimulateAssignment([]*PendingJob{deepJob, shallowJob}, caps, 1)
+		assert.Equal(t, 0, unassigned)
+		assert.Len(t, assigned, 2)
+		for _, aj := range assigned {
+			assert.Equal(t, int64(1001), aj.CharacterID)
+		}
+	})
+
+	t.Run("jobs with non-manufacturing/reaction activity are skipped", func(t *testing.T) {
+		job := &PendingJob{
+			Entry: &models.IndustryJobQueueEntry{
+				BlueprintTypeID: 999,
+				Activity:        "copying",
+				Runs:            1,
+			},
+			Activity: "copying",
+			Depth:    0,
+		}
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 5, 0, 5, 5, 0),
+		}
+		assigned, unassigned := SimulateAssignment([]*PendingJob{job}, caps, 1)
+		assert.Empty(t, assigned)
+		assert.Equal(t, 0, unassigned)
+	})
+
+	t.Run("parallelism larger than capacities is clamped", func(t *testing.T) {
+		job := makePendingJob(1, "manufacturing", 10, 36000, 0)
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 5, 0, 5, 5, 0),
+		}
+		// parallelism=10 but only 1 capacity — should clamp to 1
+		assigned, unassigned := SimulateAssignment([]*PendingJob{job}, caps, 10)
+		assert.Equal(t, 0, unassigned)
+		assert.Len(t, assigned, 1)
+		assert.Equal(t, int64(1001), assigned[0].CharacterID)
+	})
+
+	t.Run("empty capacities — all jobs unassigned", func(t *testing.T) {
+		job := makePendingJob(1, "manufacturing", 10, 36000, 0)
+		assigned, unassigned := SimulateAssignment([]*PendingJob{job}, []*calculator.CharacterCapacity{}, 5)
+		assert.Len(t, assigned, 1)
+		assert.Equal(t, int64(0), assigned[0].CharacterID)
+		assert.Equal(t, 10, unassigned)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// EstimateWallClock tests
+// ---------------------------------------------------------------------------
+
+func Test_EstimateWallClock(t *testing.T) {
+	t.Run("empty assignments returns 0", func(t *testing.T) {
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 5, 0, 5, 5, 0),
+		}
+		result := EstimateWallClock([]*AssignedJob{}, caps)
+		assert.Equal(t, 0, result)
+	})
+
+	t.Run("single assignment returns its duration", func(t *testing.T) {
+		pj := makePendingJob(1, "manufacturing", 10, 36000, 0)
+		job := &AssignedJob{
+			Original:    pj,
+			Activity:    "manufacturing",
+			Runs:        10,
+			DurationSec: 3600,
+			Depth:       0,
+			CharacterID: 1001,
+		}
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 1, 0, 5, 5, 0),
+		}
+		result := EstimateWallClock([]*AssignedJob{job}, caps)
+		assert.Equal(t, 3600, result)
+	})
+
+	t.Run("two assignments same depth same character uses LPT across slots", func(t *testing.T) {
+		pj := makePendingJob(1, "manufacturing", 10, 36000, 0)
+		job1 := &AssignedJob{
+			Original:    pj,
+			Activity:    "manufacturing",
+			Runs:        5,
+			DurationSec: 3600,
+			Depth:       0,
+			CharacterID: 1001,
+		}
+		job2 := &AssignedJob{
+			Original:    pj,
+			Activity:    "manufacturing",
+			Runs:        5,
+			DurationSec: 1800,
+			Depth:       0,
+			CharacterID: 1001,
+		}
+		// Character has 2 mfg slots; jobs run in parallel
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 2, 0, 5, 5, 0),
+		}
+		result := EstimateWallClock([]*AssignedJob{job1, job2}, caps)
+		// LPT: 3600 in slot 0, 1800 in slot 1 → max is 3600
+		assert.Equal(t, 3600, result)
+	})
+
+	t.Run("two assignments different depths sum sequentially", func(t *testing.T) {
+		pj := makePendingJob(1, "manufacturing", 5, 36000, 0)
+		deepJob := &AssignedJob{
+			Original:    pj,
+			Activity:    "manufacturing",
+			Runs:        5,
+			DurationSec: 7200,
+			Depth:       1,
+			CharacterID: 1001,
+		}
+		shallowJob := &AssignedJob{
+			Original:    pj,
+			Activity:    "manufacturing",
+			Runs:        5,
+			DurationSec: 3600,
+			Depth:       0,
+			CharacterID: 1001,
+		}
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 1, 0, 5, 5, 0),
+		}
+		result := EstimateWallClock([]*AssignedJob{deepJob, shallowJob}, caps)
+		// Depths processed sequentially: depth1 (7200) + depth0 (3600) = 10800
+		assert.Equal(t, 10800, result)
+	})
+
+	t.Run("multiple characters at same depth uses max across chars", func(t *testing.T) {
+		pj := makePendingJob(1, "manufacturing", 5, 36000, 0)
+		// char 1001 has a 5000s job, char 1002 has a 3000s job
+		job1 := &AssignedJob{
+			Original:    pj,
+			Activity:    "manufacturing",
+			Runs:        5,
+			DurationSec: 5000,
+			Depth:       0,
+			CharacterID: 1001,
+		}
+		job2 := &AssignedJob{
+			Original:    pj,
+			Activity:    "manufacturing",
+			Runs:        3,
+			DurationSec: 3000,
+			Depth:       0,
+			CharacterID: 1002,
+		}
+		caps := []*calculator.CharacterCapacity{
+			makeCapacity(1001, 1, 0, 5, 5, 0),
+			makeCapacity(1002, 1, 0, 5, 5, 0),
+		}
+		result := EstimateWallClock([]*AssignedJob{job1, job2}, caps)
+		// Both run in parallel; total = max(5000, 3000) = 5000
+		assert.Equal(t, 5000, result)
+	})
+
+	t.Run("unassigned job CharacterID=0 uses 1 slot fallback", func(t *testing.T) {
+		pj := makePendingJob(1, "manufacturing", 5, 36000, 0)
+		job := &AssignedJob{
+			Original:    pj,
+			Activity:    "manufacturing",
+			Runs:        5,
+			DurationSec: 4000,
+			Depth:       0,
+			CharacterID: 0, // unassigned
+		}
+		caps := []*calculator.CharacterCapacity{}
+		result := EstimateWallClock([]*AssignedJob{job}, caps)
+		assert.Equal(t, 4000, result)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// WalkAndMergeSteps tests
+// ---------------------------------------------------------------------------
+
+func intPtr(i int64) *int64 {
+	return &i
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func makeBlueprintRow(bpTypeID, productTypeID int64, productName string, productQty, baseTime int) *repositories.ManufacturingBlueprintRow {
+	return &repositories.ManufacturingBlueprintRow{
+		BlueprintTypeID: bpTypeID,
+		ProductTypeID:   productTypeID,
+		ProductName:     productName,
+		ProductQuantity: productQty,
+		Time:            baseTime,
+		ProductVolume:   1.0,
+	}
+}
+
+func makeMaterialRow(bpTypeID, typeID int64, name string, qty int) *repositories.ManufacturingMaterialRow {
+	return &repositories.ManufacturingMaterialRow{
+		BlueprintTypeID: bpTypeID,
+		TypeID:          typeID,
+		TypeName:        name,
+		Quantity:        qty,
+		Volume:          1.0,
+	}
+}
+
+func makeStep(id int64, parentID *int64, productTypeID, blueprintTypeID int64, activity string) *models.ProductionPlanStep {
+	return &models.ProductionPlanStep{
+		ID:              id,
+		PlanID:          1,
+		ParentStepID:    parentID,
+		ProductTypeID:   productTypeID,
+		BlueprintTypeID: blueprintTypeID,
+		Activity:        activity,
+		MELevel:         0,
+		TELevel:         0,
+		IndustrySkill:   5,
+		AdvIndustrySkill: 5,
+		Structure:       "station",
+		Rig:             "none",
+		Security:        "high",
+		FacilityTax:     0.0,
+	}
+}
+
+func emptyJitaPrices() map[int64]*models.MarketPrice {
+	return map[int64]*models.MarketPrice{}
+}
+
+func emptyAdjustedPrices() map[int64]float64 {
+	return map[int64]float64{}
+}
+
+func Test_WalkAndMergeSteps(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("plan with no steps returns error", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{},
+		}
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 10, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("plan with no root step returns error", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+		parentID := int64(99)
+		step := makeStep(1, &parentID, 100, 200, "manufacturing")
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{step},
+		}
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 10, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("single step plan produces one merged job", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		// Blueprint produces 1 unit per run
+		bp := makeBlueprintRow(200, 100, "Tritanium", 1, 3600)
+		// No materials for simplicity
+		mats := []*repositories.ManufacturingMaterialRow{}
+
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(bp, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(200), "manufacturing").Return(mats, nil)
+
+		rootStep := makeStep(1, nil, 100, 200, "manufacturing")
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep},
+		}
+
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 10, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Len(t, result.MergedJobs, 1)
+		assert.Empty(t, result.Skipped)
+
+		job := result.MergedJobs[0]
+		assert.Equal(t, int64(200), job.Entry.BlueprintTypeID)
+		assert.Equal(t, "manufacturing", job.Entry.Activity)
+		// 10 units / 1 per run = 10 runs
+		assert.Equal(t, 10, job.Entry.Runs)
+		assert.Equal(t, 0, job.Depth)
+		assert.Equal(t, "Tritanium", job.ProductName)
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("quantity scales runs correctly", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		// Blueprint produces 10 units per run
+		bp := makeBlueprintRow(200, 100, "SomeItem", 10, 3600)
+		mats := []*repositories.ManufacturingMaterialRow{}
+
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(bp, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(200), "manufacturing").Return(mats, nil)
+
+		rootStep := makeStep(1, nil, 100, 200, "manufacturing")
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep},
+		}
+
+		// Request 25 units; 10 per run → ceil(25/10) = 3 runs
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 25, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.Len(t, result.MergedJobs, 1)
+		assert.Equal(t, 3, result.MergedJobs[0].Entry.Runs)
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("multi-step plan with parent-child relationships", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		// Root: makes product A (type 100, bp 200)
+		// Child: makes intermediate B (type 110, bp 210)
+		// Root requires 5 units of B per run
+
+		rootBP := makeBlueprintRow(200, 100, "Product A", 1, 3600)
+		rootMats := []*repositories.ManufacturingMaterialRow{
+			makeMaterialRow(200, 110, "Intermediate B", 5),
+		}
+
+		childBP := makeBlueprintRow(210, 110, "Intermediate B", 10, 1800)
+		childMats := []*repositories.ManufacturingMaterialRow{
+			makeMaterialRow(210, 120, "Raw Ore", 3),
+		}
+
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(rootBP, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(200), "manufacturing").Return(rootMats, nil)
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(210), "manufacturing").Return(childBP, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(210), "manufacturing").Return(childMats, nil)
+
+		rootStep := makeStep(1, nil, 100, 200, "manufacturing")
+		childStepID := int64(1)
+		childStep := makeStep(2, &childStepID, 110, 210, "manufacturing")
+
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep, childStep},
+		}
+
+		// Request 5 units of product A
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 5, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Len(t, result.MergedJobs, 2)
+
+		// Jobs should be sorted deepest first
+		// Child (depth=1) should come before root (depth=0)
+		assert.Equal(t, 1, result.MergedJobs[0].Depth)
+		assert.Equal(t, 0, result.MergedJobs[1].Depth)
+
+		// Root: 5 units / 1 per run = 5 runs
+		rootJob := result.MergedJobs[1]
+		assert.Equal(t, 5, rootJob.Entry.Runs)
+		assert.Equal(t, int64(200), rootJob.Entry.BlueprintTypeID)
+
+		// StepProduction should be populated for both steps
+		assert.Contains(t, result.StepProduction, int64(1))
+		assert.Contains(t, result.StepProduction, int64(2))
+
+		// StepDepths should record correct depths
+		assert.Equal(t, 0, result.StepDepths[1])
+		assert.Equal(t, 1, result.StepDepths[2])
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("steps with same merge key get merged into one job", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		// Two steps that produce the same blueprint with same settings
+		// (e.g. same intermediate needed by multiple parents)
+		bp := makeBlueprintRow(210, 110, "Intermediate", 5, 1800)
+		mats := []*repositories.ManufacturingMaterialRow{}
+
+		// Root step uses intermediate twice (two children with same bp)
+		rootBP := makeBlueprintRow(200, 100, "Final Product", 1, 3600)
+		rootMats := []*repositories.ManufacturingMaterialRow{
+			makeMaterialRow(200, 110, "Intermediate", 10),
+		}
+
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(rootBP, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(200), "manufacturing").Return(rootMats, nil)
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(210), "manufacturing").Return(bp, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(210), "manufacturing").Return(mats, nil)
+
+		rootStep := makeStep(1, nil, 100, 200, "manufacturing")
+		childStepID := int64(1)
+		// Single child producing the intermediate
+		childStep := makeStep(2, &childStepID, 110, 210, "manufacturing")
+
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep, childStep},
+		}
+
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 1, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		// Two distinct blueprints, so 2 merged jobs
+		assert.Len(t, result.MergedJobs, 2)
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("blueprint not found causes step to be skipped", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		// Blueprint lookup returns nil (not found)
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(nil, nil)
+
+		rootStep := makeStep(1, nil, 100, 200, "manufacturing")
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep},
+		}
+
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 10, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result.MergedJobs)
+		assert.Len(t, result.Skipped, 1)
+		assert.Equal(t, int64(100), result.Skipped[0].TypeID)
+		assert.Equal(t, "blueprint data not found", result.Skipped[0].Reason)
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("materials fetch error causes step to be skipped", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		bp := makeBlueprintRow(200, 100, "SomeItem", 1, 3600)
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(bp, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(200), "manufacturing").Return(
+			([]*repositories.ManufacturingMaterialRow)(nil),
+			assert.AnError,
+		)
+
+		rootStep := makeStep(1, nil, 100, 200, "manufacturing")
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep},
+		}
+
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 10, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result.MergedJobs)
+		assert.Len(t, result.Skipped, 1)
+		assert.Equal(t, "failed to get materials", result.Skipped[0].Reason)
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("reaction step uses reaction TE formula for duration", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		// Reaction blueprint: 3600s base time, produces 100 units per run
+		bp := makeBlueprintRow(300, 150, "Moon Goo Product", 100, 3600)
+		mats := []*repositories.ManufacturingMaterialRow{}
+
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(300), "reaction").Return(bp, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(300), "reaction").Return(mats, nil)
+
+		rootStep := makeStep(1, nil, 150, 300, "reaction")
+		rootStep.IndustrySkill = 5 // Reactions skill level 5
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep},
+		}
+
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 100, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.Len(t, result.MergedJobs, 1)
+
+		job := result.MergedJobs[0]
+		assert.Equal(t, "reaction", job.Entry.Activity)
+		assert.NotNil(t, job.Entry.EstimatedDuration)
+
+		// Verify duration uses reaction formula:
+		// teFactor = (1 - 5*0.04) * (1 - 0) * (1 - 0) = 0.80
+		// secsPerRun = floor(3600 * 0.80) = 2880
+		// totalDuration = 2880 * 1 run = 2880
+		expectedTEFactor := calculator.ComputeTEFactor(5, "station", "none", "high")
+		expectedSecsPerRun := calculator.ComputeSecsPerRun(3600, expectedTEFactor)
+		expectedDuration := expectedSecsPerRun * 1
+		assert.Equal(t, expectedDuration, *job.Entry.EstimatedDuration)
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("step production data is recorded", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		bp := makeBlueprintRow(200, 100, "Tritanium", 5, 3600)
+		mats := []*repositories.ManufacturingMaterialRow{}
+
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(bp, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(200), "manufacturing").Return(mats, nil)
+
+		rootStep := makeStep(1, nil, 100, 200, "manufacturing")
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep},
+		}
+
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 10, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+
+		prod, ok := result.StepProduction[1]
+		assert.True(t, ok)
+		assert.Equal(t, int64(100), prod.ProductTypeID)
+		assert.Equal(t, "Tritanium", prod.ProductName)
+		// ceil(10/5) = 2 runs × 5 per run = 10 produced
+		assert.Equal(t, 10, prod.TotalQuantity)
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("location fields populated from step", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		bp := makeBlueprintRow(200, 100, "Item", 1, 3600)
+		mats := []*repositories.ManufacturingMaterialRow{}
+
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(bp, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(200), "manufacturing").Return(mats, nil)
+
+		stationName := "Jita 4-4"
+		rootStep := makeStep(1, nil, 100, 200, "manufacturing")
+		rootStep.StationName = &stationName
+		rootStep.SourceOwnerName = "My Corp"
+		rootStep.SourceDivisionName = "Hangar 1"
+		rootStep.OutputOwnerName = "My Corp"
+		rootStep.OutputDivisionName = "Hangar 2"
+
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep},
+		}
+
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 1, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.Len(t, result.MergedJobs, 1)
+
+		job := result.MergedJobs[0]
+		assert.Equal(t, "Jita 4-4", job.Entry.StationName)
+		assert.Equal(t, "My Corp > Hangar 1", job.Entry.InputLocation)
+		assert.Equal(t, "My Corp > Hangar 2", job.Entry.OutputLocation)
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("merged jobs are sorted deepest first", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		rootBP := makeBlueprintRow(200, 100, "Final", 1, 3600)
+		rootMats := []*repositories.ManufacturingMaterialRow{
+			makeMaterialRow(200, 110, "Intermediate", 2),
+		}
+		childBP := makeBlueprintRow(210, 110, "Intermediate", 1, 1800)
+		childMats := []*repositories.ManufacturingMaterialRow{}
+
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(rootBP, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(200), "manufacturing").Return(rootMats, nil)
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(210), "manufacturing").Return(childBP, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(210), "manufacturing").Return(childMats, nil)
+
+		rootStep := makeStep(1, nil, 100, 200, "manufacturing")
+		childStepID := int64(1)
+		childStep := makeStep(2, &childStepID, 110, 210, "manufacturing")
+
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStep, childStep},
+		}
+
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 1, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.Len(t, result.MergedJobs, 2)
+
+		// First job should be deeper
+		assert.Greater(t, result.MergedJobs[0].Depth, result.MergedJobs[1].Depth)
+
+		sdeRepo.AssertExpectations(t)
+	})
+
+	t.Run("two identical steps get merged into a single job", func(t *testing.T) {
+		sdeRepo := &MockJobGenSdeRepository{}
+
+		// One root step and two children producing the same item (same blueprint, same settings)
+		rootBP := makeBlueprintRow(200, 100, "Final", 1, 3600)
+		rootMats := []*repositories.ManufacturingMaterialRow{
+			makeMaterialRow(200, 110, "Component", 2),
+		}
+		compBP := makeBlueprintRow(210, 110, "Component", 1, 1800)
+		compMats := []*repositories.ManufacturingMaterialRow{}
+
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(200), "manufacturing").Return(rootBP, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(200), "manufacturing").Return(rootMats, nil)
+		sdeRepo.On("GetBlueprintForActivity", mock.Anything, int64(210), "manufacturing").Return(compBP, nil)
+		sdeRepo.On("GetBlueprintMaterialsForActivity", mock.Anything, int64(210), "manufacturing").Return(compMats, nil)
+
+		rootStepA := makeStep(1, nil, 100, 200, "manufacturing")
+		parentStepID := int64(1)
+		childStep1 := makeStep(2, &parentStepID, 110, 210, "manufacturing")
+
+		plan := &models.ProductionPlan{
+			ID:    1,
+			Steps: []*models.ProductionPlanStep{rootStepA, childStep1},
+		}
+
+		result, err := WalkAndMergeSteps(ctx, sdeRepo, plan, 3, emptyJitaPrices(), emptyAdjustedPrices())
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		// root (bp 200) + child (bp 210) = 2 distinct blueprints
+		assert.Len(t, result.MergedJobs, 2)
+
+		sdeRepo.AssertExpectations(t)
+	})
+}

--- a/internal/updaters/autoProduction.go
+++ b/internal/updaters/autoProduction.go
@@ -1,0 +1,318 @@
+package updaters
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/annymsMthd/industry-tool/internal/calculator"
+	log "github.com/annymsMthd/industry-tool/internal/logging"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/services"
+	"github.com/pkg/errors"
+)
+
+// autoProductionGroup holds data for a single (userID, planID) production group.
+type autoProductionGroup struct {
+	userID      int64
+	planID      int64
+	typeIDs     map[int64]bool
+	parallelism int
+}
+
+type AutoProductionStockpileMarkersRepository interface {
+	GetAutoProductionMarkers(ctx context.Context) ([]*models.StockpileMarker, error)
+}
+
+type AutoProductionAssetsRepository interface {
+	GetStockpileDeficits(ctx context.Context, user int64) (*repositories.StockpilesResponse, error)
+}
+
+type AutoProductionPlansRepository interface {
+	GetByID(ctx context.Context, id, userID int64) (*models.ProductionPlan, error)
+}
+
+type AutoProductionPlanRunsRepository interface {
+	Create(ctx context.Context, run *models.ProductionPlanRun) (*models.ProductionPlanRun, error)
+	GetPendingOutputForPlan(ctx context.Context, planID, userID int64) (int64, error)
+}
+
+type AutoProductionMarketRepository interface {
+	GetAllJitaPrices(ctx context.Context) (map[int64]*models.MarketPrice, error)
+	GetAllAdjustedPrices(ctx context.Context) (map[int64]float64, error)
+}
+
+type AutoProductionJobQueueRepository interface {
+	Create(ctx context.Context, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error)
+	GetSlotUsage(ctx context.Context, userID int64) (map[int64]map[string]int, error)
+}
+
+type AutoProductionCharacterRepository interface {
+	GetNames(ctx context.Context, userID int64) (map[int64]string, error)
+}
+
+type AutoProductionSkillsRepository interface {
+	GetSkillsForUser(ctx context.Context, userID int64) ([]*models.CharacterSkill, error)
+}
+
+type AutoProductionSdeRepository interface {
+	services.JobGenSdeRepository
+}
+
+type AutoProductionUpdater struct {
+	markersRepo AutoProductionStockpileMarkersRepository
+	assetsRepo  AutoProductionAssetsRepository
+	plansRepo   AutoProductionPlansRepository
+	runsRepo    AutoProductionPlanRunsRepository
+	marketRepo  AutoProductionMarketRepository
+	queueRepo   AutoProductionJobQueueRepository
+	charRepo    AutoProductionCharacterRepository
+	skillsRepo  AutoProductionSkillsRepository
+	sdeRepo     AutoProductionSdeRepository
+}
+
+func NewAutoProductionUpdater(
+	markersRepo AutoProductionStockpileMarkersRepository,
+	assetsRepo AutoProductionAssetsRepository,
+	plansRepo AutoProductionPlansRepository,
+	runsRepo AutoProductionPlanRunsRepository,
+	marketRepo AutoProductionMarketRepository,
+	queueRepo AutoProductionJobQueueRepository,
+	charRepo AutoProductionCharacterRepository,
+	skillsRepo AutoProductionSkillsRepository,
+	sdeRepo AutoProductionSdeRepository,
+) *AutoProductionUpdater {
+	return &AutoProductionUpdater{
+		markersRepo: markersRepo,
+		assetsRepo:  assetsRepo,
+		plansRepo:   plansRepo,
+		runsRepo:    runsRepo,
+		marketRepo:  marketRepo,
+		queueRepo:   queueRepo,
+		charRepo:    charRepo,
+		skillsRepo:  skillsRepo,
+		sdeRepo:     sdeRepo,
+	}
+}
+
+// RunAll fetches all auto-production markers, groups them by (userID, planID),
+// calculates net deficits, and generates production plan runs for any outstanding demand.
+func (u *AutoProductionUpdater) RunAll(ctx context.Context) error {
+	// 1. Fetch all auto-production markers
+	markers, err := u.markersRepo.GetAutoProductionMarkers(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get auto-production markers")
+	}
+	if len(markers) == 0 {
+		return nil
+	}
+
+	// 2. Group markers by (userID, planID)
+	groups := map[string]*autoProductionGroup{}
+
+	for _, m := range markers {
+		if m.PlanID == nil {
+			continue
+		}
+		key := fmt.Sprintf("%d:%d", m.UserID, *m.PlanID)
+		g, ok := groups[key]
+		if !ok {
+			g = &autoProductionGroup{
+				userID:  m.UserID,
+				planID:  *m.PlanID,
+				typeIDs: map[int64]bool{},
+			}
+			groups[key] = g
+		}
+		g.typeIDs[m.TypeID] = true
+		if m.AutoProductionParallelism > g.parallelism {
+			g.parallelism = m.AutoProductionParallelism
+		}
+	}
+
+	// 3. Process each group
+	for _, group := range groups {
+		if err := u.processGroup(ctx, group); err != nil {
+			log.Error("auto-production: failed to process group",
+				"userID", group.userID, "planID", group.planID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (u *AutoProductionUpdater) processGroup(ctx context.Context, group *autoProductionGroup) error {
+	// 1. Get the plan with steps
+	plan, err := u.plansRepo.GetByID(ctx, group.planID, group.userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get plan")
+	}
+	if plan == nil || len(plan.Steps) == 0 {
+		return nil // plan missing or has no steps
+	}
+
+	// 2. Calculate gross deficit from stockpile data
+	deficitsResp, err := u.assetsRepo.GetStockpileDeficits(ctx, group.userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get stockpile deficits")
+	}
+
+	// Sum deficits for type_ids in this group
+	var grossDeficit int64
+	if deficitsResp != nil {
+		for _, item := range deficitsResp.Items {
+			if group.typeIDs[item.TypeID] && item.StockpileDelta < 0 {
+				grossDeficit += int64(-item.StockpileDelta) // delta is negative
+			}
+		}
+	}
+
+	if grossDeficit <= 0 {
+		return nil // no deficit
+	}
+
+	// 3. Calculate pending output from existing runs
+	pendingOutput, err := u.runsRepo.GetPendingOutputForPlan(ctx, group.planID, group.userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get pending output")
+	}
+
+	netDeficit := grossDeficit - pendingOutput
+	if netDeficit <= 0 {
+		log.Info("auto-production: deficit covered by pending output",
+			"userID", group.userID, "planID", group.planID,
+			"grossDeficit", grossDeficit, "pendingOutput", pendingOutput)
+		return nil
+	}
+
+	// 4. Fetch market data
+	jitaPrices, err := u.marketRepo.GetAllJitaPrices(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get Jita prices")
+	}
+	adjustedPrices, err := u.marketRepo.GetAllAdjustedPrices(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get adjusted prices")
+	}
+
+	// 5. Walk and merge steps
+	wr, err := services.WalkAndMergeSteps(ctx, u.sdeRepo, plan, int(netDeficit), jitaPrices, adjustedPrices)
+	if err != nil {
+		return errors.Wrap(err, "failed to walk and merge steps")
+	}
+
+	// 6. Optional character assignment
+	var assignedJobs []*services.AssignedJob
+	if group.parallelism >= 1 {
+		characterNames, err := u.charRepo.GetNames(ctx, group.userID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get character names")
+		}
+
+		allSkills, err := u.skillsRepo.GetSkillsForUser(ctx, group.userID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get character skills")
+		}
+
+		industrySkillSet := make(map[int64]bool, len(calculator.IndustrySkillIDs))
+		for _, id := range calculator.IndustrySkillIDs {
+			industrySkillSet[id] = true
+		}
+		skillsByCharacter := make(map[int64]map[int64]int)
+		for _, sk := range allSkills {
+			if !industrySkillSet[sk.SkillID] {
+				continue
+			}
+			if skillsByCharacter[sk.CharacterID] == nil {
+				skillsByCharacter[sk.CharacterID] = make(map[int64]int)
+			}
+			skillsByCharacter[sk.CharacterID][sk.SkillID] = sk.ActiveLevel
+		}
+
+		slotUsage, err := u.queueRepo.GetSlotUsage(ctx, group.userID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get slot usage")
+		}
+
+		capacities := calculator.BuildCharacterCapacities(characterNames, skillsByCharacter, slotUsage)
+		assignedJobs, _ = services.SimulateAssignment(wr.MergedJobs, capacities, group.parallelism)
+	}
+
+	// 7. Create plan run
+	run, err := u.runsRepo.Create(ctx, &models.ProductionPlanRun{
+		PlanID:   group.planID,
+		UserID:   group.userID,
+		Quantity: int(netDeficit),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to create plan run")
+	}
+
+	// 8. Create job queue entries
+	note := fmt.Sprintf("Auto-production from plan: %s", plan.Name)
+
+	if group.parallelism >= 1 && len(assignedJobs) > 0 {
+		for _, aj := range assignedJobs {
+			orig := aj.Original
+			origEntry := orig.Entry
+
+			var charIDPtr *int64
+			if aj.CharacterID != 0 {
+				cid := aj.CharacterID
+				charIDPtr = &cid
+			}
+
+			var estimatedCost *float64
+			if origEntry.EstimatedCost != nil && origEntry.Runs > 0 {
+				cost := *origEntry.EstimatedCost * float64(aj.Runs) / float64(origEntry.Runs)
+				estimatedCost = &cost
+			}
+
+			entryNote := fmt.Sprintf("%s x%d", orig.ProductName, aj.Runs)
+			newEntry := &models.IndustryJobQueueEntry{
+				UserID:            group.userID,
+				CharacterID:       charIDPtr,
+				BlueprintTypeID:   origEntry.BlueprintTypeID,
+				Activity:          aj.Activity,
+				Runs:              aj.Runs,
+				MELevel:           origEntry.MELevel,
+				TELevel:           origEntry.TELevel,
+				FacilityTax:       origEntry.FacilityTax,
+				ProductTypeID:     origEntry.ProductTypeID,
+				PlanRunID:         &run.ID,
+				PlanStepID:        origEntry.PlanStepID,
+				SortOrder:         origEntry.SortOrder,
+				StationName:       origEntry.StationName,
+				InputLocation:     origEntry.InputLocation,
+				OutputLocation:    origEntry.OutputLocation,
+				EstimatedCost:     estimatedCost,
+				EstimatedDuration: &aj.DurationSec,
+				Notes:             &entryNote,
+			}
+
+			_, err := u.queueRepo.Create(ctx, newEntry)
+			if err != nil {
+				log.Error("auto-production: failed to create queue entry",
+					"userID", group.userID, "planID", group.planID, "error", err)
+			}
+		}
+	} else {
+		for _, pj := range wr.MergedJobs {
+			pj.Entry.UserID = group.userID
+			pj.Entry.Notes = &note
+			pj.Entry.PlanRunID = &run.ID
+
+			_, err := u.queueRepo.Create(ctx, pj.Entry)
+			if err != nil {
+				log.Error("auto-production: failed to create queue entry",
+					"userID", group.userID, "planID", group.planID, "error", err)
+			}
+		}
+	}
+
+	log.Info("auto-production: generated plan run",
+		"userID", group.userID, "planID", group.planID,
+		"quantity", netDeficit, "jobs", len(wr.MergedJobs))
+
+	return nil
+}

--- a/internal/updaters/autoProduction_test.go
+++ b/internal/updaters/autoProduction_test.go
@@ -1,0 +1,530 @@
+package updaters_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/annymsMthd/industry-tool/internal/updaters"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Mocks for AutoProductionUpdater ---
+
+type mockAutoMarkersRepo struct {
+	markers []*models.StockpileMarker
+	err     error
+}
+
+func (m *mockAutoMarkersRepo) GetAutoProductionMarkers(ctx context.Context) ([]*models.StockpileMarker, error) {
+	return m.markers, m.err
+}
+
+type mockAutoAssetsRepo struct {
+	response *repositories.StockpilesResponse
+	err      error
+}
+
+func (m *mockAutoAssetsRepo) GetStockpileDeficits(ctx context.Context, user int64) (*repositories.StockpilesResponse, error) {
+	return m.response, m.err
+}
+
+type mockAutoPlansRepo struct {
+	plan map[int64]*models.ProductionPlan
+	err  error
+}
+
+func (m *mockAutoPlansRepo) GetByID(ctx context.Context, id, userID int64) (*models.ProductionPlan, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.plan[id], nil
+}
+
+type mockAutoPlanRunsRepo struct {
+	created        *models.ProductionPlanRun
+	createErr      error
+	pendingOutput  int64
+	pendingErr     error
+	createdRuns    []*models.ProductionPlanRun
+}
+
+func (m *mockAutoPlanRunsRepo) Create(ctx context.Context, run *models.ProductionPlanRun) (*models.ProductionPlanRun, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	m.createdRuns = append(m.createdRuns, run)
+	if m.created != nil {
+		return m.created, nil
+	}
+	r := *run
+	r.ID = 999
+	return &r, nil
+}
+
+func (m *mockAutoPlanRunsRepo) GetPendingOutputForPlan(ctx context.Context, planID, userID int64) (int64, error) {
+	return m.pendingOutput, m.pendingErr
+}
+
+type mockAutoMarketRepo struct {
+	jitaPrices     map[int64]*models.MarketPrice
+	jitaErr        error
+	adjustedPrices map[int64]float64
+	adjustedErr    error
+}
+
+func (m *mockAutoMarketRepo) GetAllJitaPrices(ctx context.Context) (map[int64]*models.MarketPrice, error) {
+	return m.jitaPrices, m.jitaErr
+}
+
+func (m *mockAutoMarketRepo) GetAllAdjustedPrices(ctx context.Context) (map[int64]float64, error) {
+	return m.adjustedPrices, m.adjustedErr
+}
+
+type mockAutoQueueRepo struct {
+	created    []*models.IndustryJobQueueEntry
+	createErr  error
+	slotUsage  map[int64]map[string]int
+	slotErr    error
+}
+
+func (m *mockAutoQueueRepo) Create(ctx context.Context, entry *models.IndustryJobQueueEntry) (*models.IndustryJobQueueEntry, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	m.created = append(m.created, entry)
+	e := *entry
+	e.ID = int64(len(m.created))
+	return &e, nil
+}
+
+func (m *mockAutoQueueRepo) GetSlotUsage(ctx context.Context, userID int64) (map[int64]map[string]int, error) {
+	return m.slotUsage, m.slotErr
+}
+
+type mockAutoCharRepo struct {
+	names    map[int64]string
+	namesErr error
+}
+
+func (m *mockAutoCharRepo) GetNames(ctx context.Context, userID int64) (map[int64]string, error) {
+	return m.names, m.namesErr
+}
+
+type mockAutoSkillsRepo struct {
+	skills    []*models.CharacterSkill
+	skillsErr error
+}
+
+func (m *mockAutoSkillsRepo) GetSkillsForUser(ctx context.Context, userID int64) ([]*models.CharacterSkill, error) {
+	return m.skills, m.skillsErr
+}
+
+type mockAutoSdeRepo struct {
+	blueprint *repositories.ManufacturingBlueprintRow
+	bpErr     error
+	materials []*repositories.ManufacturingMaterialRow
+	matErr    error
+}
+
+func (m *mockAutoSdeRepo) GetBlueprintForActivity(ctx context.Context, blueprintTypeID int64, activity string) (*repositories.ManufacturingBlueprintRow, error) {
+	return m.blueprint, m.bpErr
+}
+
+func (m *mockAutoSdeRepo) GetBlueprintMaterialsForActivity(ctx context.Context, blueprintTypeID int64, activity string) ([]*repositories.ManufacturingMaterialRow, error) {
+	return m.materials, m.matErr
+}
+
+// --- Helpers ---
+
+func planIDPtr(id int64) *int64 {
+	return &id
+}
+
+func makeMinimalPlan(userID, planID int64) *models.ProductionPlan {
+	return &models.ProductionPlan{
+		ID:            planID,
+		UserID:        userID,
+		Name:          "Test Plan",
+		ProductTypeID: 587,
+		Steps: []*models.ProductionPlanStep{
+			{
+				ID:              1,
+				PlanID:          planID,
+				BlueprintTypeID: 700,
+				Activity:        "manufacturing",
+				ProductTypeID:   587,
+				ProductName:     "Rifter",
+				MELevel:         0,
+				TELevel:         0,
+				FacilityTax:     0.0,
+				Structure:       "none",
+				Rig:             "none",
+				Security:        "null",
+			},
+		},
+	}
+}
+
+func makeMinimalBlueprint() *repositories.ManufacturingBlueprintRow {
+	return &repositories.ManufacturingBlueprintRow{
+		BlueprintTypeID: 700,
+		ProductTypeID:   587,
+		ProductName:     "Rifter",
+		ProductQuantity: 1,
+		Time:            3600,
+		ProductVolume:   27289.0,
+	}
+}
+
+func setupAutoProductionUpdater(
+	markers []*models.StockpileMarker,
+	deficits *repositories.StockpilesResponse,
+	plan *models.ProductionPlan,
+	pendingOutput int64,
+	jitaPrices map[int64]*models.MarketPrice,
+	adjustedPrices map[int64]float64,
+) (*updaters.AutoProductionUpdater, *mockAutoPlanRunsRepo, *mockAutoQueueRepo) {
+	markersRepo := &mockAutoMarkersRepo{markers: markers}
+	assetsRepo := &mockAutoAssetsRepo{response: deficits}
+
+	plansMap := map[int64]*models.ProductionPlan{}
+	if plan != nil {
+		plansMap[plan.ID] = plan
+	}
+	plansRepo := &mockAutoPlansRepo{plan: plansMap}
+
+	if jitaPrices == nil {
+		jitaPrices = map[int64]*models.MarketPrice{}
+	}
+	if adjustedPrices == nil {
+		adjustedPrices = map[int64]float64{}
+	}
+
+	runsRepo := &mockAutoPlanRunsRepo{pendingOutput: pendingOutput}
+	marketRepo := &mockAutoMarketRepo{jitaPrices: jitaPrices, adjustedPrices: adjustedPrices}
+	queueRepo := &mockAutoQueueRepo{}
+	charRepo := &mockAutoCharRepo{names: map[int64]string{}}
+	skillsRepo := &mockAutoSkillsRepo{skills: []*models.CharacterSkill{}}
+	sdeRepo := &mockAutoSdeRepo{
+		blueprint: makeMinimalBlueprint(),
+		materials: []*repositories.ManufacturingMaterialRow{},
+	}
+
+	u := updaters.NewAutoProductionUpdater(
+		markersRepo,
+		assetsRepo,
+		plansRepo,
+		runsRepo,
+		marketRepo,
+		queueRepo,
+		charRepo,
+		skillsRepo,
+		sdeRepo,
+	)
+
+	return u, runsRepo, queueRepo
+}
+
+// --- Tests ---
+
+func Test_AutoProduction_NoMarkersDoesNothing(t *testing.T) {
+	u, runsRepo, queueRepo := setupAutoProductionUpdater(
+		[]*models.StockpileMarker{},
+		nil,
+		nil,
+		0,
+		nil,
+		nil,
+	)
+
+	err := u.RunAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, runsRepo.createdRuns, 0)
+	assert.Len(t, queueRepo.created, 0)
+}
+
+func Test_AutoProduction_MarkersRepoErrorPropagated(t *testing.T) {
+	markersRepo := &mockAutoMarkersRepo{err: errors.New("db failure")}
+	assetsRepo := &mockAutoAssetsRepo{}
+	plansRepo := &mockAutoPlansRepo{plan: map[int64]*models.ProductionPlan{}}
+	runsRepo := &mockAutoPlanRunsRepo{}
+	marketRepo := &mockAutoMarketRepo{jitaPrices: map[int64]*models.MarketPrice{}, adjustedPrices: map[int64]float64{}}
+	queueRepo := &mockAutoQueueRepo{}
+	charRepo := &mockAutoCharRepo{names: map[int64]string{}}
+	skillsRepo := &mockAutoSkillsRepo{}
+	sdeRepo := &mockAutoSdeRepo{}
+
+	u := updaters.NewAutoProductionUpdater(markersRepo, assetsRepo, plansRepo, runsRepo, marketRepo, queueRepo, charRepo, skillsRepo, sdeRepo)
+
+	err := u.RunAll(context.Background())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "auto-production markers")
+}
+
+func Test_AutoProduction_MarkerWithNoPlanIDSkipped(t *testing.T) {
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 100, PlanID: nil, AutoProductionEnabled: true},
+	}
+	u, runsRepo, queueRepo := setupAutoProductionUpdater(
+		markers, nil, nil, 0, nil, nil,
+	)
+
+	err := u.RunAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, runsRepo.createdRuns, 0)
+	assert.Len(t, queueRepo.created, 0)
+}
+
+func Test_AutoProduction_NoDeficitDoesNotCreateRun(t *testing.T) {
+	planID := int64(10)
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 587, PlanID: &planID, AutoProductionEnabled: true, AutoProductionParallelism: 0},
+	}
+
+	// deficit = 0 (StockpileDelta >= 0)
+	deficits := &repositories.StockpilesResponse{
+		Items: []*repositories.StockpileItem{
+			{TypeID: 587, StockpileDelta: 0},
+		},
+	}
+
+	plan := makeMinimalPlan(1, planID)
+	u, runsRepo, queueRepo := setupAutoProductionUpdater(markers, deficits, plan, 0, nil, nil)
+
+	err := u.RunAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, runsRepo.createdRuns, 0)
+	assert.Len(t, queueRepo.created, 0)
+}
+
+func Test_AutoProduction_PendingOutputCoversDeficit(t *testing.T) {
+	planID := int64(11)
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 587, PlanID: &planID, AutoProductionEnabled: true},
+	}
+
+	// gross deficit = 5 (delta = -5)
+	deficits := &repositories.StockpilesResponse{
+		Items: []*repositories.StockpileItem{
+			{TypeID: 587, StockpileDelta: -5},
+		},
+	}
+
+	plan := makeMinimalPlan(1, planID)
+	// pending output >= gross deficit, so net = 0
+	u, runsRepo, queueRepo := setupAutoProductionUpdater(markers, deficits, plan, 10, nil, nil)
+
+	err := u.RunAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, runsRepo.createdRuns, 0)
+	assert.Len(t, queueRepo.created, 0)
+}
+
+func Test_AutoProduction_CreatesRunAndJobsForNetDeficit(t *testing.T) {
+	planID := int64(20)
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 587, PlanID: &planID, AutoProductionEnabled: true, AutoProductionParallelism: 0},
+	}
+
+	// gross deficit = 3 (delta = -3)
+	deficits := &repositories.StockpilesResponse{
+		Items: []*repositories.StockpileItem{
+			{TypeID: 587, StockpileDelta: -3},
+		},
+	}
+
+	plan := makeMinimalPlan(1, planID)
+	// pending output = 0, so net deficit = 3
+	u, runsRepo, queueRepo := setupAutoProductionUpdater(markers, deficits, plan, 0, nil, nil)
+
+	err := u.RunAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, runsRepo.createdRuns, 1)
+	assert.Equal(t, int(3), runsRepo.createdRuns[0].Quantity)
+	assert.Equal(t, planID, runsRepo.createdRuns[0].PlanID)
+	// One merged job for the single-step plan
+	assert.Len(t, queueRepo.created, 1)
+	assert.Equal(t, int64(700), queueRepo.created[0].BlueprintTypeID)
+	assert.Equal(t, "manufacturing", queueRepo.created[0].Activity)
+	assert.Equal(t, 3, queueRepo.created[0].Runs)
+}
+
+func Test_AutoProduction_PartialPendingOutputReducesNetDeficit(t *testing.T) {
+	planID := int64(21)
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 587, PlanID: &planID, AutoProductionEnabled: true, AutoProductionParallelism: 0},
+	}
+
+	// gross deficit = 10
+	deficits := &repositories.StockpilesResponse{
+		Items: []*repositories.StockpileItem{
+			{TypeID: 587, StockpileDelta: -10},
+		},
+	}
+
+	plan := makeMinimalPlan(1, planID)
+	// pending = 6, so net = 4
+	u, runsRepo, queueRepo := setupAutoProductionUpdater(markers, deficits, plan, 6, nil, nil)
+
+	err := u.RunAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, runsRepo.createdRuns, 1)
+	assert.Equal(t, 4, runsRepo.createdRuns[0].Quantity)
+	assert.Len(t, queueRepo.created, 1)
+	assert.Equal(t, 4, queueRepo.created[0].Runs)
+}
+
+func Test_AutoProduction_MultipleTypeIDsInGroupSumsDeficits(t *testing.T) {
+	planID := int64(22)
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 587, PlanID: &planID, AutoProductionEnabled: true, AutoProductionParallelism: 0},
+		{UserID: 1, TypeID: 588, PlanID: &planID, AutoProductionEnabled: true, AutoProductionParallelism: 0},
+	}
+
+	// Both types have deficits
+	deficits := &repositories.StockpilesResponse{
+		Items: []*repositories.StockpileItem{
+			{TypeID: 587, StockpileDelta: -4},
+			{TypeID: 588, StockpileDelta: -6},
+			{TypeID: 999, StockpileDelta: -100}, // unrelated type, should be ignored
+		},
+	}
+
+	plan := makeMinimalPlan(1, planID)
+	u, runsRepo, queueRepo := setupAutoProductionUpdater(markers, deficits, plan, 0, nil, nil)
+
+	err := u.RunAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, runsRepo.createdRuns, 1)
+	// gross = 4 + 6 = 10, pending = 0, net = 10
+	assert.Equal(t, 10, runsRepo.createdRuns[0].Quantity)
+	assert.Len(t, queueRepo.created, 1)
+	assert.Equal(t, 10, queueRepo.created[0].Runs)
+}
+
+func Test_AutoProduction_NilPlanDoesNotCrash(t *testing.T) {
+	planID := int64(30)
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 587, PlanID: &planID, AutoProductionEnabled: true},
+	}
+	deficits := &repositories.StockpilesResponse{
+		Items: []*repositories.StockpileItem{
+			{TypeID: 587, StockpileDelta: -5},
+		},
+	}
+
+	// Plan repo returns nil (plan not found)
+	markersRepo := &mockAutoMarkersRepo{markers: markers}
+	assetsRepo := &mockAutoAssetsRepo{response: deficits}
+	plansRepo := &mockAutoPlansRepo{plan: map[int64]*models.ProductionPlan{}} // empty map = nil returned
+	runsRepo := &mockAutoPlanRunsRepo{}
+	marketRepo := &mockAutoMarketRepo{jitaPrices: map[int64]*models.MarketPrice{}, adjustedPrices: map[int64]float64{}}
+	queueRepo := &mockAutoQueueRepo{}
+	charRepo := &mockAutoCharRepo{names: map[int64]string{}}
+	skillsRepo := &mockAutoSkillsRepo{}
+	sdeRepo := &mockAutoSdeRepo{}
+
+	u := updaters.NewAutoProductionUpdater(markersRepo, assetsRepo, plansRepo, runsRepo, marketRepo, queueRepo, charRepo, skillsRepo, sdeRepo)
+
+	err := u.RunAll(context.Background())
+
+	// Should not error — missing plan is handled gracefully via logging
+	assert.NoError(t, err)
+	assert.Len(t, runsRepo.createdRuns, 0)
+}
+
+func Test_AutoProduction_DeficitsRepoErrorLogsAndContinues(t *testing.T) {
+	planID := int64(31)
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 587, PlanID: &planID, AutoProductionEnabled: true},
+	}
+
+	plan := makeMinimalPlan(1, planID)
+	markersRepo := &mockAutoMarkersRepo{markers: markers}
+	// assets repo returns error
+	assetsRepo := &mockAutoAssetsRepo{err: errors.New("assets db down")}
+	plansMap := map[int64]*models.ProductionPlan{planID: plan}
+	plansRepo := &mockAutoPlansRepo{plan: plansMap}
+	runsRepo := &mockAutoPlanRunsRepo{}
+	marketRepo := &mockAutoMarketRepo{jitaPrices: map[int64]*models.MarketPrice{}, adjustedPrices: map[int64]float64{}}
+	queueRepo := &mockAutoQueueRepo{}
+	charRepo := &mockAutoCharRepo{names: map[int64]string{}}
+	skillsRepo := &mockAutoSkillsRepo{}
+	sdeRepo := &mockAutoSdeRepo{}
+
+	u := updaters.NewAutoProductionUpdater(markersRepo, assetsRepo, plansRepo, runsRepo, marketRepo, queueRepo, charRepo, skillsRepo, sdeRepo)
+
+	err := u.RunAll(context.Background())
+
+	// RunAll logs per-group errors and continues — returns nil
+	assert.NoError(t, err)
+	assert.Len(t, runsRepo.createdRuns, 0)
+}
+
+func Test_AutoProduction_RunCreationErrorLogsAndContinues(t *testing.T) {
+	planID := int64(32)
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 587, PlanID: &planID, AutoProductionEnabled: true, AutoProductionParallelism: 0},
+	}
+	deficits := &repositories.StockpilesResponse{
+		Items: []*repositories.StockpileItem{
+			{TypeID: 587, StockpileDelta: -5},
+		},
+	}
+
+	plan := makeMinimalPlan(1, planID)
+	markersRepo := &mockAutoMarkersRepo{markers: markers}
+	assetsRepo := &mockAutoAssetsRepo{response: deficits}
+	plansRepo := &mockAutoPlansRepo{plan: map[int64]*models.ProductionPlan{planID: plan}}
+	runsRepo := &mockAutoPlanRunsRepo{createErr: errors.New("run create failed")}
+	marketRepo := &mockAutoMarketRepo{jitaPrices: map[int64]*models.MarketPrice{}, adjustedPrices: map[int64]float64{}}
+	queueRepo := &mockAutoQueueRepo{}
+	charRepo := &mockAutoCharRepo{names: map[int64]string{}}
+	skillsRepo := &mockAutoSkillsRepo{}
+	sdeRepo := &mockAutoSdeRepo{
+		blueprint: makeMinimalBlueprint(),
+		materials: []*repositories.ManufacturingMaterialRow{},
+	}
+
+	u := updaters.NewAutoProductionUpdater(markersRepo, assetsRepo, plansRepo, runsRepo, marketRepo, queueRepo, charRepo, skillsRepo, sdeRepo)
+
+	err := u.RunAll(context.Background())
+
+	// RunAll logs per-group errors and continues — returns nil
+	assert.NoError(t, err)
+	assert.Len(t, queueRepo.created, 0)
+}
+
+func Test_AutoProduction_NoteContainsPlanName(t *testing.T) {
+	planID := int64(40)
+	markers := []*models.StockpileMarker{
+		{UserID: 1, TypeID: 587, PlanID: &planID, AutoProductionEnabled: true, AutoProductionParallelism: 0},
+	}
+	deficits := &repositories.StockpilesResponse{
+		Items: []*repositories.StockpileItem{
+			{TypeID: 587, StockpileDelta: -2},
+		},
+	}
+
+	plan := makeMinimalPlan(1, planID)
+	plan.Name = "My Rifter Plan"
+	u, _, queueRepo := setupAutoProductionUpdater(markers, deficits, plan, 0, nil, nil)
+
+	err := u.RunAll(context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, queueRepo.created, 1)
+	assert.NotNil(t, queueRepo.created[0].Notes)
+	assert.Contains(t, *queueRepo.created[0].Notes, "My Rifter Plan")
+}


### PR DESCRIPTION
## Summary
- Stockpile markers can be linked to production plans for automatic restocking via a background runner (default 30min interval)
- Net deficit dedup: subtracts pending/active production output before generating new plan runs
- Max parallelism setting per marker for character slot assignment
- Auto-buy exclusion: markers with auto-production enabled are skipped by auto-buy (no double-sourcing)
- Extracts shared job generation logic into `internal/services/` to avoid circular deps between controllers and updaters
- New `GET /v1/industry/plans/by-product/{typeId}` endpoint for frontend plan selector
- Auto-production UI in both the Add Stockpile and Edit Stockpile dialogs, plus status column on the deficits page

## Test plan
- [x] Backend tests passing (`make test-backend`) — 65.2% coverage
- [x] Frontend tests passing (`make test-frontend`) — 273/273 tests, 50 snapshots
- [x] Production build passing (`make build-production`)
- [x] 30 new unit tests for `internal/services/jobGeneration_test.go`
- [x] Repository tests for new columns and methods
- [x] Updater and runner tests for auto-production logic
- [x] Controller tests for plans-by-product endpoint
- [ ] Manual test: create stockpile marker, link plan, enable auto-production, verify runner generates plan run

🤖 Generated with [Claude Code](https://claude.com/claude-code)