### PR TITLE
Add inventory asset aggregation

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -170,19 +170,22 @@ repo := repositories.NewMyRepo(db)
 
 ### Running tests
 
-- **Full suite**: `make test-backend` (tears down, starts fresh DB, runs everything)
+Tests use **gotestsum** (`pkgname` format) for clean output — shows package-level pass/fail and only prints verbose output for failures. Read the summary at the end rather than scanning the full log.
+
+- **Full suite**: `make test-backend` (tears down, starts fresh DB, runs everything with gotestsum)
 - **Targeted** (faster — prefer when you changed 1-2 packages):
   ```bash
   # Ensure DB is running
   docker-compose -f docker-compose.test.yaml up -d database
   # Run specific package(s)
   docker-compose -f docker-compose.test.yaml run --rm backend-test \
-    go test -v -p 1 ./internal/controllers/
+    gotestsum --format pkgname -- -p 1 ./internal/controllers/
   # Run by test name pattern
   docker-compose -f docker-compose.test.yaml run --rm backend-test \
-    go test -v -p 1 -run "Test_ProductionPlans" ./internal/controllers/
+    gotestsum --format pkgname -- -p 1 -run "Test_ProductionPlans" ./internal/controllers/
   ```
 - Use targeted tests during development; use full `make test-backend` for final verification
+- When a test fails, gotestsum prints the full failure output — read the FAIL lines at the bottom first
 
 ## Key Relationships
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Test binary, built with `go test -c`
 *.test
+!Dockerfile.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,3 @@
+FROM golang:1.25
+
+RUN go install gotest.tools/gotestsum@latest

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,6 +1,8 @@
 services:
   backend-test:
-    image: golang:1.25
+    build:
+      context: .
+      dockerfile: Dockerfile.test
     volumes:
       - ./artifacts:/artifacts
       - .:/app

--- a/docs/features/asset-aggregation.md
+++ b/docs/features/asset-aggregation.md
@@ -1,0 +1,42 @@
+# Asset Aggregation
+
+## Overview
+Inventory items of the same type are aggregated (stacked) within each scope — hangar, container, delivery, asset safety, or corp division. Multiple ESI item stacks of the same `type_id` from the same owner at the same location are collapsed into a single row with summed quantities, volumes, and values.
+
+## Status
+- **Phase 1**: Backend SQL aggregation — COMPLETE
+
+## Key Decisions
+- Aggregation is done at the SQL level via `GROUP BY type_id` (not in Go or frontend)
+- No model changes required — the `Asset` struct already has no `ItemID` field
+- No frontend changes required — the UI renders whatever asset rows it receives
+- Stockpile markers still work correctly since they're keyed by `(type_id, owner_id, location_id, container_id, division_number)` which matches the GROUP BY grouping
+- `InjectOrphanStockpileRows()` requires no changes since it keys on `{typeID, ownerID, locationID, containerID, divisionNumber}`
+
+## Implementation
+
+### Modified Queries in `internal/repositories/assets.go`
+
+Four SQL queries were updated with `GROUP BY` + `SUM()`:
+
+1. **`hangaredItemsQuery`** — character hangar/deliveries/asset safety items
+2. **`itemsInContainersQuery`** — items inside character containers
+3. **`corpHangaredItemsQuery`** — corporation division items
+4. **`corpItemsInContainersQuery`** — items inside corporation containers
+
+Each query changed:
+- `quantity` → `SUM(quantity)`
+- `volume * quantity` → `SUM(volume * quantity)`
+- `stockpile_delta` and `deficit_value` recalculated using `SUM(quantity)`
+- Added `GROUP BY` on all non-aggregated columns
+- Replaced `ORDER BY item_id` with `ORDER BY type_name` where applicable
+
+### Files Modified
+- `internal/repositories/assets.go` — 4 SQL queries
+- `internal/repositories/assets_test.go` — 4 new test cases
+
+### Tests
+- `Test_AssetsShouldAggregateMultipleStacksInHangar`
+- `Test_AssetsShouldAggregateMultipleStacksInContainers`
+- `Test_AssetsShouldAggregateCorpDivisionItems`
+- `Test_AggregatedAssetsWithStockpileMarkers`

--- a/makefile
+++ b/makefile
@@ -56,14 +56,14 @@ test-backend: test-clean
 	@echo "Running backend tests with coverage..."
 	@mkdir -p artifacts/coverage/backend
 	$(DOCKER_COMPOSE) -f docker-compose.test.yaml run --rm backend-test \
-		sh -c "go test -v -p 1 -coverprofile=/artifacts/coverage/backend/coverage.out ./internal/... && \
+		sh -c "gotestsum --format pkgname -- -p 1 -coverprofile=/artifacts/coverage/backend/coverage.out ./internal/... && \
 		       go tool cover -html=/artifacts/coverage/backend/coverage.out -o /artifacts/coverage/backend/coverage.html"
 	@echo "✓ Backend coverage report: artifacts/coverage/backend/coverage.html"
 
 test-backend-sde-integration:
 	@echo "Running SDE integration test (downloads real SDE from CCP)..."
 	$(DOCKER_COMPOSE) -f docker-compose.test.yaml run --rm backend-test \
-		sh -c "SDE_INTEGRATION_TEST=1 go test -v -run Test_SdeClient_Integration -timeout 300s ./internal/client/"
+		sh -c "SDE_INTEGRATION_TEST=1 gotestsum --format pkgname -- -run Test_SdeClient_Integration -timeout 300s ./internal/client/"
 	@echo "✓ SDE integration test passed"
 
 test-frontend: test-clean


### PR DESCRIPTION
## Summary
- Aggregate same-type items within each container/hangar/division into single rows with summed quantity, volume, and value using SQL `GROUP BY` — replaces per-stack view
- Add gotestsum for cleaner Go test output, installed in Docker test container via `Dockerfile.test`

## Changes
- **`internal/repositories/assets.go`** — 4 SQL queries updated with `GROUP BY` + `SUM()` for quantity, volume, value, and stockpile delta
- **`internal/repositories/assets_test.go`** — 4 new aggregation tests + 1 ordering fix for alphabetical `ORDER BY`
- **`docs/features/asset-aggregation.md`** — Feature documentation
- **`Dockerfile.test`** — New test container with gotestsum pre-installed
- **`docker-compose.test.yaml`** — Build from `Dockerfile.test` instead of base Go image
- **`makefile`** — Use `gotestsum --format pkgname` in test targets
- **`.gitignore`** — Add `!Dockerfile.test` exception for `*.test` rule
- **`.claude/agents/backend-dev.md`** — Document gotestsum usage

## Test plan
- [x] All 1038 backend tests pass with gotestsum output
- [x] Production build passes (`make build-production`)
- [ ] Manual verification: inventory page shows aggregated rows instead of duplicate stacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)