### PR TITLE
Add dynamic mock ESI admin API and E2E tests for all untested features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,13 @@
 2. **Always run tests with Makefile targets** (`make test-e2e-ci`, `make test-backend`, etc.) — never run test commands directly.
 3. **Write tests for every new backend file.** Every new repository, controller, and updater must have a corresponding `_test.go` file. When asked to "write tests," cover all three layers — not just controllers and updaters.
 4. **All changes must have tests.** Every code change — bug fixes, new features, refactors — must include corresponding test coverage. No code changes without tests.
-5. **Create/update feature docs in `docs/features/{category}/`** for every new feature or significant change. Use `lowercase-kebab-case.md` naming. Categories: `core/`, `market/`, `social/`, `trading/`, `industry/`, `infrastructure/`. Agent docs go in `docs/agents/`. Spawn the `docs` agent to create docs and update `docs/features/INDEX.md`.
-6. **Go slices: initialize as `items := []*Type{}` NOT `var items []*Type`.** Prevents nil JSON marshaling (`null` instead of `[]`).
-7. **Do NOT include Discord usernames or other personal attributions in GitHub issues.**
-8. **Check feature docs first.** Before exploring code or planning a feature, check `docs/features/INDEX.md` to find the relevant doc. Feature docs contain schema, API, key decisions, and file paths — use them as the starting point.
-9. Always use the executor sub-agent for bash commands instead of running them directly.
-10. **Delegate all implementation work to domain agents.** Never write Go, SQL, or migration code directly — use the `backend-dev` agent. Never write React, TypeScript, or MUI code directly — use the `frontend-dev` agent. Never write Playwright tests, mock ESI code, or E2E seed data directly — use the `sdet` agent. **For database schema design, migration review, or query optimization, spawn the `dba` agent first** — it provides schema context, migration drafts, and optimization recommendations before backend-dev implements. The main thread plans and orchestrates; agents execute. For cross-cutting tasks (e.g., new API endpoint), spawn both backend and frontend agents.
+5. **Frontend-touching features require E2E tests.** Any new page, UI feature, or user-facing workflow change must include E2E test coverage. Spawn the `sdet` agent for test files. Use the mock ESI admin API (`e2e/helpers/mock-esi.ts`) when tests need to control ESI responses at runtime.
+6. **Create/update feature docs in `docs/features/{category}/`** for every new feature or significant change. Use `lowercase-kebab-case.md` naming. Categories: `core/`, `market/`, `social/`, `trading/`, `industry/`, `infrastructure/`. Agent docs go in `docs/agents/`. Spawn the `docs` agent to create docs and update `docs/features/INDEX.md`.
+7. **Go slices: initialize as `items := []*Type{}` NOT `var items []*Type`.** Prevents nil JSON marshaling (`null` instead of `[]`).
+8. **Do NOT include Discord usernames or other personal attributions in GitHub issues.**
+9. **Check feature docs first.** Before exploring code or planning a feature, check `docs/features/INDEX.md` to find the relevant doc. Feature docs contain schema, API, key decisions, and file paths — use them as the starting point.
+10. Always use the executor sub-agent for bash commands instead of running them directly.
+11. **Delegate all implementation work to domain agents.** Never write Go, SQL, or migration code directly — use the `backend-dev` agent. Never write React, TypeScript, or MUI code directly — use the `frontend-dev` agent. Never write Playwright tests, mock ESI code, or E2E seed data directly — use the `sdet` agent. **For database schema design, migration review, or query optimization, spawn the `dba` agent first** — it provides schema context, migration drafts, and optimization recommendations before backend-dev implements. The main thread plans and orchestrates; agents execute. For cross-cutting tasks (e.g., new API endpoint), spawn both backend and frontend agents.
 
 ---
 
@@ -63,6 +64,15 @@ This catches issues like untyped arrays (`const x = []` → `never[]`) that pass
 3. backend-dev implements/updates repository methods and tests
 4. Restart server to auto-apply migration
 5. Spawn `dba` to update `docs/database-schema.md`
+
+### Add New Frontend Feature
+
+1. Implement the feature (frontend-dev, backend-dev agents)
+2. If feature uses ESI data not yet mocked → update `cmd/mock-esi/main.go` (backend-dev agent)
+3. If feature needs new seed data → update `e2e/seed.sql` (sdet agent)
+4. Write E2E tests in `e2e/tests/NN-feature.spec.ts` (sdet agent)
+5. Run `make test-e2e` to verify all tests pass
+6. Update feature docs (docs agent)
 
 ---
 

--- a/cmd/mock-esi/main.go
+++ b/cmd/mock-esi/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 type asset struct {
@@ -65,82 +66,6 @@ type marketOrder struct {
 	Range        string  `json:"range"`
 }
 
-// Character assets keyed by character ID
-var characterAssets = map[int64][]asset{
-	// Alice Alpha — assets in Jita
-	2001001: {
-		{ItemID: 100001, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 50000, TypeID: 34},  // Tritanium
-		{ItemID: 100002, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 25000, TypeID: 35},  // Pyerite
-		{ItemID: 100003, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 10000, TypeID: 36},  // Mexallon
-		{ItemID: 100004, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 1, TypeID: 11399, IsSingleton: true},    // Raven Navy Issue
-		{ItemID: 100010, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 1, TypeID: 9999001, IsSingleton: true}, // Container
-		{ItemID: 100011, LocationFlag: "Hangar", LocationID: 100010, LocationType: "item", Quantity: 5000, TypeID: 37},        // Isogen in container
-	},
-	// Alice Beta — assets in Amarr
-	2001002: {
-		{ItemID: 110001, LocationFlag: "Hangar", LocationID: 60008494, LocationType: "station", Quantity: 3, TypeID: 587, IsSingleton: true},  // Rifter
-		{ItemID: 110002, LocationFlag: "Hangar", LocationID: 60008494, LocationType: "station", Quantity: 5000, TypeID: 38},   // Nocxium
-	},
-	// Bob Bravo — assets in Jita
-	2002001: {
-		{ItemID: 200001, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 30000, TypeID: 34},  // Tritanium
-		{ItemID: 200002, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 10, TypeID: 587, IsSingleton: true},     // Rifter
-	},
-	// Charlie Charlie — assets in Jita
-	2003001: {
-		{ItemID: 300001, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 1000, TypeID: 35},   // Pyerite
-	},
-	// Diana Delta — assets in Amarr
-	2004001: {
-		{ItemID: 400001, LocationFlag: "Hangar", LocationID: 60008494, LocationType: "station", Quantity: 15000, TypeID: 34},  // Tritanium
-	},
-}
-
-// Character asset names (container names)
-var characterNames = map[int64][]nameEntry{
-	2001001: {
-		{ItemID: 100010, Name: "Minerals Box"},
-	},
-}
-
-// Corporation assets keyed by corp ID
-var corpAssets = map[int64][]asset{
-	3001001: { // Stargazer Industries
-		{ItemID: 500000, LocationFlag: "OfficeFolder", LocationID: 60003760, LocationType: "item", Quantity: 1, TypeID: 27, IsSingleton: true}, // Office
-		{ItemID: 500001, LocationFlag: "CorpSAG1", LocationID: 500000, LocationType: "item", Quantity: 100000, TypeID: 34},                    // Tritanium
-		{ItemID: 500002, LocationFlag: "CorpSAG2", LocationID: 500000, LocationType: "item", Quantity: 5, TypeID: 587, IsSingleton: true},      // Rifter
-	},
-}
-
-var corpDivisions = map[int64]divisionsResponse{
-	3001001: {
-		Hangar: []divisionEntry{
-			{Division: 1, Name: "Main Hangar"},
-			{Division: 2, Name: "Production Materials"},
-		},
-		Wallet: []divisionEntry{
-			{Division: 1, Name: "Master Wallet"},
-		},
-	},
-}
-
-// Character to corporation mapping
-var charToCorp = map[int64]int64{
-	2001001: 3001001,
-	2001002: 3001001,
-	2002001: 3002001,
-	2003001: 3003001,
-	2004001: 3004001,
-}
-
-var corpNames = map[int64]string{
-	3001001: "Stargazer Industries",
-	3002001: "Bob's Mining Co",
-	3003001: "Charlie Trade Corp",
-	3004001: "Scout Fleet",
-}
-
-// Character skills keyed by character ID
 type skillEntry struct {
 	SkillID            int64 `json:"skill_id"`
 	TrainedSkillLevel  int   `json:"trained_skill_level"`
@@ -153,24 +78,6 @@ type skillsResponse struct {
 	TotalSP int64        `json:"total_sp"`
 }
 
-var characterSkills = map[int64]skillsResponse{
-	2001001: {
-		Skills: []skillEntry{
-			{SkillID: 3380, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},  // Industry
-			{SkillID: 3388, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},  // Advanced Industry
-			{SkillID: 45746, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 45255},  // Reactions
-		},
-		TotalSP: 5000000,
-	},
-	2002001: {
-		Skills: []skillEntry{
-			{SkillID: 3380, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 45255},
-		},
-		TotalSP: 2000000,
-	},
-}
-
-// Character industry jobs
 type industryJob struct {
 	JobID               int64   `json:"job_id"`
 	InstallerID         int64   `json:"installer_id"`
@@ -201,68 +108,257 @@ type blueprintEntry struct {
 	Runs               int    `json:"runs"`
 }
 
-// Character blueprints keyed by character ID
-var characterBlueprints = map[int64][]blueprintEntry{
-	// Alice Alpha — a BPO ME10 and a BPC ME8
-	2001001: {
-		{ItemID: 700001, TypeID: 787, LocationID: 60003760, LocationFlag: "Hangar", Quantity: -1, MaterialEfficiency: 10, TimeEfficiency: 20, Runs: -1},
-		{ItemID: 700002, TypeID: 46166, LocationID: 60003760, LocationFlag: "Hangar", Quantity: -2, MaterialEfficiency: 8, TimeEfficiency: 16, Runs: 50},
-	},
-	// Bob Bravo — a BPO ME8
-	2002001: {
-		{ItemID: 700003, TypeID: 787, LocationID: 60003760, LocationFlag: "Hangar", Quantity: -1, MaterialEfficiency: 8, TimeEfficiency: 16, Runs: -1},
-	},
+type knownNameEntry struct {
+	Name     string
+	Category string
 }
 
-// Corporation blueprints keyed by corp ID
-var corpBlueprints = map[int64][]blueprintEntry{
-	3001001: {
-		{ItemID: 710001, TypeID: 787, LocationID: 60003760, LocationFlag: "CorpSAG1", Quantity: -1, MaterialEfficiency: 9, TimeEfficiency: 18, Runs: -1},
-	},
+// PI types
+
+type piPlanet struct {
+	LastUpdate    string `json:"last_update"`
+	NumPins       int    `json:"num_pins"`
+	OwnerID       int64  `json:"owner_id"`
+	PlanetID      int64  `json:"planet_id"`
+	PlanetType    string `json:"planet_type"`
+	SolarSystemID int64  `json:"solar_system_id"`
+	UpgradeLevel  int    `json:"upgrade_level"`
 }
 
-var characterIndustryJobs = map[int64][]industryJob{
-	2001001: {
-		{
-			JobID: 500001, InstallerID: 2001001, FacilityID: 60003760, StationID: 60003760,
-			ActivityID: 1, BlueprintID: 9876, BlueprintTypeID: 787,
-			BlueprintLocationID: 60003760, OutputLocationID: 60003760,
-			Runs: 10, Cost: 1500000, ProductTypeID: 587, Status: "active",
-			Duration: 3600, StartDate: "2026-02-22T00:00:00Z", EndDate: "2026-02-22T01:00:00Z",
+type piPinContent struct {
+	Amount float64 `json:"amount"`
+	TypeID int64   `json:"type_id"`
+}
+
+type piExtractorDetail struct {
+	CycleTime     int   `json:"cycle_time"`
+	HeadRadius    float64 `json:"head_radius"`
+	Heads         []struct{} `json:"heads"`
+	ProductTypeID int64 `json:"product_type_id"`
+	QtyPerCycle   int   `json:"qty_per_cycle"`
+}
+
+type piFactoryDetail struct {
+	SchematicID int `json:"schematic_id"`
+}
+
+type piPin struct {
+	PinID            int64              `json:"pin_id"`
+	TypeID           int64              `json:"type_id"`
+	Latitude         float64            `json:"latitude"`
+	Longitude        float64            `json:"longitude"`
+	InstallTime      *string            `json:"install_time,omitempty"`
+	ExpiryTime       *string            `json:"expiry_time,omitempty"`
+	LastCycleStart   *string            `json:"last_cycle_start,omitempty"`
+	SchematicID      *int               `json:"schematic_id,omitempty"`
+	Contents         []piPinContent     `json:"contents"`
+	ExtractorDetails *piExtractorDetail `json:"extractor_details,omitempty"`
+	FactoryDetails   *piFactoryDetail   `json:"factory_details,omitempty"`
+}
+
+type piLink struct {
+	SourcePinID      int64 `json:"source_pin_id"`
+	DestinationPinID int64 `json:"destination_pin_id"`
+	LinkLevel        int   `json:"link_level"`
+}
+
+type piRoute struct {
+	RouteID          int64   `json:"route_id"`
+	SourcePinID      int64   `json:"source_pin_id"`
+	DestinationPinID int64   `json:"destination_pin_id"`
+	ContentTypeID    int64   `json:"content_type_id"`
+	Quantity         float64 `json:"quantity"`
+	Waypoints        []int64 `json:"waypoints"`
+}
+
+type piColony struct {
+	Links  []piLink  `json:"links"`
+	Pins   []piPin   `json:"pins"`
+	Routes []piRoute `json:"routes"`
+}
+
+// State holds all mock ESI data behind a RWMutex for concurrent access safety.
+// The backend fetches multiple characters in parallel, so reads must be protected.
+type State struct {
+	mu                    sync.RWMutex
+	characterAssets       map[int64][]asset
+	characterNames        map[int64][]nameEntry
+	corpAssets            map[int64][]asset
+	corpDivisions         map[int64]divisionsResponse
+	charToCorp            map[int64]int64
+	corpNames             map[int64]string
+	characterSkills       map[int64]skillsResponse
+	characterIndustryJobs map[int64][]industryJob
+	characterBlueprints   map[int64][]blueprintEntry
+	corpBlueprints        map[int64][]blueprintEntry
+	marketOrders          []marketOrder
+	knownNames            map[int64]knownNameEntry
+	characterPlanets      map[int64][]piPlanet
+	planetDetails         map[string]piColony
+}
+
+// newDefaultState returns a fresh State populated with the standard E2E test fixtures.
+func newDefaultState() *State {
+	return &State{
+		characterAssets: map[int64][]asset{
+			// Alice Alpha — assets in Jita
+			2001001: {
+				{ItemID: 100001, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 50000, TypeID: 34},  // Tritanium
+				{ItemID: 100002, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 25000, TypeID: 35},  // Pyerite
+				{ItemID: 100003, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 10000, TypeID: 36},  // Mexallon
+				{ItemID: 100004, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 1, TypeID: 11399, IsSingleton: true},    // Raven Navy Issue
+				{ItemID: 100010, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 1, TypeID: 9999001, IsSingleton: true}, // Container
+				{ItemID: 100011, LocationFlag: "Hangar", LocationID: 100010, LocationType: "item", Quantity: 5000, TypeID: 37},        // Isogen in container
+			},
+			// Alice Beta — assets in Amarr
+			2001002: {
+				{ItemID: 110001, LocationFlag: "Hangar", LocationID: 60008494, LocationType: "station", Quantity: 3, TypeID: 587, IsSingleton: true},  // Rifter
+				{ItemID: 110002, LocationFlag: "Hangar", LocationID: 60008494, LocationType: "station", Quantity: 5000, TypeID: 38},   // Nocxium
+			},
+			// Bob Bravo — assets in Jita
+			2002001: {
+				{ItemID: 200001, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 30000, TypeID: 34},  // Tritanium
+				{ItemID: 200002, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 10, TypeID: 587, IsSingleton: true},     // Rifter
+			},
+			// Charlie Charlie — assets in Jita
+			2003001: {
+				{ItemID: 300001, LocationFlag: "Hangar", LocationID: 60003760, LocationType: "station", Quantity: 1000, TypeID: 35},   // Pyerite
+			},
+			// Diana Delta — assets in Amarr
+			2004001: {
+				{ItemID: 400001, LocationFlag: "Hangar", LocationID: 60008494, LocationType: "station", Quantity: 15000, TypeID: 34},  // Tritanium
+			},
 		},
-	},
-}
-
-var marketOrders = []marketOrder{
-	// Tritanium sell
-	{OrderID: 1, TypeID: 34, LocationID: 60003760, VolumeTotal: 10000000, VolumeRemain: 5000000, MinVolume: 1, Price: 6.00, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
-	// Tritanium buy
-	{OrderID: 2, TypeID: 34, LocationID: 60003760, VolumeTotal: 10000000, VolumeRemain: 5000000, MinVolume: 1, Price: 5.50, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
-	// Pyerite sell
-	{OrderID: 3, TypeID: 35, LocationID: 60003760, VolumeTotal: 5000000, VolumeRemain: 2000000, MinVolume: 1, Price: 11.50, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
-	// Pyerite buy
-	{OrderID: 4, TypeID: 35, LocationID: 60003760, VolumeTotal: 5000000, VolumeRemain: 2000000, MinVolume: 1, Price: 10.00, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
-	// Mexallon sell
-	{OrderID: 5, TypeID: 36, LocationID: 60003760, VolumeTotal: 1000000, VolumeRemain: 500000, MinVolume: 1, Price: 75.00, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
-	// Mexallon buy
-	{OrderID: 6, TypeID: 36, LocationID: 60003760, VolumeTotal: 1000000, VolumeRemain: 500000, MinVolume: 1, Price: 70.00, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
-	// Isogen sell
-	{OrderID: 11, TypeID: 37, LocationID: 60003760, VolumeTotal: 500000, VolumeRemain: 200000, MinVolume: 1, Price: 55.00, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
-	// Isogen buy
-	{OrderID: 12, TypeID: 37, LocationID: 60003760, VolumeTotal: 500000, VolumeRemain: 200000, MinVolume: 1, Price: 50.00, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
-	// Rifter sell
-	{OrderID: 7, TypeID: 587, LocationID: 60003760, VolumeTotal: 100, VolumeRemain: 50, MinVolume: 1, Price: 600000, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
-	// Rifter buy
-	{OrderID: 8, TypeID: 587, LocationID: 60003760, VolumeTotal: 100, VolumeRemain: 50, MinVolume: 1, Price: 500000, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
-	// Raven Navy Issue sell
-	{OrderID: 9, TypeID: 11399, LocationID: 60003760, VolumeTotal: 10, VolumeRemain: 5, MinVolume: 1, Price: 520000000, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
-	// Raven Navy Issue buy
-	{OrderID: 10, TypeID: 11399, LocationID: 60003760, VolumeTotal: 10, VolumeRemain: 5, MinVolume: 1, Price: 500000000, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
+		characterNames: map[int64][]nameEntry{
+			2001001: {
+				{ItemID: 100010, Name: "Minerals Box"},
+			},
+		},
+		corpAssets: map[int64][]asset{
+			3001001: { // Stargazer Industries
+				{ItemID: 500000, LocationFlag: "OfficeFolder", LocationID: 60003760, LocationType: "item", Quantity: 1, TypeID: 27, IsSingleton: true}, // Office
+				{ItemID: 500001, LocationFlag: "CorpSAG1", LocationID: 500000, LocationType: "item", Quantity: 100000, TypeID: 34},                    // Tritanium
+				{ItemID: 500002, LocationFlag: "CorpSAG2", LocationID: 500000, LocationType: "item", Quantity: 5, TypeID: 587, IsSingleton: true},      // Rifter
+			},
+		},
+		corpDivisions: map[int64]divisionsResponse{
+			3001001: {
+				Hangar: []divisionEntry{
+					{Division: 1, Name: "Main Hangar"},
+					{Division: 2, Name: "Production Materials"},
+				},
+				Wallet: []divisionEntry{
+					{Division: 1, Name: "Master Wallet"},
+				},
+			},
+		},
+		charToCorp: map[int64]int64{
+			2001001: 3001001,
+			2001002: 3001001,
+			2002001: 3002001,
+			2003001: 3003001,
+			2004001: 3004001,
+		},
+		corpNames: map[int64]string{
+			3001001: "Stargazer Industries",
+			3002001: "Bob's Mining Co",
+			3003001: "Charlie Trade Corp",
+			3004001: "Scout Fleet",
+		},
+		characterSkills: map[int64]skillsResponse{
+			2001001: {
+				Skills: []skillEntry{
+					{SkillID: 3380, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},  // Industry
+					{SkillID: 3388, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},  // Advanced Industry
+					{SkillID: 45746, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 45255},  // Reactions
+				},
+				TotalSP: 5000000,
+			},
+			2002001: {
+				Skills: []skillEntry{
+					{SkillID: 3380, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 45255},
+				},
+				TotalSP: 2000000,
+			},
+		},
+		characterIndustryJobs: map[int64][]industryJob{
+			2001001: {
+				{
+					JobID: 500001, InstallerID: 2001001, FacilityID: 60003760, StationID: 60003760,
+					ActivityID: 1, BlueprintID: 9876, BlueprintTypeID: 787,
+					BlueprintLocationID: 60003760, OutputLocationID: 60003760,
+					Runs: 10, Cost: 1500000, ProductTypeID: 587, Status: "active",
+					Duration: 3600, StartDate: "2026-02-22T00:00:00Z", EndDate: "2026-02-22T01:00:00Z",
+				},
+			},
+		},
+		characterBlueprints: map[int64][]blueprintEntry{
+			// Alice Alpha — a BPO ME10 and a BPC ME8
+			2001001: {
+				{ItemID: 700001, TypeID: 787, LocationID: 60003760, LocationFlag: "Hangar", Quantity: -1, MaterialEfficiency: 10, TimeEfficiency: 20, Runs: -1},
+				{ItemID: 700002, TypeID: 46166, LocationID: 60003760, LocationFlag: "Hangar", Quantity: -2, MaterialEfficiency: 8, TimeEfficiency: 16, Runs: 50},
+			},
+			// Bob Bravo — a BPO ME8
+			2002001: {
+				{ItemID: 700003, TypeID: 787, LocationID: 60003760, LocationFlag: "Hangar", Quantity: -1, MaterialEfficiency: 8, TimeEfficiency: 16, Runs: -1},
+			},
+		},
+		corpBlueprints: map[int64][]blueprintEntry{
+			3001001: {
+				{ItemID: 710001, TypeID: 787, LocationID: 60003760, LocationFlag: "CorpSAG1", Quantity: -1, MaterialEfficiency: 9, TimeEfficiency: 18, Runs: -1},
+			},
+		},
+		marketOrders: []marketOrder{
+			// Tritanium sell
+			{OrderID: 1, TypeID: 34, LocationID: 60003760, VolumeTotal: 10000000, VolumeRemain: 5000000, MinVolume: 1, Price: 6.00, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+			// Tritanium buy
+			{OrderID: 2, TypeID: 34, LocationID: 60003760, VolumeTotal: 10000000, VolumeRemain: 5000000, MinVolume: 1, Price: 5.50, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+			// Pyerite sell
+			{OrderID: 3, TypeID: 35, LocationID: 60003760, VolumeTotal: 5000000, VolumeRemain: 2000000, MinVolume: 1, Price: 11.50, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+			// Pyerite buy
+			{OrderID: 4, TypeID: 35, LocationID: 60003760, VolumeTotal: 5000000, VolumeRemain: 2000000, MinVolume: 1, Price: 10.00, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+			// Mexallon sell
+			{OrderID: 5, TypeID: 36, LocationID: 60003760, VolumeTotal: 1000000, VolumeRemain: 500000, MinVolume: 1, Price: 75.00, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+			// Mexallon buy
+			{OrderID: 6, TypeID: 36, LocationID: 60003760, VolumeTotal: 1000000, VolumeRemain: 500000, MinVolume: 1, Price: 70.00, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+			// Isogen sell
+			{OrderID: 11, TypeID: 37, LocationID: 60003760, VolumeTotal: 500000, VolumeRemain: 200000, MinVolume: 1, Price: 55.00, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+			// Isogen buy
+			{OrderID: 12, TypeID: 37, LocationID: 60003760, VolumeTotal: 500000, VolumeRemain: 200000, MinVolume: 1, Price: 50.00, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "station"},
+			// Rifter sell
+			{OrderID: 7, TypeID: 587, LocationID: 60003760, VolumeTotal: 100, VolumeRemain: 50, MinVolume: 1, Price: 600000, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
+			// Rifter buy
+			{OrderID: 8, TypeID: 587, LocationID: 60003760, VolumeTotal: 100, VolumeRemain: 50, MinVolume: 1, Price: 500000, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
+			// Raven Navy Issue sell
+			{OrderID: 9, TypeID: 11399, LocationID: 60003760, VolumeTotal: 10, VolumeRemain: 5, MinVolume: 1, Price: 520000000, IsBuyOrder: false, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
+			// Raven Navy Issue buy
+			{OrderID: 10, TypeID: 11399, LocationID: 60003760, VolumeTotal: 10, VolumeRemain: 5, MinVolume: 1, Price: 500000000, IsBuyOrder: true, Duration: 90, Issued: "2025-01-01T00:00:00Z", Range: "region"},
+		},
+		knownNames: map[int64]knownNameEntry{
+			60003760: {Name: "Jita IV - Moon 4 - Caldari Navy Assembly Plant", Category: "station"},
+			60008494: {Name: "Amarr VIII (Oris) - Emperor Family Academy", Category: "station"},
+		},
+		// PI data — empty by default; tests inject via admin API
+		characterPlanets: map[int64][]piPlanet{},
+		planetDetails:    map[string]piColony{},
+	}
 }
 
 func writeJSON(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(data)
+}
+
+func writeAdminOK(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"ok"}`))
+}
+
+func writeAdminError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, `{"error":%q}`, msg)
 }
 
 func extractID(path, prefix, suffix string) (int64, bool) {
@@ -289,14 +385,20 @@ func main() {
 		port = "8090"
 	}
 
+	state := newDefaultState()
+
 	mux := http.NewServeMux()
 
-	// GET /characters/{id}/assets
+	// GET /characters/{id}/assets (and other character endpoints)
 	mux.HandleFunc("/characters/", func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
 		// POST /characters/affiliation
 		if strings.HasSuffix(path, "/affiliation") && r.Method == "POST" {
+			state.mu.RLock()
+			charToCorp := state.charToCorp
+			state.mu.RUnlock()
+
 			var charIDs []int64
 			json.NewDecoder(r.Body).Decode(&charIDs)
 			result := []affiliation{}
@@ -318,7 +420,9 @@ func main() {
 				http.Error(w, "invalid character id", 400)
 				return
 			}
-			names, ok := characterNames[charID]
+			state.mu.RLock()
+			names, ok := state.characterNames[charID]
+			state.mu.RUnlock()
 			if !ok {
 				names = []nameEntry{}
 			}
@@ -333,7 +437,9 @@ func main() {
 				http.Error(w, "invalid character id", 400)
 				return
 			}
-			assets, ok := characterAssets[charID]
+			state.mu.RLock()
+			assets, ok := state.characterAssets[charID]
+			state.mu.RUnlock()
 			if !ok {
 				assets = []asset{}
 			}
@@ -349,7 +455,9 @@ func main() {
 				http.Error(w, "invalid character id", 400)
 				return
 			}
-			skills, ok := characterSkills[charID]
+			state.mu.RLock()
+			skills, ok := state.characterSkills[charID]
+			state.mu.RUnlock()
 			if !ok {
 				skills = skillsResponse{Skills: []skillEntry{}, TotalSP: 0}
 			}
@@ -364,7 +472,9 @@ func main() {
 				http.Error(w, "invalid character id", 400)
 				return
 			}
-			jobs, ok := characterIndustryJobs[charID]
+			state.mu.RLock()
+			jobs, ok := state.characterIndustryJobs[charID]
+			state.mu.RUnlock()
 			if !ok {
 				jobs = []industryJob{}
 			}
@@ -380,7 +490,9 @@ func main() {
 				http.Error(w, "invalid character id", 400)
 				return
 			}
-			bps, ok := characterBlueprints[charID]
+			state.mu.RLock()
+			bps, ok := state.characterBlueprints[charID]
+			state.mu.RUnlock()
 			if !ok {
 				bps = []blueprintEntry{}
 			}
@@ -391,6 +503,163 @@ func main() {
 
 		http.Error(w, "not found", 404)
 	})
+
+	// Versioned character endpoints (v1, v3, v4) — ESI uses version-prefixed URLs for
+	// some endpoints (e.g. /v1/characters/{id}/planets/, /v3/characters/{id}/planets/{id}/,
+	// /v4/characters/{id}/skills/, /v3/characters/{id}/blueprints/).
+	// Go's ServeMux prefix matching requires separate handlers for these paths.
+
+	// handleVersionedCharacter parses versioned character paths and dispatches to state.
+	handleVersionedCharacter := func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		// Normalise: strip the version prefix (/v1/, /v3/, /v4/, etc.)
+		// e.g. /v1/characters/2001001/planets/ → /characters/2001001/planets/
+		//       /v3/characters/2001001/planets/40000001/ → /characters/2001001/planets/40000001/
+		// path[1:] strips leading slash; find the first '/' in the remainder to skip "v1", "v3", etc.
+		normPath := path
+		if rest1 := path[1:]; len(rest1) > 0 {
+			if idx := strings.Index(rest1, "/"); idx != -1 {
+				// idx is the position of the slash after the version segment
+				// normPath should start from that slash
+				normPath = rest1[idx:]
+			}
+		}
+		// normPath is now /characters/2001001/planets/ etc.
+		// Strip any trailing slash and query string for extractID compatibility
+		normPathClean := strings.TrimRight(strings.SplitN(normPath, "?", 2)[0], "/")
+
+		// GET /characters/{id}/skills  (v4)
+		if strings.Contains(normPath, "/skills") && r.Method == "GET" {
+			charID, ok := extractID(normPathClean, "/characters/", "/skills")
+			if !ok {
+				http.Error(w, "invalid character id", 400)
+				return
+			}
+			state.mu.RLock()
+			skills, ok := state.characterSkills[charID]
+			state.mu.RUnlock()
+			if !ok {
+				skills = skillsResponse{Skills: []skillEntry{}, TotalSP: 0}
+			}
+			writeJSON(w, skills)
+			return
+		}
+
+		// GET /characters/{id}/industry/jobs  (v1)
+		if strings.Contains(normPath, "/industry/jobs") && r.Method == "GET" {
+			charID, ok := extractID(normPathClean, "/characters/", "/industry/jobs")
+			if !ok {
+				http.Error(w, "invalid character id", 400)
+				return
+			}
+			state.mu.RLock()
+			jobs, ok := state.characterIndustryJobs[charID]
+			state.mu.RUnlock()
+			if !ok {
+				jobs = []industryJob{}
+			}
+			w.Header().Set("X-Pages", "1")
+			writeJSON(w, jobs)
+			return
+		}
+
+		// GET /characters/{id}/blueprints  (v3)
+		if strings.Contains(normPath, "/blueprints") && r.Method == "GET" {
+			charID, ok := extractID(normPathClean, "/characters/", "/blueprints")
+			if !ok {
+				http.Error(w, "invalid character id", 400)
+				return
+			}
+			state.mu.RLock()
+			bps, ok := state.characterBlueprints[charID]
+			state.mu.RUnlock()
+			if !ok {
+				bps = []blueprintEntry{}
+			}
+			w.Header().Set("X-Pages", "1")
+			writeJSON(w, bps)
+			return
+		}
+
+		// GET /characters/{id}/contracts  (v1)
+		if strings.Contains(normPath, "/contracts") && r.Method == "GET" {
+			// No contracts in test data — return empty paginated list
+			w.Header().Set("X-Pages", "1")
+			writeJSON(w, []struct{}{})
+			return
+		}
+
+		// GET /characters/{id}/planets/  (v1) — list of PI colonies
+		// GET /characters/{id}/planets/{planetID}/  (v3) — colony details
+		if strings.Contains(normPath, "/planets/") && r.Method == "GET" {
+			// Determine whether this is the list or detail endpoint by checking
+			// what comes after "/planets/" in the normalised path.
+			afterPlanets := ""
+			if idx := strings.Index(normPath, "/planets/"); idx != -1 {
+				tail := normPath[idx+len("/planets/"):]
+				// Strip trailing slashes and query params
+				tail = strings.TrimRight(tail, "/")
+				if qi := strings.Index(tail, "?"); qi != -1 {
+					tail = tail[:qi]
+				}
+				afterPlanets = tail
+			}
+
+			if afterPlanets == "" {
+				// List: GET /characters/{charID}/planets/
+				// extractID strips prefix "/characters/" and suffix "/planets/"
+				charID, ok := extractID(normPath, "/characters/", "/planets/")
+				if !ok {
+					http.Error(w, "invalid character id", 400)
+					return
+				}
+				state.mu.RLock()
+				planets, pok := state.characterPlanets[charID]
+				state.mu.RUnlock()
+				if !pok {
+					planets = []piPlanet{}
+				}
+				writeJSON(w, planets)
+				return
+			}
+
+			// Detail: GET /characters/{charID}/planets/{planetID}/
+			// Extract charID from the segment between "/characters/" and "/planets/"
+			rest := strings.TrimPrefix(normPath, "/characters/")
+			slashIdx := strings.Index(rest, "/")
+			if slashIdx == -1 {
+				http.Error(w, "invalid path", 400)
+				return
+			}
+			charID, err := strconv.ParseInt(rest[:slashIdx], 10, 64)
+			if err != nil {
+				http.Error(w, "invalid character id", 400)
+				return
+			}
+			planetID, err := strconv.ParseInt(afterPlanets, 10, 64)
+			if err != nil {
+				http.Error(w, "invalid planet id", 400)
+				return
+			}
+
+			key := fmt.Sprintf("%d:%d", charID, planetID)
+			state.mu.RLock()
+			colony, ok := state.planetDetails[key]
+			state.mu.RUnlock()
+			if !ok {
+				colony = piColony{Links: []piLink{}, Pins: []piPin{}, Routes: []piRoute{}}
+			}
+			writeJSON(w, colony)
+			return
+		}
+
+		http.Error(w, "not found", 404)
+	}
+
+	mux.HandleFunc("/v1/characters/", handleVersionedCharacter)
+	mux.HandleFunc("/v3/characters/", handleVersionedCharacter)
+	mux.HandleFunc("/v4/characters/", handleVersionedCharacter)
 
 	// Corporation endpoints
 	mux.HandleFunc("/corporations/", func(w http.ResponseWriter, r *http.Request) {
@@ -410,7 +679,9 @@ func main() {
 				http.Error(w, "invalid corp id", 400)
 				return
 			}
-			assets, ok := corpAssets[corpID]
+			state.mu.RLock()
+			assets, ok := state.corpAssets[corpID]
+			state.mu.RUnlock()
 			if !ok {
 				assets = []asset{}
 			}
@@ -426,7 +697,9 @@ func main() {
 				http.Error(w, "invalid corp id", 400)
 				return
 			}
-			bps, ok := corpBlueprints[corpID]
+			state.mu.RLock()
+			bps, ok := state.corpBlueprints[corpID]
+			state.mu.RUnlock()
 			if !ok {
 				bps = []blueprintEntry{}
 			}
@@ -442,7 +715,9 @@ func main() {
 				http.Error(w, "invalid corp id", 400)
 				return
 			}
-			divs, ok := corpDivisions[corpID]
+			state.mu.RLock()
+			divs, ok := state.corpDivisions[corpID]
+			state.mu.RUnlock()
 			if !ok {
 				divs = divisionsResponse{Hangar: []divisionEntry{}, Wallet: []divisionEntry{}}
 			}
@@ -456,7 +731,9 @@ func main() {
 			http.Error(w, "invalid corp id", 400)
 			return
 		}
-		name, ok := corpNames[corpID]
+		state.mu.RLock()
+		name, ok := state.corpNames[corpID]
+		state.mu.RUnlock()
 		if !ok {
 			name = fmt.Sprintf("Unknown Corp %d", corpID)
 		}
@@ -470,13 +747,6 @@ func main() {
 	})
 
 	// POST /universe/names/
-	var knownNames = map[int64]struct {
-		Name     string
-		Category string
-	}{
-		60003760: {Name: "Jita IV - Moon 4 - Caldari Navy Assembly Plant", Category: "station"},
-		60008494: {Name: "Amarr VIII (Oris) - Emperor Family Academy", Category: "station"},
-	}
 	mux.HandleFunc("/universe/names/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			http.Error(w, "method not allowed", 405)
@@ -492,6 +762,10 @@ func main() {
 			Name     string `json:"name"`
 			Category string `json:"category"`
 		}
+		state.mu.RLock()
+		knownNames := state.knownNames
+		state.mu.RUnlock()
+
 		results := []nameResult{}
 		for _, id := range ids {
 			if entry, ok := knownNames[id]; ok {
@@ -503,9 +777,229 @@ func main() {
 
 	// GET /latest/markets/{regionID}/orders/
 	mux.HandleFunc("/latest/markets/", func(w http.ResponseWriter, r *http.Request) {
+		state.mu.RLock()
+		orders := state.marketOrders
+		state.mu.RUnlock()
+
 		w.Header().Set("X-Pages", "1")
-		writeJSON(w, marketOrders)
+		writeJSON(w, orders)
 	})
+
+	// Admin API — only registered when E2E_TESTING=true
+	if os.Getenv("E2E_TESTING") == "true" {
+		log.Println("E2E_TESTING enabled: registering admin API endpoints")
+
+		// POST /_admin/reset
+		mux.HandleFunc("/_admin/reset", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "POST" {
+				writeAdminError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			fresh := newDefaultState()
+			state.mu.Lock()
+			state.characterAssets = fresh.characterAssets
+			state.characterNames = fresh.characterNames
+			state.corpAssets = fresh.corpAssets
+			state.corpDivisions = fresh.corpDivisions
+			state.charToCorp = fresh.charToCorp
+			state.corpNames = fresh.corpNames
+			state.characterSkills = fresh.characterSkills
+			state.characterIndustryJobs = fresh.characterIndustryJobs
+			state.characterBlueprints = fresh.characterBlueprints
+			state.corpBlueprints = fresh.corpBlueprints
+			state.marketOrders = fresh.marketOrders
+			state.knownNames = fresh.knownNames
+			state.characterPlanets = fresh.characterPlanets
+			state.planetDetails = fresh.planetDetails
+			state.mu.Unlock()
+			writeAdminOK(w)
+		})
+
+		// PUT /_admin/character-assets/{charID}
+		mux.HandleFunc("/_admin/character-assets/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "PUT" {
+				writeAdminError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			charID, ok := extractID(r.URL.Path, "/_admin/character-assets/", "")
+			if !ok {
+				writeAdminError(w, http.StatusBadRequest, "invalid character id")
+				return
+			}
+			var assets []asset
+			if err := json.NewDecoder(r.Body).Decode(&assets); err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+				return
+			}
+			state.mu.Lock()
+			state.characterAssets[charID] = assets
+			state.mu.Unlock()
+			writeAdminOK(w)
+		})
+
+		// PUT /_admin/character-skills/{charID}
+		mux.HandleFunc("/_admin/character-skills/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "PUT" {
+				writeAdminError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			charID, ok := extractID(r.URL.Path, "/_admin/character-skills/", "")
+			if !ok {
+				writeAdminError(w, http.StatusBadRequest, "invalid character id")
+				return
+			}
+			var skills skillsResponse
+			if err := json.NewDecoder(r.Body).Decode(&skills); err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+				return
+			}
+			state.mu.Lock()
+			state.characterSkills[charID] = skills
+			state.mu.Unlock()
+			writeAdminOK(w)
+		})
+
+		// PUT /_admin/character-industry-jobs/{charID}
+		mux.HandleFunc("/_admin/character-industry-jobs/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "PUT" {
+				writeAdminError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			charID, ok := extractID(r.URL.Path, "/_admin/character-industry-jobs/", "")
+			if !ok {
+				writeAdminError(w, http.StatusBadRequest, "invalid character id")
+				return
+			}
+			var jobs []industryJob
+			if err := json.NewDecoder(r.Body).Decode(&jobs); err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+				return
+			}
+			state.mu.Lock()
+			state.characterIndustryJobs[charID] = jobs
+			state.mu.Unlock()
+			writeAdminOK(w)
+		})
+
+		// PUT /_admin/character-blueprints/{charID}
+		mux.HandleFunc("/_admin/character-blueprints/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "PUT" {
+				writeAdminError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			charID, ok := extractID(r.URL.Path, "/_admin/character-blueprints/", "")
+			if !ok {
+				writeAdminError(w, http.StatusBadRequest, "invalid character id")
+				return
+			}
+			var bps []blueprintEntry
+			if err := json.NewDecoder(r.Body).Decode(&bps); err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+				return
+			}
+			state.mu.Lock()
+			state.characterBlueprints[charID] = bps
+			state.mu.Unlock()
+			writeAdminOK(w)
+		})
+
+		// PUT /_admin/corp-assets/{corpID}
+		mux.HandleFunc("/_admin/corp-assets/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "PUT" {
+				writeAdminError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			corpID, ok := extractID(r.URL.Path, "/_admin/corp-assets/", "")
+			if !ok {
+				writeAdminError(w, http.StatusBadRequest, "invalid corp id")
+				return
+			}
+			var assets []asset
+			if err := json.NewDecoder(r.Body).Decode(&assets); err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+				return
+			}
+			state.mu.Lock()
+			state.corpAssets[corpID] = assets
+			state.mu.Unlock()
+			writeAdminOK(w)
+		})
+
+		// PUT /_admin/market-orders
+		mux.HandleFunc("/_admin/market-orders", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "PUT" {
+				writeAdminError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			var orders []marketOrder
+			if err := json.NewDecoder(r.Body).Decode(&orders); err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+				return
+			}
+			state.mu.Lock()
+			state.marketOrders = orders
+			state.mu.Unlock()
+			writeAdminOK(w)
+		})
+
+		// PUT /_admin/character-planets/{charID}
+		mux.HandleFunc("/_admin/character-planets/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "PUT" {
+				writeAdminError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			charID, ok := extractID(r.URL.Path, "/_admin/character-planets/", "")
+			if !ok {
+				writeAdminError(w, http.StatusBadRequest, "invalid character id")
+				return
+			}
+			var planets []piPlanet
+			if err := json.NewDecoder(r.Body).Decode(&planets); err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+				return
+			}
+			state.mu.Lock()
+			state.characterPlanets[charID] = planets
+			state.mu.Unlock()
+			writeAdminOK(w)
+		})
+
+		// PUT /_admin/planet-details/{charID}/{planetID}
+		mux.HandleFunc("/_admin/planet-details/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "PUT" {
+				writeAdminError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			// Path: /_admin/planet-details/{charID}/{planetID}
+			rest := strings.TrimPrefix(r.URL.Path, "/_admin/planet-details/")
+			rest = strings.TrimRight(rest, "/")
+			parts := strings.SplitN(rest, "/", 2)
+			if len(parts) != 2 {
+				writeAdminError(w, http.StatusBadRequest, "expected path /_admin/planet-details/{charID}/{planetID}")
+				return
+			}
+			charID, err := strconv.ParseInt(parts[0], 10, 64)
+			if err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid character id")
+				return
+			}
+			planetID, err := strconv.ParseInt(parts[1], 10, 64)
+			if err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid planet id")
+				return
+			}
+			var colony piColony
+			if err := json.NewDecoder(r.Body).Decode(&colony); err != nil {
+				writeAdminError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+				return
+			}
+			key := fmt.Sprintf("%d:%d", charID, planetID)
+			state.mu.Lock()
+			state.planetDetails[key] = colony
+			state.mu.Unlock()
+			writeAdminOK(w)
+		})
+	}
 
 	log.Printf("Mock ESI server starting on port %s", port)
 	if err := http.ListenAndServe(":"+port, mux); err != nil {

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -24,6 +24,9 @@ services:
       dockerfile: Dockerfile.mock-esi
     environment:
       PORT: "8090"
+      E2E_TESTING: "true"
+    ports:
+      - "8090:8090"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8090/latest/markets/10000002/orders/ || exit 1"]
       interval: 2s
@@ -48,6 +51,8 @@ services:
       OAUTH_CLIENT_SECRET: "e2e-dummy"
       ESI_BASE_URL: "http://mock-esi:8090"
       ASSET_UPDATE_INTERVAL_SEC: "10"
+      INDUSTRY_JOBS_UPDATE_INTERVAL_SEC: "10"
+      PI_UPDATE_INTERVAL_SEC: "10"
     depends_on:
       database:
         condition: service_healthy
@@ -107,6 +112,7 @@ services:
     environment:
       CI: "true"
       BASE_URL: "http://frontend:3000"
+      MOCK_ESI_URL: "http://mock-esi:8090"
     depends_on:
       frontend:
         condition: service_healthy

--- a/docs/features/infrastructure/e2e-testing.md
+++ b/docs/features/infrastructure/e2e-testing.md
@@ -42,7 +42,13 @@ Only bootstrap data that can't be created through the app is seeded via SQL:
 
 Characters and corporations are created during tests via E2E API routes (see below), exercising the full backend creation flow through the mock ESI.
 
-### 4. E2E API Routes (test-only endpoints)
+### 4. Dynamic Mock ESI (Runtime Data Manipulation)
+
+The mock ESI server (`cmd/mock-esi/main.go`) uses a thread-safe `State` struct protected by `sync.RWMutex`. All existing handlers read state under `RLock()`. Admin API endpoints (`/_admin/*`) acquire `Lock()` for writes. This allows tests to inject, replace, or reset mock ESI data at runtime without restarting the server.
+
+The `/_admin/reset` endpoint restores all data to the hardcoded defaults, ensuring test isolation. Tests that mutate mock state should call `resetMockESI()` in `afterAll`.
+
+### 5. E2E API Routes (test-only endpoints)
 
 Two Next.js API routes are available only when `E2E_TESTING=true`:
 
@@ -111,6 +117,14 @@ Runs automatically via the `e2e-tests` job in `.github/workflows/ci.yml`. Upload
 6. **Stockpile Workflow** (`06-stockpiles.spec.ts`) — Set/edit/delete stockpile markers from assets page, verify deficit calculations on stockpiles page
 7. **Contacts Workflow** (`07-contacts.spec.ts`) — Send contact request (Alice → Bob), accept, verify bidirectional connection
 8. **Marketplace Workflow** (`08-marketplace.spec.ts`) — Create listing (Bob), browse (Alice), purchase, buy orders
+9. **Auto-Sell** (`09-auto-sell.spec.ts`) — Auto-sell container configuration
+10. **Industry** (`10-industry.spec.ts`) — Industry jobs page, active jobs sync from mock ESI, queue empty state, add job tab, blueprint search, dynamic mock ESI injection
+11. **Stations** (`11-stations.spec.ts`) — Station management CRUD: add/edit/delete preferred stations
+12. **Production Plans** (`12-production-plans.spec.ts`) — Create/edit/delete production plans, plan editor with step tree, blueprint search
+13. **Reactions** (`13-reactions.spec.ts`) — Reactions calculator tabs, settings toolbar, reaction list, shopping list, plan summary
+14. **Planetary Industry** (`14-pi.spec.ts`) — PI overview/profit/supply chain tabs, dynamic mock PI planet injection, stats chips
+15. **Transport** (`15-transport.spec.ts`) — Transport profiles CRUD, JF routes dialog, transport jobs
+16. **Settings** (`16-settings.spec.ts`) — Settings page, Discord settings section
 
 ---
 
@@ -127,6 +141,53 @@ Runs automatically via the `e2e-tests` job in `.github/workflows/ci.yml`. Upload
 | `GET /corporations/{id}/divisions` | Hangar/wallet divisions |
 | `GET /universe/structures/{id}` | Returns 403 (no player-owned structures in test data) |
 | `GET /latest/markets/{regionID}/orders/` | Market buy/sell orders for The Forge |
+| `GET /characters/{id}/skills` | Character skills (per-character canned data) |
+| `GET /characters/{id}/industry/jobs` | Character industry jobs (per-character canned data) |
+| `GET /characters/{id}/blueprints` | Character blueprints (per-character canned data) |
+| `GET /characters/{id}/contracts` | Character contracts (empty array) |
+| `GET /characters/{id}/planets` | Character PI planets (per-character canned data) |
+| `GET /characters/{id}/planets/{planetID}` | Planet colony details (per-character canned data) |
+| `GET /latest/route/{origin}/{dest}` | Jump route between systems (system ID array) |
+
+**Note:** All character endpoints support versioned paths (`/v1/characters/`, `/v3/characters/`, `/v4/characters/`).
+
+---
+
+## Dynamic Mock ESI (Admin API)
+
+The mock ESI server exposes an admin API to manipulate mock data at runtime. This allows tests to inject, replace, or reset mock ESI state without restarting the server or relying on pre-canned data. The admin API is **only available when `E2E_TESTING=true`**.
+
+### Admin API Endpoints
+
+| Method | Path | Body | Purpose |
+|--------|------|------|---------|
+| POST | `/_admin/reset` | none | Reset all data to defaults |
+| PUT | `/_admin/character-assets/{charID}` | `[]asset` | Replace character assets |
+| PUT | `/_admin/character-skills/{charID}` | `skillsResponse` | Replace character skills |
+| PUT | `/_admin/character-industry-jobs/{charID}` | `[]industryJob` | Replace industry jobs |
+| PUT | `/_admin/character-blueprints/{charID}` | `[]blueprintEntry` | Replace blueprints |
+| PUT | `/_admin/corp-assets/{corpID}` | `[]asset` | Replace corp assets |
+| PUT | `/_admin/market-orders` | `[]marketOrder` | Replace all market orders |
+| PUT | `/_admin/character-planets/{charID}` | `[]piPlanet` | Replace character PI planets |
+| PUT | `/_admin/planet-details/{charID}/{planetID}` | `piColony` | Replace planet colony details |
+
+### Playwright Helper
+
+The `e2e/helpers/mock-esi.ts` module wraps these endpoints with typed TypeScript functions. Import and use in tests:
+
+```typescript
+import { setCharacterIndustryJobs, resetMockESI, type IndustryJob } from '../helpers/mock-esi';
+
+test.afterAll(async () => {
+  await resetMockESI();
+});
+```
+
+### Rules
+
+- Always call `resetMockESI()` in `afterAll` if any test mutated mock state
+- Prefer admin API over adding new canned data for single-test scenarios
+- Use `toPass` polling pattern when waiting for background runners to sync changed mock data
 
 ---
 
@@ -141,6 +202,8 @@ e2e/
   seed.sql                  # Bootstrap data (static universe + users only)
   fixtures/
     auth.ts                 # Multi-user auth fixtures (Alice, Bob, Charlie, Diana)
+  helpers/
+    mock-esi.ts             # Playwright helper for mock ESI admin API
   tests/
     01-landing.spec.ts      # Auth + landing page
     02-characters.spec.ts   # Character creation + display
@@ -150,6 +213,14 @@ e2e/
     06-stockpiles.spec.ts   # Stockpile markers + deficits
     07-contacts.spec.ts     # Contact requests + acceptance
     08-marketplace.spec.ts  # Listings, purchases, buy orders
+    09-auto-sell.spec.ts    # Auto-sell container configuration
+    10-industry.spec.ts     # Industry jobs + dynamic mock ESI
+    11-stations.spec.ts     # Station management CRUD
+    12-production-plans.spec.ts  # Production plan lifecycle
+    13-reactions.spec.ts    # Reactions calculator
+    14-pi.spec.ts           # Planetary Industry
+    15-transport.spec.ts    # Transport profiles + JF routes
+    16-settings.spec.ts     # Settings page
 
 frontend/pages/api/e2e/
   add-character.ts          # E2E-only: create character via backend

--- a/e2e/helpers/mock-esi.ts
+++ b/e2e/helpers/mock-esi.ts
@@ -1,0 +1,288 @@
+/**
+ * mock-esi.ts — Helper module for the mock ESI admin API.
+ *
+ * The mock ESI server exposes admin endpoints under /_admin/ when
+ * E2E_TESTING=true. These allow tests to override canned ESI data
+ * on a per-test basis and reset to defaults between tests.
+ *
+ * Base URL is resolved from MOCK_ESI_URL (default: http://localhost:8090).
+ * In CI (Docker), set MOCK_ESI_URL=http://mock-esi:8090.
+ */
+
+const MOCK_ESI_BASE = process.env.MOCK_ESI_URL ?? 'http://localhost:8090';
+
+// ---------------------------------------------------------------------------
+// TypeScript interfaces — mirror the Go structs in cmd/mock-esi/main.go
+// ---------------------------------------------------------------------------
+
+export interface Asset {
+  item_id: number;
+  is_blueprint_copy: boolean;
+  is_singleton: boolean;
+  location_flag: string;
+  location_id: number;
+  location_type: string;
+  quantity: number;
+  type_id: number;
+}
+
+export interface SkillEntry {
+  skill_id: number;
+  trained_skill_level: number;
+  active_skill_level: number;
+  skillpoints_in_skill: number;
+}
+
+export interface SkillsResponse {
+  skills: SkillEntry[];
+  total_sp: number;
+}
+
+export interface IndustryJob {
+  job_id: number;
+  installer_id: number;
+  facility_id: number;
+  station_id: number;
+  activity_id: number;
+  blueprint_id: number;
+  blueprint_type_id: number;
+  blueprint_location_id: number;
+  output_location_id: number;
+  runs: number;
+  cost: number;
+  product_type_id: number;
+  status: string;
+  duration: number;
+  start_date: string;
+  end_date: string;
+}
+
+export interface BlueprintEntry {
+  item_id: number;
+  type_id: number;
+  location_id: number;
+  location_flag: string;
+  /** -1 = BPO, -2 = BPC */
+  quantity: number;
+  material_efficiency: number;
+  time_efficiency: number;
+  /** -1 for BPOs (unlimited runs) */
+  runs: number;
+}
+
+export interface MarketOrder {
+  order_id: number;
+  type_id: number;
+  location_id: number;
+  volume_total: number;
+  volume_remain: number;
+  min_volume: number;
+  price: number;
+  is_buy_order: boolean;
+  duration: number;
+  issued: string;
+  range: string;
+}
+
+// ---------------------------------------------------------------------------
+// PI interfaces — mirror the Go piPlanet / piColony types in cmd/mock-esi/main.go
+// ---------------------------------------------------------------------------
+
+export interface PiPlanet {
+  last_update: string;
+  num_pins: number;
+  owner_id: number;
+  planet_id: number;
+  planet_type: string;
+  solar_system_id: number;
+  upgrade_level: number;
+}
+
+export interface PiPinContent {
+  amount: number;
+  type_id: number;
+}
+
+export interface PiExtractorDetail {
+  cycle_time: number;
+  head_radius: number;
+  heads: object[];
+  product_type_id: number;
+  qty_per_cycle: number;
+}
+
+export interface PiFactoryDetail {
+  schematic_id: number;
+}
+
+export interface PiPin {
+  pin_id: number;
+  type_id: number;
+  latitude: number;
+  longitude: number;
+  install_time?: string;
+  expiry_time?: string;
+  last_cycle_start?: string;
+  schematic_id?: number;
+  contents: PiPinContent[];
+  extractor_details?: PiExtractorDetail;
+  factory_details?: PiFactoryDetail;
+}
+
+export interface PiLink {
+  source_pin_id: number;
+  destination_pin_id: number;
+  link_level: number;
+}
+
+export interface PiRoute {
+  route_id: number;
+  source_pin_id: number;
+  destination_pin_id: number;
+  content_type_id: number;
+  quantity: number;
+  waypoints: number[];
+}
+
+export interface PiColony {
+  links: PiLink[];
+  pins: PiPin[];
+  routes: PiRoute[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper
+// ---------------------------------------------------------------------------
+
+async function adminRequest(
+  method: 'POST' | 'PUT',
+  path: string,
+  body?: unknown,
+): Promise<void> {
+  const url = `${MOCK_ESI_BASE}${path}`;
+  const init: RequestInit = {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = await res.text();
+    } catch {
+      // ignore
+    }
+    throw new Error(
+      `Mock ESI admin request failed: ${method} ${path} → ${res.status} ${res.statusText}${detail ? ': ' + detail : ''}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported API
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset all mock ESI state to the default canned fixtures.
+ * Call this in afterEach/afterAll when a test mutates mock data.
+ */
+export async function resetMockESI(): Promise<void> {
+  await adminRequest('POST', '/_admin/reset');
+}
+
+/**
+ * Replace the asset list for a single character.
+ * The backend will serve this data on the next /characters/{charID}/assets call.
+ */
+export async function setCharacterAssets(
+  charID: number,
+  assets: Asset[],
+): Promise<void> {
+  await adminRequest('PUT', `/_admin/character-assets/${charID}`, assets);
+}
+
+/**
+ * Replace the skills response for a single character.
+ */
+export async function setCharacterSkills(
+  charID: number,
+  skills: SkillsResponse,
+): Promise<void> {
+  await adminRequest('PUT', `/_admin/character-skills/${charID}`, skills);
+}
+
+/**
+ * Replace the industry jobs list for a single character.
+ */
+export async function setCharacterIndustryJobs(
+  charID: number,
+  jobs: IndustryJob[],
+): Promise<void> {
+  await adminRequest(
+    'PUT',
+    `/_admin/character-industry-jobs/${charID}`,
+    jobs,
+  );
+}
+
+/**
+ * Replace the blueprint list for a single character.
+ */
+export async function setCharacterBlueprints(
+  charID: number,
+  blueprints: BlueprintEntry[],
+): Promise<void> {
+  await adminRequest(
+    'PUT',
+    `/_admin/character-blueprints/${charID}`,
+    blueprints,
+  );
+}
+
+/**
+ * Replace the asset list for a corporation.
+ */
+export async function setCorpAssets(
+  corpID: number,
+  assets: Asset[],
+): Promise<void> {
+  await adminRequest('PUT', `/_admin/corp-assets/${corpID}`, assets);
+}
+
+/**
+ * Replace the full market orders list (all regions share the same mock orders).
+ */
+export async function setMarketOrders(orders: MarketOrder[]): Promise<void> {
+  await adminRequest('PUT', '/_admin/market-orders', orders);
+}
+
+/**
+ * Set the planets list for a single character.
+ * The backend will serve this data on the next /v1/characters/{charID}/planets/ call.
+ */
+export async function setCharacterPlanets(
+  charID: number,
+  planets: PiPlanet[],
+): Promise<void> {
+  await adminRequest('PUT', `/_admin/character-planets/${charID}`, planets);
+}
+
+/**
+ * Set the colony details for a specific character+planet combination.
+ * The backend will serve this on GET /v3/characters/{charID}/planets/{planetID}/.
+ */
+export async function setPlanetDetails(
+  charID: number,
+  planetID: number,
+  colony: PiColony,
+): Promise<void> {
+  await adminRequest(
+    'PUT',
+    `/_admin/planet-details/${charID}/${planetID}`,
+    colony,
+  );
+}

--- a/e2e/seed.sql
+++ b/e2e/seed.sql
@@ -51,4 +51,147 @@ INSERT INTO users (id, name) VALUES
   (1003, 'Charlie Trader'),
   (1004, 'Diana Scout');
 
+-- ===========================================
+-- SDE Data for Industry Tests
+-- ===========================================
+
+-- Categories
+INSERT INTO sde_categories (category_id, name, published) VALUES
+  (4,  'Material',  true),
+  (6,  'Ship',      true),
+  (9,  'Blueprint', true),
+  (16, 'Skill',     true)
+ON CONFLICT (category_id) DO NOTHING;
+
+-- Groups
+INSERT INTO sde_groups (group_id, name, category_id, published) VALUES
+  (18,  'Mineral',           4,  true),
+  (25,  'Frigate',           6,  true),
+  (105, 'Frigate Blueprint', 9,  true),
+  (270, 'Science',           16, true)
+ON CONFLICT (group_id) DO NOTHING;
+
+-- Enrich existing item types with group_id so SDE queries can join sde_groups
+UPDATE asset_item_types SET group_id = 18 WHERE type_id IN (34, 35, 36, 37, 38);
+UPDATE asset_item_types SET group_id = 25 WHERE type_id = 587;
+
+-- Blueprint item type (needed by SearchBlueprints which joins asset_item_types on blueprint_type_id)
+INSERT INTO asset_item_types (type_id, type_name, volume, group_id) VALUES
+  (787, 'Rifter Blueprint', 0.01, 105)
+ON CONFLICT (type_id) DO NOTHING;
+
+-- Skill item types (referenced by sde_blueprint_skills)
+INSERT INTO asset_item_types (type_id, type_name, volume, group_id) VALUES
+  (3380,  'Industry',                  0.01, 270),
+  (3388,  'Advanced Industry',         0.01, 270),
+  (3387,  'Mass Production',           0.01, 270),
+  (24625, 'Advanced Mass Production',  0.01, 270),
+  (45746, 'Reactions',                 0.01, 270),
+  (45748, 'Mass Reactions',            0.01, 270),
+  (45749, 'Advanced Mass Reactions',   0.01, 270)
+ON CONFLICT (type_id) DO NOTHING;
+
+-- Blueprint definition
+INSERT INTO sde_blueprints (blueprint_type_id, max_production_limit) VALUES
+  (787, 300)
+ON CONFLICT (blueprint_type_id) DO NOTHING;
+
+-- Manufacturing activity (1 hour)
+INSERT INTO sde_blueprint_activities (blueprint_type_id, activity, time) VALUES
+  (787, 'manufacturing', 3600)
+ON CONFLICT (blueprint_type_id, activity) DO NOTHING;
+
+-- Product: 1x Rifter per run
+INSERT INTO sde_blueprint_products (blueprint_type_id, activity, type_id, quantity) VALUES
+  (787, 'manufacturing', 587, 1)
+ON CONFLICT (blueprint_type_id, activity, type_id) DO NOTHING;
+
+-- Materials: Tritanium 2500, Pyerite 1000, Mexallon 250, Isogen 50
+INSERT INTO sde_blueprint_materials (blueprint_type_id, activity, type_id, quantity) VALUES
+  (787, 'manufacturing', 34, 2500),
+  (787, 'manufacturing', 35, 1000),
+  (787, 'manufacturing', 36, 250),
+  (787, 'manufacturing', 37, 50)
+ON CONFLICT (blueprint_type_id, activity, type_id) DO NOTHING;
+
+-- Skill requirement: Industry Level 1
+INSERT INTO sde_blueprint_skills (blueprint_type_id, activity, type_id, level) VALUES
+  (787, 'manufacturing', 3380, 1)
+ON CONFLICT (blueprint_type_id, activity, type_id) DO NOTHING;
+
+-- Industry cost indices (Jita system)
+INSERT INTO industry_cost_indices (system_id, activity, cost_index) VALUES
+  (30000142, 'manufacturing', 0.0638),
+  (30000142, 'reaction',      0.0200)
+ON CONFLICT (system_id, activity) DO NOTHING;
+
+-- Market prices for manufacturing calculator (EIV calculation)
+-- market_prices columns: type_id, region_id, buy_price, sell_price, adjusted_price
+INSERT INTO market_prices (type_id, region_id, buy_price, sell_price, adjusted_price) VALUES
+  (34,  10000002, 5.50,       6.00,        5.75),
+  (35,  10000002, 10.00,      11.50,       10.75),
+  (36,  10000002, 70.00,      75.00,       72.50),
+  (37,  10000002, 50.00,      55.00,       52.50),
+  (38,  10000002, 800.00,     900.00,      850.00),
+  (587, 10000002, 500000.00,  600000.00,   550000.00)
+ON CONFLICT (type_id) DO UPDATE SET
+  buy_price      = EXCLUDED.buy_price,
+  sell_price     = EXCLUDED.sell_price,
+  adjusted_price = EXCLUDED.adjusted_price;
+
+-- ===========================================
+-- SDE Data for Reactions Calculator Tests
+-- ===========================================
+
+-- Advanced Material group (category 4 = Material)
+INSERT INTO sde_groups (group_id, name, category_id, published) VALUES
+  (428, 'Advanced Material', 4, true)
+ON CONFLICT (group_id) DO NOTHING;
+
+-- Crystalline Carbonide (reaction output product)
+-- This must have a group_id pointing to a non-filtered group so it appears in ReactionPicker
+-- (filtered groups: 'Intermediate Materials', 'Unrefined Mineral')
+INSERT INTO asset_item_types (type_id, type_name, volume, group_id) VALUES
+  (16634, 'Crystalline Carbonide', 0.01, 428)
+ON CONFLICT (type_id) DO NOTHING;
+
+-- Crystalline Carbonide Reaction Formula (blueprint-equivalent for reactions)
+-- blueprint_type_id: 28209
+INSERT INTO asset_item_types (type_id, type_name, volume, group_id) VALUES
+  (28209, 'Crystalline Carbonide Reaction Formula', 0.01, 105)
+ON CONFLICT (type_id) DO NOTHING;
+
+INSERT INTO sde_blueprints (blueprint_type_id, max_production_limit) VALUES
+  (28209, 0)
+ON CONFLICT (blueprint_type_id) DO NOTHING;
+
+-- Reaction activity: 1 hour (3600s) — matches GetAllReactions WHERE time >= 3600
+INSERT INTO sde_blueprint_activities (blueprint_type_id, activity, time) VALUES
+  (28209, 'reaction', 3600)
+ON CONFLICT (blueprint_type_id, activity) DO NOTHING;
+
+-- Output: 100x Crystalline Carbonide per run
+INSERT INTO sde_blueprint_products (blueprint_type_id, activity, type_id, quantity) VALUES
+  (28209, 'reaction', 16634, 100)
+ON CONFLICT (blueprint_type_id, activity, type_id) DO NOTHING;
+
+-- Inputs: Nocxium 40 + Isogen 80 (both already in asset_item_types)
+INSERT INTO sde_blueprint_materials (blueprint_type_id, activity, type_id, quantity) VALUES
+  (28209, 'reaction', 38, 40),
+  (28209, 'reaction', 37, 80)
+ON CONFLICT (blueprint_type_id, activity, type_id) DO NOTHING;
+
+-- Skill requirement: Reactions Level 1
+INSERT INTO sde_blueprint_skills (blueprint_type_id, activity, type_id, level) VALUES
+  (28209, 'reaction', 45746, 1)
+ON CONFLICT (blueprint_type_id, activity, type_id) DO NOTHING;
+
+-- Market price for Crystalline Carbonide output
+INSERT INTO market_prices (type_id, region_id, buy_price, sell_price, adjusted_price) VALUES
+  (16634, 10000002, 3500.00, 4000.00, 3750.00)
+ON CONFLICT (type_id) DO UPDATE SET
+  buy_price      = EXCLUDED.buy_price,
+  sell_price     = EXCLUDED.sell_price,
+  adjusted_price = EXCLUDED.adjusted_price;
+
 COMMIT;

--- a/e2e/tests/10-industry.spec.ts
+++ b/e2e/tests/10-industry.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect } from '@playwright/test';
+import {
+  setCharacterIndustryJobs,
+  resetMockESI,
+  type IndustryJob,
+} from '../helpers/mock-esi';
+
+// Alice Alpha's character ID
+const ALICE_ALPHA_ID = 2001001;
+
+test.describe('Industry', () => {
+  test.afterAll(async () => {
+    // Reset mock ESI state if any test mutated it
+    await resetMockESI();
+  });
+
+  test('navigate to industry page shows heading and tabs', async ({ page }) => {
+    await page.goto('/industry');
+
+    // Page heading (use getByRole to avoid matching "No active industry jobs" cell)
+    await expect(page.getByRole('heading', { name: 'Industry Jobs' })).toBeVisible({ timeout: 10000 });
+
+    // All three tabs should be present
+    await expect(page.getByRole('tab', { name: /Active Jobs/i })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /Queue/i })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Add Job' })).toBeVisible();
+  });
+
+  test('active jobs tab shows synced ESI job for Rifter', async ({ page }) => {
+    // Clear localStorage so the tab state is fresh
+    await page.goto('/industry');
+    await page.evaluate(() => localStorage.clear());
+    await page.goto('/industry');
+
+    // Active Jobs tab is selected by default (tab index 0)
+    await expect(page.getByRole('tab', { name: /Active Jobs/i })).toBeVisible({ timeout: 10000 });
+
+    // The background runner syncs Alice Alpha's active Rifter manufacturing job from mock ESI.
+    // This runner fires at startup, so the job should appear within 30s.
+    // Wait for "Rifter" product name in the jobs table.
+    // Use toPass polling: reload until the product name cell appears (runner fires every 10s).
+    await expect(async () => {
+      await page.reload();
+      await expect(page.getByText('Rifter', { exact: true })).toBeVisible({ timeout: 5000 });
+    }).toPass({ timeout: 60000 });
+
+    // The job status chip should show "active" — use exact:true to avoid matching the "Active Jobs (1)" tab label
+    await expect(page.getByText('active', { exact: true })).toBeVisible();
+  });
+
+  test('queue tab shows empty state', async ({ page }) => {
+    await page.goto('/industry');
+    await page.evaluate(() => localStorage.clear());
+    await page.goto('/industry');
+
+    // Click the Queue tab
+    await page.getByRole('tab', { name: /Queue/i }).click();
+
+    // No planned jobs exist yet — the table should show empty state
+    await expect(page.getByText('No jobs in queue')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('add job tab shows blueprint search input', async ({ page }) => {
+    await page.goto('/industry');
+    await page.evaluate(() => localStorage.clear());
+    await page.goto('/industry');
+
+    // Click the Add Job tab
+    await page.getByRole('tab', { name: 'Add Job' }).click();
+
+    // Blueprint search autocomplete should be visible
+    await expect(page.getByLabel('Search Blueprint')).toBeVisible({ timeout: 5000 });
+
+    // Activity selector should default to Manufacturing
+    await expect(page.getByText('Manufacturing')).toBeVisible();
+
+    // Runs field should be visible
+    await expect(page.getByLabel('Runs')).toBeVisible();
+  });
+
+  test('blueprint search autocomplete returns Rifter result', async ({ page }) => {
+    await page.goto('/industry');
+    await page.evaluate(() => localStorage.clear());
+    await page.goto('/industry');
+
+    // Navigate to Add Job tab
+    await page.getByRole('tab', { name: 'Add Job' }).click();
+
+    // Wait for the search input to appear
+    const searchInput = page.getByLabel('Search Blueprint');
+    await expect(searchInput).toBeVisible({ timeout: 5000 });
+
+    // Type "Rifter" — the search fires after a 300ms debounce and requires at least 2 chars
+    await searchInput.fill('Ri');
+
+    // Wait a moment for debounce then continue typing
+    await searchInput.fill('Rifter');
+
+    // The autocomplete dropdown should show Rifter as a result
+    // Multiple Rifter variants may appear — pick the first match
+    await expect(page.getByRole('option', { name: /Rifter/i }).first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('mock ESI: inject second active job appears after re-sync', async ({ page }) => {
+    // Inject a second active job alongside the original Rifter job.
+    // The controller only returns status IN ('active', 'paused', 'ready').
+    const originalJob: IndustryJob = {
+      job_id: 500001,
+      installer_id: ALICE_ALPHA_ID,
+      facility_id: 60003760,
+      station_id: 60003760,
+      activity_id: 1,
+      blueprint_id: 9876,
+      blueprint_type_id: 787,
+      blueprint_location_id: 60003760,
+      output_location_id: 60003760,
+      runs: 10,
+      cost: 1500000,
+      product_type_id: 587,
+      status: 'active',
+      duration: 3600,
+      start_date: '2026-02-22T00:00:00Z',
+      end_date: '2026-02-22T01:00:00Z',
+    };
+
+    const secondJob: IndustryJob = {
+      job_id: 500002,
+      installer_id: ALICE_ALPHA_ID,
+      facility_id: 60003760,
+      station_id: 60003760,
+      activity_id: 1,
+      blueprint_id: 9877,
+      blueprint_type_id: 787,
+      blueprint_location_id: 60003760,
+      output_location_id: 60003760,
+      runs: 5,
+      cost: 750000,
+      product_type_id: 587,
+      status: 'active',
+      duration: 7200,
+      start_date: '2026-02-22T00:00:00Z',
+      end_date: '2026-02-22T02:00:00Z',
+    };
+
+    // Update mock ESI so next poll returns both jobs
+    await setCharacterIndustryJobs(ALICE_ALPHA_ID, [originalJob, secondJob]);
+
+    // Wait for the background runner to poll mock ESI (fires every 10s in E2E)
+    // and pick up the new job. Reload the page to fetch fresh data.
+    await page.goto('/industry');
+    await page.evaluate(() => localStorage.clear());
+    await page.goto('/industry');
+
+    // Wait for Active Jobs tab
+    await expect(page.getByRole('tab', { name: /Active Jobs/i })).toBeVisible({ timeout: 10000 });
+
+    // Both jobs should show "Rifter" — we expect at least 2 rows with Rifter product
+    // Use toPass polling: reload until 2 Rifter product name cells appear (runner fires every 10s).
+    await expect(async () => {
+      await page.reload();
+      // Both jobs have product_type_id 587 (Rifter) — expect at least 2 text matches
+      const rifterCells = page.getByText('Rifter', { exact: true });
+      await expect(rifterCells.first()).toBeVisible({ timeout: 3000 });
+      await expect(rifterCells.nth(1)).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 35000 });
+
+    // Verify the second job has runs=5 — formatNumber(5) = "5"
+    await expect(page.getByText('5', { exact: true }).first()).toBeVisible();
+  });
+});

--- a/e2e/tests/11-stations.spec.ts
+++ b/e2e/tests/11-stations.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Stations', () => {
+  test('navigate to stations page shows Preferred Stations heading', async ({ page }) => {
+    await page.goto('/stations');
+
+    await expect(page.getByRole('heading', { name: 'Preferred Stations' })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('stations page shows empty state initially', async ({ page }) => {
+    await page.goto('/stations');
+
+    // Table renders but no stations are configured yet
+    await expect(
+      page.getByText('No preferred stations configured. Click "Add Station" to get started.')
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test('open add station dialog', async ({ page }) => {
+    await page.goto('/stations');
+
+    // Click "Add Station" button
+    await page.getByRole('button', { name: /Add Station/i }).click();
+
+    // Dialog should appear with title "Add Station"
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText('Add Station')).toBeVisible();
+
+    // Dialog should have Station autocomplete field
+    await expect(dialog.getByLabel('Station')).toBeVisible();
+
+    // Close dialog
+    await dialog.getByRole('button', { name: /Cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('station autocomplete searches and shows results for Jita', async ({ page }) => {
+    await page.goto('/stations');
+
+    // Open Add Station dialog
+    await page.getByRole('button', { name: /Add Station/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Type "Jita" into the station search autocomplete
+    const stationInput = dialog.getByLabel('Station');
+    await stationInput.fill('Jita');
+
+    // Wait for autocomplete dropdown to appear with Jita station
+    // The search has a 300ms debounce, so wait for the option to appear
+    await expect(
+      page.getByRole('option', { name: /Jita IV - Moon 4/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Close dialog
+    await dialog.getByRole('button', { name: /Cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('create station with Jita and Raitaru structure', async ({ page }) => {
+    await page.goto('/stations');
+
+    // Open Add Station dialog
+    await page.getByRole('button', { name: /Add Station/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Search for and select Jita station
+    const stationInput = dialog.getByLabel('Station');
+    await stationInput.fill('Jita');
+    await expect(
+      page.getByRole('option', { name: /Jita IV - Moon 4/i })
+    ).toBeVisible({ timeout: 5000 });
+    await page.getByRole('option', { name: /Jita IV - Moon 4/i }).click();
+
+    // Verify structure is already set to Raitaru (default)
+    // Set facility tax to 1%
+    const taxInput = dialog.getByLabel('Facility Tax %');
+    await taxInput.clear();
+    await taxInput.fill('1');
+
+    // Save the station (button says "Add" for new stations)
+    await dialog.getByRole('button', { name: /^Add$/i }).click();
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // The station should now appear in the table
+    await expect(page.getByRole('cell', { name: /Jita IV - Moon 4/i })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('cell', { name: /raitaru/i })).toBeVisible();
+    await expect(page.getByRole('cell', { name: '1%' })).toBeVisible();
+  });
+
+  test('edit station changes facility tax', async ({ page }) => {
+    await page.goto('/stations');
+
+    // Wait for the Jita station row to be visible (created in previous test)
+    await expect(page.getByRole('cell', { name: /Jita IV - Moon 4/i })).toBeVisible({ timeout: 10000 });
+
+    // Click the edit icon button on the Jita station row
+    const jitaRow = page.getByRole('row').filter({ hasText: /Jita IV - Moon 4/ });
+    await jitaRow.getByRole('button').first().click();
+
+    // Dialog should open as "Edit Station" with station search disabled
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText('Edit Station')).toBeVisible();
+
+    // Station name should be pre-filled and disabled
+    const stationInput = dialog.getByLabel('Station');
+    await expect(stationInput).toBeDisabled();
+
+    // Change facility tax to 2%
+    const taxInput = dialog.getByLabel('Facility Tax %');
+    await taxInput.clear();
+    await taxInput.fill('2');
+
+    // Save (button says "Update" for edits)
+    await dialog.getByRole('button', { name: /^Update$/i }).click();
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Verify updated tax value in the table
+    await expect(page.getByRole('cell', { name: '2%' })).toBeVisible({ timeout: 5000 });
+  });
+
+  test('delete station removes it from the table', async ({ page }) => {
+    await page.goto('/stations');
+
+    // Wait for the Jita station row
+    await expect(page.getByRole('cell', { name: /Jita IV - Moon 4/i })).toBeVisible({ timeout: 10000 });
+
+    // Accept the native browser confirm dialog
+    page.on('dialog', dialog => dialog.accept());
+
+    // Click the delete icon button on the Jita station row
+    const jitaRow = page.getByRole('row').filter({ hasText: /Jita IV - Moon 4/ });
+    await jitaRow.getByRole('button').last().click();
+
+    // Station should be removed and empty state should appear
+    await expect(
+      page.getByText('No preferred stations configured. Click "Add Station" to get started.')
+    ).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/e2e/tests/12-production-plans.spec.ts
+++ b/e2e/tests/12-production-plans.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Production Plans', () => {
+  test('navigate to production plans page shows heading', async ({ page }) => {
+    await page.goto('/production-plans');
+
+    await expect(page.getByRole('heading', { name: 'Production Plans' })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('empty state is shown when no plans exist', async ({ page }) => {
+    await page.goto('/production-plans');
+
+    await expect(
+      page.getByText('No production plans yet. Create one to define how items should be produced.')
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test('New Plan button opens Create Production Plan dialog', async ({ page }) => {
+    await page.goto('/production-plans');
+
+    await page.getByRole('button', { name: /New Plan/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText('Create Production Plan')).toBeVisible();
+
+    // Blueprint search input should be present
+    await expect(dialog.getByLabel('Search for a product')).toBeVisible();
+
+    // Optional station fields should be present
+    await expect(dialog.getByLabel('Default Manufacturing Station')).toBeVisible();
+    await expect(dialog.getByLabel('Default Reaction Station')).toBeVisible();
+
+    // Close dialog
+    await dialog.getByRole('button', { name: /Cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('blueprint search autocomplete returns Rifter result', async ({ page }) => {
+    await page.goto('/production-plans');
+
+    await page.getByRole('button', { name: /New Plan/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Type "Ri" first then extend — autocomplete fires after 300ms debounce with 2+ chars
+    const searchInput = dialog.getByLabel('Search for a product');
+    await searchInput.fill('Ri');
+    await searchInput.fill('Rifter');
+
+    // Dropdown should show Rifter manufacturing option (may have multiple variants — use first)
+    await expect(
+      page.getByRole('option', { name: /Rifter.*manufacturing/i }).first()
+    ).toBeVisible({ timeout: 10000 });
+
+    // Press Escape to close the autocomplete dropdown before clicking Cancel
+    // (the open dropdown intercepts pointer events on the Cancel button)
+    await searchInput.press('Escape');
+    await dialog.getByRole('button', { name: /Cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('create a Rifter production plan', async ({ page }) => {
+    await page.goto('/production-plans');
+
+    // Open create dialog
+    await page.getByRole('button', { name: /New Plan/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Search for Rifter blueprint
+    const searchInput = dialog.getByLabel('Search for a product');
+    await searchInput.fill('Rifter');
+
+    // Wait for the autocomplete option and select the first match (may have variants)
+    const option = page.getByRole('option', { name: /Rifter.*manufacturing/i }).first();
+    await expect(option).toBeVisible({ timeout: 10000 });
+    await option.click();
+
+    // Create button should now be enabled — click it
+    await dialog.getByRole('button', { name: /Create Plan/i }).click();
+
+    // Dialog closes and editor view opens automatically after creation
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // The editor shows the plan name (product name is used as default plan name)
+    await expect(page.getByRole('heading', { name: /Rifter/i })).toBeVisible({ timeout: 10000 });
+
+    // Editor also shows step count and the Generate Jobs button
+    await expect(page.getByText(/production step/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: /Generate Jobs/i })).toBeVisible();
+  });
+
+  test('plan editor shows Step Tree tab', async ({ page }) => {
+    await page.goto('/production-plans');
+
+    // The Rifter plan created in the previous test should be in the list
+    await expect(page.getByText('Rifter').first()).toBeVisible({ timeout: 10000 });
+
+    // Click the edit icon on the Rifter plan row to open the editor
+    const rifterRow = page.getByRole('row').filter({ hasText: 'Rifter' }).first();
+    await rifterRow.getByRole('button').first().click();
+
+    // Editor loads — verify plan name and tabs
+    await expect(page.getByRole('heading', { name: /Rifter/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('tab', { name: 'Step Tree' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Batch Configure' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Transport' })).toBeVisible();
+  });
+
+  test('Back to Plans button returns to list view', async ({ page }) => {
+    await page.goto('/production-plans');
+
+    // Wait for the plan row and open the editor
+    await expect(page.getByText('Rifter').first()).toBeVisible({ timeout: 10000 });
+    const rifterRow = page.getByRole('row').filter({ hasText: 'Rifter' }).first();
+    await rifterRow.getByRole('button').first().click();
+
+    // Verify we're in editor view
+    await expect(page.getByRole('heading', { name: /Rifter/i })).toBeVisible({ timeout: 10000 });
+
+    // Click "Back to Plans"
+    await page.getByRole('button', { name: /Back to Plans/i }).click();
+
+    // Should return to the list view with heading and table
+    await expect(page.getByRole('heading', { name: 'Production Plans' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Rifter').first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('delete plan removes it from the list', async ({ page }) => {
+    await page.goto('/production-plans');
+
+    // Wait for the Rifter plan row
+    await expect(page.getByText('Rifter').first()).toBeVisible({ timeout: 10000 });
+
+    // Click the delete icon (last button) on the Rifter row
+    const rifterRow = page.getByRole('row').filter({ hasText: 'Rifter' }).first();
+    await rifterRow.getByRole('button').last().click();
+
+    // Plan should be removed — empty state message should reappear
+    await expect(
+      page.getByText('No production plans yet. Create one to define how items should be produced.')
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/e2e/tests/13-reactions.spec.ts
+++ b/e2e/tests/13-reactions.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Reactions Calculator', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage so tab/settings state is fresh for each test
+    await page.goto('/reactions');
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('navigate to reactions page shows tabs', async ({ page }) => {
+    await page.goto('/reactions');
+
+    // All three tabs should be present
+    await expect(page.getByRole('tab', { name: 'Pick Reactions' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('tab', { name: /Shopping List/i })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Plan Summary' })).toBeVisible();
+  });
+
+  test('settings toolbar controls are visible', async ({ page }) => {
+    await page.goto('/reactions');
+
+    // MUI Select without explicit labelId prop does not wire aria-labelledby automatically
+    // in MUI v7. Scope to the FormControl container using the label text to find each combobox.
+
+    // Structure dropdown — find the FormControl containing the "Structure" label
+    const structureControl = page.locator('.MuiFormControl-root').filter({
+      has: page.locator('label').filter({ hasText: 'Structure' }),
+    });
+    await expect(structureControl.getByRole('combobox')).toBeVisible({ timeout: 10000 });
+
+    // Rig dropdown
+    const rigControl = page.locator('.MuiFormControl-root').filter({
+      has: page.locator('label').filter({ hasText: 'Rig' }),
+    });
+    await expect(rigControl.getByRole('combobox')).toBeVisible();
+
+    // Security dropdown
+    const securityControl = page.locator('.MuiFormControl-root').filter({
+      has: page.locator('label').filter({ hasText: 'Security' }),
+    });
+    await expect(securityControl.getByRole('combobox')).toBeVisible();
+
+    // Cycle Days input
+    await expect(page.getByLabel('Cycle Days')).toBeVisible();
+
+    // System autocomplete (Autocomplete renders a combobox input with associated label)
+    await expect(page.getByRole('combobox', { name: /System/i })).toBeVisible();
+  });
+
+  test('Pick Reactions tab shows reaction list with seeded Crystalline Carbonide', async ({ page }) => {
+    await page.goto('/reactions');
+
+    // The Pick Reactions tab is active by default
+    await expect(page.getByRole('tab', { name: 'Pick Reactions' })).toBeVisible({ timeout: 10000 });
+
+    // The reactions table should load and show our seeded reaction.
+    // The API fetches all reactions from sde_blueprint_activities where activity='reaction'.
+    // Our seed adds Crystalline Carbonide Reaction Formula (blueprint 28209) → Crystalline Carbonide (16634).
+    // The product group is 'Advanced Material' which is not in the SIMPLE_GROUPS filter,
+    // so it will appear in the table.
+    // Use toPass with reload to handle slow API responses or delayed rendering.
+    await expect(async () => {
+      await page.reload();
+      await expect(page.getByText('Crystalline Carbonide')).toBeVisible({ timeout: 5000 });
+    }).toPass({ timeout: 30000 });
+
+    // The Group column should show the Crystalline Carbonide group name.
+    // We don't assert the specific group name here because the SDE import populates
+    // the real EVE group names which may differ from seed data ("Advanced Material").
+    // It is sufficient that the product name is visible and the reaction loaded correctly.
+  });
+
+  test('Pick Reactions tab shows reaction count and ME factor', async ({ page }) => {
+    await page.goto('/reactions');
+
+    await expect(page.getByRole('tab', { name: 'Pick Reactions' })).toBeVisible({ timeout: 10000 });
+
+    // The toolbar above the table shows "N reactions | ME: X"
+    // Wait for data to load by waiting for the reaction to appear first
+    await expect(page.getByText('Crystalline Carbonide')).toBeVisible({ timeout: 15000 });
+
+    // Verify the count display is shown (contains "reactions")
+    await expect(page.getByText(/\d+ reaction/)).toBeVisible();
+  });
+
+  test('Search filter narrows down the reaction list', async ({ page }) => {
+    await page.goto('/reactions');
+
+    await expect(page.getByRole('tab', { name: 'Pick Reactions' })).toBeVisible({ timeout: 10000 });
+
+    // Wait for reactions to load
+    await expect(page.getByText('Crystalline Carbonide')).toBeVisible({ timeout: 15000 });
+
+    // Search for "crystal" — should still show Crystalline Carbonide
+    const searchInput = page.getByLabel('Search');
+    await searchInput.fill('crystal');
+    await expect(page.getByText('Crystalline Carbonide')).toBeVisible({ timeout: 5000 });
+
+    // Search for something that doesn't match — table should show "No reactions found"
+    await searchInput.fill('zzznomatch');
+    await expect(page.getByText('No reactions found')).toBeVisible({ timeout: 5000 });
+
+    // Clear search — Crystalline Carbonide returns
+    await searchInput.fill('');
+    await expect(page.getByText('Crystalline Carbonide')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Shopping List tab shows empty state when no reactions selected', async ({ page }) => {
+    await page.goto('/reactions');
+
+    // Wait for data to load
+    await expect(page.getByRole('tab', { name: 'Pick Reactions' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Crystalline Carbonide')).toBeVisible({ timeout: 15000 });
+
+    // Switch to Shopping List tab
+    await page.getByRole('tab', { name: /Shopping List/i }).click();
+
+    // No reactions selected yet — empty state message
+    await expect(
+      page.getByText('Select reactions in the Pick Reactions tab to generate a shopping list.')
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Plan Summary tab shows empty state when no reactions selected', async ({ page }) => {
+    await page.goto('/reactions');
+
+    // Wait for data to load
+    await expect(page.getByRole('tab', { name: 'Pick Reactions' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Crystalline Carbonide')).toBeVisible({ timeout: 15000 });
+
+    // Switch to Plan Summary tab
+    await page.getByRole('tab', { name: 'Plan Summary' }).click();
+
+    // No reactions selected yet — empty state message
+    await expect(
+      page.getByText('Select reactions in the Pick Reactions tab to see a plan summary.')
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test('selecting a reaction instance populates Shopping List and Plan Summary', async ({ page }) => {
+    await page.goto('/reactions');
+
+    // Wait for reactions to load — use toPass with reload in case API is slow
+    await expect(page.getByRole('tab', { name: 'Pick Reactions' })).toBeVisible({ timeout: 10000 });
+    await expect(async () => {
+      await page.reload();
+      await expect(page.getByText('Crystalline Carbonide')).toBeVisible({ timeout: 5000 });
+    }).toPass({ timeout: 30000 });
+
+    // Find the Instances field in the Crystalline Carbonide row and set it to 1
+    // The row contains the product name so we scope to the row
+    const carbonideRow = page.getByRole('row').filter({ hasText: 'Crystalline Carbonide' }).first();
+    const instancesInput = carbonideRow.getByPlaceholder('0');
+    await instancesInput.fill('1');
+
+    // The Shopping List tab label should update to show (1)
+    await expect(page.getByRole('tab', { name: /Shopping List \(1\)/i })).toBeVisible({ timeout: 5000 });
+
+    // Switch to Shopping List tab — it should now have materials
+    await page.getByRole('tab', { name: /Shopping List/i }).click();
+
+    // The plan API is called when selections change; wait for the shopping list to populate.
+    // The SDE import overwrites seeded blueprint materials with real EVE data, so we
+    // cannot test for specific material names like "Nocxium"/"Isogen" (seed data).
+    // Instead, verify the shopping list has items by waiting for the "Total" footer row
+    // which always appears when shopping_list.length > 0.
+    await expect(page.locator('td').filter({ hasText: /^Total$/ })).toBeVisible({ timeout: 15000 });
+
+    // Switch to Plan Summary tab — it should now show summary stats
+    await page.getByRole('tab', { name: 'Plan Summary' }).click();
+
+    // Plan Summary shows stat cards: Investment, Revenue, Profit
+    // Use exact:true for 'Profit' to avoid matching the "Net Profit" table column header
+    // from the Shopping List tab that may still be in DOM during tab transition.
+    await expect(page.getByText('Investment')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Revenue')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Profit', { exact: true })).toBeVisible({ timeout: 5000 });
+  });
+
+  test('structure dropdown changes persist to default Tatara', async ({ page }) => {
+    await page.goto('/reactions');
+
+    // MUI v7 Select without explicit labelId prop does not wire aria-labelledby automatically.
+    // Scope to the FormControl container that wraps the Structure label and combobox.
+    const structureControl = page.locator('.MuiFormControl-root').filter({
+      has: page.locator('label').filter({ hasText: 'Structure' }),
+    });
+    const structureSelect = structureControl.getByRole('combobox');
+    await expect(structureSelect).toBeVisible({ timeout: 10000 });
+
+    // The default structure is 'tatara' — verify the displayed value in the combobox
+    await expect(structureControl.getByRole('combobox')).toHaveText('Tatara', { timeout: 5000 });
+
+    // Change to Athanor
+    await structureSelect.click();
+    await page.getByRole('option', { name: 'Athanor' }).click();
+
+    // Verify the selection changed — scope to the combobox display value to avoid matching
+    // the MUI MenuItem "Athanor" that may still be in DOM after the dropdown closes.
+    await expect(structureControl.getByRole('combobox')).toHaveText('Athanor', { timeout: 5000 });
+  });
+});

--- a/e2e/tests/14-pi.spec.ts
+++ b/e2e/tests/14-pi.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test';
+import {
+  setCharacterPlanets,
+  setPlanetDetails,
+  resetMockESI,
+  type PiPlanet,
+  type PiColony,
+} from '../helpers/mock-esi';
+
+// Alice Alpha's character ID (created in 02-characters.spec.ts)
+const ALICE_ALPHA_ID = 2001001;
+
+// Jita solar system (exists in seed.sql)
+const JITA_SYSTEM_ID = 30000142;
+
+test.describe('Planetary Industry', () => {
+  test.afterAll(async () => {
+    await resetMockESI();
+  });
+
+  test('navigate to /pi shows heading and tabs', async ({ page }) => {
+    await page.goto('/pi');
+    // Clear PI tab state so we start on the Overview tab
+    await page.evaluate(() => localStorage.removeItem('pi-tab'));
+    await page.reload();
+
+    await expect(
+      page.getByRole('heading', { name: 'Planetary Industry' }),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Profit' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Supply Chain' })).toBeVisible();
+  });
+
+  test('Overview tab shows empty state when no planets are synced', async ({
+    page,
+  }) => {
+    await page.goto('/pi');
+    await page.evaluate(() => localStorage.removeItem('pi-tab'));
+    await page.reload();
+
+    // Overview is the default tab (index 0)
+    await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Wait for loading to complete then confirm empty state message
+    await expect(
+      page.getByText(/No planets found/i),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test('tab switching works', async ({ page }) => {
+    await page.goto('/pi');
+    await page.evaluate(() => localStorage.removeItem('pi-tab'));
+    await page.reload();
+
+    await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Switch to Profit tab
+    await page.getByRole('tab', { name: 'Profit' }).click();
+    // The profit table renders — just confirm we navigated away from overview empty state
+    // (Profit tab fetches from /api/pi/profit which returns empty data without planets)
+    await expect(
+      page.getByRole('tab', { name: 'Profit' }),
+    ).toHaveAttribute('aria-selected', 'true');
+
+    // Switch to Supply Chain tab
+    await page.getByRole('tab', { name: 'Supply Chain' }).click();
+    await expect(
+      page.getByRole('tab', { name: 'Supply Chain' }),
+    ).toHaveAttribute('aria-selected', 'true');
+
+    // Switch back to Overview
+    await page.getByRole('tab', { name: 'Overview' }).click();
+    await expect(
+      page.getByRole('tab', { name: 'Overview' }),
+    ).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('planets appear after injecting PI data and waiting for sync', async ({
+    page,
+  }) => {
+    // Inject a barren planet in Jita for Alice Alpha
+    const planet: PiPlanet = {
+      last_update: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1 hour ago
+      num_pins: 3,
+      owner_id: ALICE_ALPHA_ID,
+      planet_id: 40000001,
+      planet_type: 'barren',
+      solar_system_id: JITA_SYSTEM_ID,
+      upgrade_level: 4,
+    };
+
+    // A simple colony: one command center + one extractor (expired, so stale_data or expired status)
+    // Using a future expiry so the extractor shows as running
+    const futureExpiry = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const colony: PiColony = {
+      links: [],
+      pins: [
+        {
+          pin_id: 1001,
+          type_id: 2525, // barren command center
+          latitude: 0.1,
+          longitude: 0.2,
+          contents: [],
+        },
+        {
+          pin_id: 1002,
+          type_id: 3060, // Extractor Control Unit (barren)
+          latitude: 0.3,
+          longitude: 0.4,
+          expiry_time: futureExpiry,
+          install_time: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+          contents: [],
+          extractor_details: {
+            cycle_time: 1800,
+            head_radius: 0.01,
+            heads: [],
+            product_type_id: 2267, // Aqueous Liquids (P0 raw)
+            qty_per_cycle: 9000,
+          },
+        },
+      ],
+      routes: [],
+    };
+
+    await setCharacterPlanets(ALICE_ALPHA_ID, [planet]);
+    await setPlanetDetails(ALICE_ALPHA_ID, 40000001, colony);
+
+    // Wait for the PI runner to pick up the new mock data and write it to the DB.
+    // The runner interval is PI_UPDATE_INTERVAL_SEC=10 in E2E.
+    // Strategy: load the page, clear tab state, then reload until the planet appears.
+    await page.goto('/pi');
+    await page.evaluate(() => localStorage.removeItem('pi-tab'));
+
+    // Poll by reloading: the runner fires every 10s; after each reload the component
+    // fetches fresh data. We retry for up to 30s.
+    await expect(async () => {
+      await page.reload();
+      await expect(page.getByText(/Jita/i)).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 35000 });
+
+    // The planet card should show the planet type
+    await expect(page.getByText(/Barren/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('stats chips show planet and extractor counts after data is loaded', async ({
+    page,
+  }) => {
+    // Data from the previous test is already in the DB (runner synced it).
+    // Navigate fresh so the component fetches current state.
+    await page.goto('/pi');
+    await page.evaluate(() => localStorage.removeItem('pi-tab'));
+    await page.reload();
+
+    // Planet data should already be in DB from previous test — no need to wait for runner
+    await expect(page.getByText('Jita')).toBeVisible({ timeout: 15000 });
+
+    // StatChip labels appear in the overview stats bar.
+    // 'Planets' also appears as a navbar link, so use .last() to target the stats chip
+    // which is rendered after the navbar in DOM order.
+    await expect(page.getByText('Planets').last()).toBeVisible({ timeout: 5000 });
+    // 'Extractors' appears in both the StatChip (stats bar) and in each planet card
+    // that has extractors (as a section heading). Use .first() to target either.
+    await expect(page.getByText('Extractors').first()).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/e2e/tests/15-transport.spec.ts
+++ b/e2e/tests/15-transport.spec.ts
@@ -1,0 +1,216 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Transport', () => {
+  test('navigate to transport page shows heading and tabs', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Page heading (h5 Typography component renders as an h5 element)
+    await expect(page.getByRole('heading', { name: 'Transport' })).toBeVisible({ timeout: 10000 });
+
+    // All three tabs should be visible
+    await expect(page.getByRole('tab', { name: 'Transport Jobs' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Transport Profiles' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'JF Routes' })).toBeVisible();
+  });
+
+  test('Transport Jobs tab shows empty state', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Transport Jobs tab is active by default (index 0)
+    await expect(page.getByRole('tab', { name: 'Transport Jobs' })).toBeVisible({ timeout: 10000 });
+
+    // No jobs exist yet — empty state message
+    await expect(page.getByText('No transport jobs')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Transport Profiles tab shows empty state', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Click the Transport Profiles tab
+    await page.getByRole('tab', { name: 'Transport Profiles' }).click();
+
+    // No profiles exist yet — empty state message
+    await expect(page.getByText('No transport profiles configured')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('JF Routes tab shows empty state', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Click the JF Routes tab
+    await page.getByRole('tab', { name: 'JF Routes' }).click();
+
+    // No routes exist yet — empty state message
+    await expect(page.getByText('No JF routes configured')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('open add transport profile dialog', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Navigate to the Transport Profiles tab
+    await page.getByRole('tab', { name: 'Transport Profiles' }).click();
+    await expect(page.getByText('No transport profiles configured')).toBeVisible({ timeout: 10000 });
+
+    // Click "Add Profile"
+    await page.getByRole('button', { name: /Add Profile/i }).click();
+
+    // Dialog should appear with "Add Transport Profile" title
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText('Add Transport Profile')).toBeVisible();
+
+    // Dialog should have the Profile Name field
+    await expect(dialog.getByLabel('Profile Name')).toBeVisible();
+
+    // Transport Method dropdown should default to Freighter
+    await expect(dialog.getByText('Freighter')).toBeVisible();
+
+    // Cancel and verify dialog closes
+    await dialog.getByRole('button', { name: /Cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('create a freighter transport profile', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Navigate to the Transport Profiles tab
+    await page.getByRole('tab', { name: 'Transport Profiles' }).click();
+    // Wait for loading to complete: the "Add Profile" button appears only after loading=false.
+    // Then verify the empty state text is present.
+    await expect(page.getByRole('button', { name: /Add Profile/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('No transport profiles configured')).toBeVisible({ timeout: 5000 });
+
+    // Open add dialog
+    await page.getByRole('button', { name: /Add Profile/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Fill in the profile name
+    await dialog.getByLabel('Profile Name').fill('Jita Freighter');
+
+    // Transport Method is already "Freighter" — leave as is
+
+    // Set cargo capacity
+    const cargoInput = dialog.getByLabel('Cargo Capacity (m3)');
+    await cargoInput.clear();
+    await cargoInput.fill('860000');
+
+    // Set rate per m3 per jump (visible for non-JF methods)
+    const rateInput = dialog.getByLabel('Rate per m3 per Jump (ISK)');
+    await rateInput.clear();
+    await rateInput.fill('200');
+
+    // Create the profile
+    await dialog.getByRole('button', { name: /^Create$/i }).click();
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Profile should appear in the table
+    await expect(page.getByRole('cell', { name: 'Jita Freighter' })).toBeVisible({ timeout: 5000 });
+    // Use exact: true to match only the transport method chip ("Freighter"),
+    // not the profile name cell which contains the substring "Freighter" ("Jita Freighter")
+    await expect(page.getByText('Freighter', { exact: true })).toBeVisible();
+  });
+
+  test('edit transport profile changes cargo capacity', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Navigate to the Transport Profiles tab
+    await page.getByRole('tab', { name: 'Transport Profiles' }).click();
+
+    // Wait for the profile row created in the previous test
+    await expect(page.getByRole('cell', { name: 'Jita Freighter' })).toBeVisible({ timeout: 10000 });
+
+    // Click the edit icon button on the profile row
+    const profileRow = page.getByRole('row').filter({ hasText: 'Jita Freighter' });
+    await profileRow.getByRole('button').first().click();
+
+    // Dialog should open as "Edit Transport Profile"
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText('Edit Transport Profile')).toBeVisible();
+
+    // Update the profile name
+    const nameInput = dialog.getByLabel('Profile Name');
+    await nameInput.clear();
+    await nameInput.fill('Jita Freighter XL');
+
+    // Update cargo capacity
+    const cargoInput = dialog.getByLabel('Cargo Capacity (m3)');
+    await cargoInput.clear();
+    await cargoInput.fill('1200000');
+
+    // Save
+    await dialog.getByRole('button', { name: /^Update$/i }).click();
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Verify updated name appears in the table
+    await expect(page.getByRole('cell', { name: 'Jita Freighter XL' })).toBeVisible({ timeout: 5000 });
+  });
+
+  test('delete transport profile removes it from the table', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Navigate to the Transport Profiles tab
+    await page.getByRole('tab', { name: 'Transport Profiles' }).click();
+
+    // Wait for the profile row created in previous tests
+    await expect(page.getByRole('cell', { name: 'Jita Freighter XL' })).toBeVisible({ timeout: 10000 });
+
+    // Accept the native browser confirm dialog
+    page.on('dialog', dialog => dialog.accept());
+
+    // Click the delete icon button on the profile row
+    const profileRow = page.getByRole('row').filter({ hasText: 'Jita Freighter XL' });
+    await profileRow.getByRole('button').last().click();
+
+    // Profile should be removed and empty state should appear
+    await expect(page.getByText('No transport profiles configured')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('open add JF route dialog and cancel', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Navigate to the JF Routes tab
+    await page.getByRole('tab', { name: 'JF Routes' }).click();
+    await expect(page.getByText('No JF routes configured')).toBeVisible({ timeout: 10000 });
+
+    // Click "Add JF Route"
+    await page.getByRole('button', { name: /Add JF Route/i }).click();
+
+    // Dialog should appear with "Add JF Route" title
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText('Add JF Route')).toBeVisible();
+
+    // Dialog should have Route Name field and Origin/Destination system inputs
+    await expect(dialog.getByLabel('Route Name')).toBeVisible();
+    await expect(dialog.getByLabel('Origin System')).toBeVisible();
+    await expect(dialog.getByLabel('Destination System')).toBeVisible();
+
+    // Cancel and verify dialog closes
+    await dialog.getByRole('button', { name: /Cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('open add transport job dialog and cancel', async ({ page }) => {
+    await page.goto('/transport');
+
+    // Transport Jobs tab is the default (index 0)
+    await expect(page.getByText('No transport jobs')).toBeVisible({ timeout: 10000 });
+
+    // Click "Create Transport Job"
+    await page.getByRole('button', { name: /Create Transport Job/i }).click();
+
+    // Dialog should appear
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Cancel and verify dialog closes
+    await dialog.getByRole('button', { name: /Cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/e2e/tests/16-settings.spec.ts
+++ b/e2e/tests/16-settings.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Settings', () => {
+  test('navigate to settings page shows Settings heading', async ({ page }) => {
+    await page.goto('/settings');
+
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Discord settings section is visible in unlinked state', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Discord Notifications card heading is visible
+    await expect(page.getByText('Discord Notifications')).toBeVisible({ timeout: 10000 });
+
+    // Unlinked state: descriptive text and link button are shown
+    await expect(
+      page.getByText('Link your Discord account to receive notifications when marketplace events occur.')
+    ).toBeVisible();
+
+    await expect(page.getByRole('link', { name: /Link Discord Account/i })).toBeVisible();
+  });
+
+  test('page renders without errors', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Page loads and the main container content is visible
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible({ timeout: 10000 });
+
+    // No error boundary or crash message
+    await expect(page.getByText(/something went wrong/i)).not.toBeVisible();
+    await expect(page.getByText(/application error/i)).not.toBeVisible();
+
+    // Notification Targets section is NOT shown when Discord is unlinked
+    await expect(page.getByText('Notification Targets')).not.toBeVisible();
+  });
+});

--- a/frontend/pages/api/e2e/add-character.ts
+++ b/frontend/pages/api/e2e/add-character.ts
@@ -29,7 +29,15 @@ export default async function handler(
     esiToken: `fake-token-${characterName.toLowerCase().replace(/\s+/g, "-")}`,
     esiRefreshToken: `fake-refresh-${characterName.toLowerCase().replace(/\s+/g, "-")}`,
     esiTokenExpiresOn: expiresOn,
-    esiScopes: "publicData esi-assets.read_assets.v1",
+    esiScopes: [
+      "publicData",
+      "esi-assets.read_assets.v1",
+      "esi-skills.read_skills.v1",
+      "esi-industry.read_character_jobs.v1",
+      "esi-characters.read_blueprints.v1",
+      "esi-planets.manage_planets.v1",
+      "esi-contracts.read_character_contracts.v1",
+    ].join(" "),
   });
 
   if (response.kind === "error") {


### PR DESCRIPTION
## Summary
- **Dynamic Mock ESI**: Refactored `cmd/mock-esi/main.go` to use a thread-safe `State` struct with `sync.RWMutex`. Added `/_admin/` endpoints (reset, character-assets, character-skills, character-industry-jobs, character-blueprints, corp-assets, market-orders, character-planets, planet-details) for runtime data manipulation during tests.
- **7 new E2E test files**: Industry jobs (`10`), stations (`11`), production plans (`12`), reactions (`13`), planetary industry (`14`), transport (`15`), and settings (`16`) — expanding from 54 to 104 total test cases.
- **Playwright helper module**: `e2e/helpers/mock-esi.ts` with typed TypeScript functions wrapping all admin API endpoints.
- **SDE seed data**: Extended `e2e/seed.sql` with blueprint, reaction, and PI data needed for industry/reactions tests.
- **New CLAUDE.md rule**: Rule 5 now requires E2E tests for all frontend-touching features.

## Test plan
- [x] All 104 E2E tests pass (`make test-e2e-ci`)
- [x] Existing 54 tests unaffected (no regressions)
- [x] Dynamic mock ESI admin API tested via industry and PI test files
- [x] Documentation updated: `e2e-testing.md`, `sdet.md`, `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)