### PR TITLE
Fix contract sync varchar overflow on contract_key

### DIFF
--- a/internal/database/migrations/20260227102630_widen_contract_key_to_text.down.sql
+++ b/internal/database/migrations/20260227102630_widen_contract_key_to_text.down.sql
@@ -1,0 +1,4 @@
+-- Migration: widen_contract_key_to_text
+-- Created: Fri Feb 27 10:26:30 AM PST 2026
+
+alter table purchase_transactions alter column contract_key type varchar(50);

--- a/internal/database/migrations/20260227102630_widen_contract_key_to_text.up.sql
+++ b/internal/database/migrations/20260227102630_widen_contract_key_to_text.up.sql
@@ -1,0 +1,4 @@
+-- Migration: widen_contract_key_to_text
+-- Created: Fri Feb 27 10:26:30 AM PST 2026
+
+alter table purchase_transactions alter column contract_key type text;


### PR DESCRIPTION
## Summary
- Widens `purchase_transactions.contract_key` from `VARCHAR(50)` to `TEXT`
- Fixes `pq: value too long for type character varying(50)` error during contract sync auto-completion
- `CompleteWithContractID` appends ` [EVE:{id}]` to the existing key, which can exceed 50 chars

## Notes
- Metadata-only change in PostgreSQL — instant, no table rewrite, no index rebuild
- Auto-applied on next server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)