### PR TITLE
Fix contract sync: add missing corp contracts ESI scope

### DIFF
--- a/frontend/packages/client/auth/api.ts
+++ b/frontend/packages/client/auth/api.ts
@@ -53,6 +53,7 @@ export let corpScopesArray = [
     "esi-corporations.read_starbases.v1",
     "esi-industry.read_corporation_jobs.v1",
     "esi-markets.read_corporation_orders.v1",
+    "esi-contracts.read_corporation_contracts.v1",
     "esi-corporations.read_container_logs.v1",
     "esi-industry.read_corporation_mining.v1",
     "esi-corporations.read_facilities.v1",


### PR DESCRIPTION
## Summary
- Corporation OAuth flow was missing `esi-contracts.read_corporation_contracts.v1` scope
- This caused contract sync to skip all corporation contracts, so purchases assigned to a buyer's corporation (like the "221st Support group" case) would never auto-complete from `contract_created` → `completed`
- Adds the missing scope to `corpScopesArray`

**Note:** Existing users will need to re-add their corporations to pick up the new scope.

## Test plan
- [ ] Verify corp OAuth flow now requests the contracts scope
- [ ] Re-add a corporation and confirm `esi-contracts.read_corporation_contracts.v1` appears in stored scopes
- [ ] Create a purchase, mark contract_created, complete the in-game contract assigned to a corp, and verify auto-completion within 15 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)