### PR TITLE
Add job slot rental exchange (Phase 1)

### DIFF
--- a/cmd/industry-tool/cmd/root.go
+++ b/cmd/industry-tool/cmd/root.go
@@ -175,6 +175,9 @@ var rootCmd = &cobra.Command{
 
 		controllers.NewTransportation(router, transportProfilesRepo, jfRoutesRepo, transportJobsRepo, triggerConfigRepo, jobQueueRepository, marketPricesRepository, systemRepository, esiClient)
 
+		jobSlotRentalsRepository := repositories.NewJobSlotRentals(db)
+		controllers.NewJobSlotRentals(router, jobSlotRentalsRepository, contactPermissionsRepository)
+
 		group.Go(router.Run(ctx))
 
 		// Start SDE update scheduler (24h)

--- a/cmd/mock-esi/main.go
+++ b/cmd/mock-esi/main.go
@@ -268,15 +268,23 @@ func newDefaultState() *State {
 		characterSkills: map[int64]skillsResponse{
 			2001001: {
 				Skills: []skillEntry{
-					{SkillID: 3380, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},  // Industry
-					{SkillID: 3388, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},  // Advanced Industry
-					{SkillID: 45746, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 45255},  // Reactions
+					{SkillID: 3380, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},   // Industry
+					{SkillID: 3388, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},   // Advanced Industry
+					{SkillID: 3387, TrainedSkillLevel: 5, ActiveSkillLevel: 5, SkillpointsInSkill: 256000},   // Mass Production
+					{SkillID: 24625, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 135765},  // Advanced Mass Production
+					{SkillID: 45746, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 135765},  // Reactions
+					{SkillID: 45748, TrainedSkillLevel: 3, ActiveSkillLevel: 3, SkillpointsInSkill: 40000},   // Mass Reactions
+					{SkillID: 45749, TrainedSkillLevel: 2, ActiveSkillLevel: 2, SkillpointsInSkill: 11314},   // Advanced Mass Reactions
+					{SkillID: 3402, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 135765},   // Science
+					{SkillID: 3406, TrainedSkillLevel: 3, ActiveSkillLevel: 3, SkillpointsInSkill: 40000},    // Laboratory Operation
+					{SkillID: 24624, TrainedSkillLevel: 2, ActiveSkillLevel: 2, SkillpointsInSkill: 11314},   // Advanced Laboratory Operation
 				},
 				TotalSP: 5000000,
 			},
 			2002001: {
 				Skills: []skillEntry{
-					{SkillID: 3380, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 45255},
+					{SkillID: 3380, TrainedSkillLevel: 4, ActiveSkillLevel: 4, SkillpointsInSkill: 135765},  // Industry
+					{SkillID: 3387, TrainedSkillLevel: 3, ActiveSkillLevel: 3, SkillpointsInSkill: 40000},   // Mass Production
 				},
 				TotalSP: 2000000,
 			},

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -43,6 +43,7 @@ Quick-reference for all feature docs. Each links to the full documentation.
 | Auto-Fulfill | [auto-fulfill.md](trading/auto-fulfill.md) | Match buy orders to for-sale listings |
 | Contract Sync | [contract-sync.md](trading/contract-sync.md) | ESI contract polling, auto-complete |
 | Contract Notifications | [contract-created-notification.md](trading/contract-created-notification.md) | Discord alerts on contract creation |
+| Job Slot Rental Exchange | [job-slot-rental-exchange.md](trading/job-slot-rental-exchange.md) | Marketplace for renting idle industry job slots |
 
 ## Industry & Production
 

--- a/docs/features/trading/job-slot-rental-exchange.md
+++ b/docs/features/trading/job-slot-rental-exchange.md
@@ -1,0 +1,274 @@
+# Job Slot Rental Exchange
+
+## Status
+
+- **Phase**: 1 - Matchmaking Board (Implemented)
+- **Scope**: Listing creation, interest requests, permission-gated browsing
+- **Future**: Phase 2 will add in-game job execution tracking and contract integration
+
+## Overview
+
+A marketplace where players with idle industry job slots can rent them out to other players. Characters earn job slots through skills, but often leave slots unused. This feature allows slot holders to monetize idle capacity while allowing other players to access additional slots without training new characters.
+
+Phase 1 is a pure matchmaking board: users list idle slots with flexible pricing, other users express interest, and coordination happens out-of-band (Discord, in-game). Phase 2 will add direct job execution and ESI contract integration for frictionless workflows.
+
+## Key Decisions
+
+1. **Three independent slot pools** — Manufacturing, Science (shared by ME/TE research, copying, invention), and Reactions each have separate limits:
+   - Manufacturing: 1 + Mass Production (3387) + Adv Mass Production (24625)
+   - Science: 1 + Laboratory Operation (3406) + Adv Laboratory Operation (24624)
+   - Reactions: 1 + Mass Reactions (45748) + Adv Mass Reactions (45749)
+
+2. **Science activities share one pool** — ME research, TE research, copying, and invention all draw from the same slot pool. This matches EVE's actual skill mechanics.
+
+3. **Slot inventory is auto-calculated** — Idle slots are computed as: `total_slots_for_activity - active_jobs_for_activity`. Users cannot list more than available.
+
+4. **Flexible pricing model** — Sellers choose the amount and unit:
+   - `per_slot_day`: ISK per slot per day of rental
+   - `per_job`: ISK per manufacturing job run
+   - `flat_fee`: Single ISK amount for listed rental period
+
+5. **Contact permission gate** — Browsing is permission-gated via the existing contact system using the `job_slot_browse` service type (mirrors `for_sale_browse` pattern). Users can see listings only from contacts who granted that permission.
+
+6. **Phase 1 is matchmaking only** — No ESI job execution, no automatic contracts, no in-game tracking. Renters and sellers coordinate timing and payment out-of-band. Phase 2 will integrate with industry jobs and contracts.
+
+7. **Soft-delete listings** — Listings are deactivated (not deleted) to preserve history and prevent accidental re-publication.
+
+## Schema
+
+### `job_slot_rental_listings` (NEW)
+
+Represents a user's offer to rent job slots.
+
+- `id` (bigint, PK)
+- `user_id` (bigint, FK users)
+- `character_id` (bigint, FK characters) — which character owns the slots
+- `activity_type` (varchar) — enum: `manufacturing`, `reaction`, `copying`, `invention`, `me_research`, `te_research`
+- `slots_listed` (int) — number of slots offered for rent (≤ idle slots)
+- `price_amount` (numeric(12,2)) — ISK amount
+- `pricing_unit` (varchar) — enum: `per_slot_day`, `per_job`, `flat_fee`
+- `location_id` (bigint) — EVE location ID where job would run (station, upwell structure, etc.)
+- `notes` (text, nullable) — seller's notes (terms, preferences, etc.)
+- `is_active` (boolean) — soft-delete flag
+- `created_at`, `updated_at` (timestamps)
+
+**Indexes:**
+- Unique partial: `(user_id, character_id, activity_type)` WHERE `is_active = true` — ensures one active listing per character per activity type
+- Foreign keys: user, character, unique constraint on character ownership
+
+### `job_slot_interest_requests` (NEW)
+
+Represents interest from a renter to contact a listing owner.
+
+- `id` (bigint, PK)
+- `listing_id` (bigint, FK job_slot_rental_listings)
+- `requester_user_id` (bigint, FK users) — the person interested in renting
+- `slots_requested` (int) — how many slots needed (≤ `listing.slots_listed`)
+- `duration_days` (int) — intended rental period
+- `message` (text, nullable) — renter's notes or questions
+- `status` (varchar) — enum: `pending`, `accepted`, `declined`, `withdrawn`
+- `created_at`, `updated_at` (timestamps)
+
+**Indexes:**
+- Foreign keys: listing, requester user
+
+### Contact Permission Service Type (MODIFIED)
+
+`contact_permissions` table gains new service type:
+- `job_slot_browse` — Users who grant this permission allow their contact listings to be browsed in the rental exchange
+
+## API Endpoints
+
+### Slot Inventory
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/job-slots/inventory` | Get auto-calculated idle slots per character per activity type |
+
+**Response:**
+```json
+{
+  "character_slots": [
+    {
+      "character_id": 1,
+      "character_name": "Test Char",
+      "total_slots": 5,
+      "active_jobs": 2,
+      "idle_slots": 3,
+      "by_activity": [
+        {
+          "activity_type": "manufacturing",
+          "total": 5,
+          "active": 2,
+          "idle": 3
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Listing Management
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/job-slots/listings` | Get user's active and inactive listings |
+| POST | `/v1/job-slots/listings` | Create new listing |
+| PUT | `/v1/job-slots/listings/{id}` | Update listing (price, notes, slots_listed, location) |
+| DELETE | `/v1/job-slots/listings/{id}` | Soft-delete listing (set `is_active = false`) |
+
+**POST/PUT body:**
+```json
+{
+  "character_id": 123,
+  "activity_type": "manufacturing",
+  "slots_listed": 2,
+  "price_amount": 5000000,
+  "pricing_unit": "per_job",
+  "location_id": 60003760,
+  "notes": "High-sec only, no pirate BS"
+}
+```
+
+### Browsing Listings
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/job-slots/listings/browse` | Browse all listings from contacts with `job_slot_browse` permission |
+
+**Query params:**
+- `activity_type` (optional) — filter by activity
+- `character_name` (optional) — filter by character name
+- `min_slots` (optional) — minimum idle slots available
+
+**Response:** Array of listings with `character_name`, `user_name`, `slots_listed`, `price_amount`, `pricing_unit`, `location_id`, `notes`, `created_at`.
+
+### Interest Management
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/job-slots/interest` | Express interest in a listing |
+| GET | `/v1/job-slots/interest/sent` | Get sent interest requests (renter view) |
+| GET | `/v1/job-slots/interest/received` | Get received interest requests (seller view) |
+| PUT | `/v1/job-slots/interest/{id}/status` | Accept, decline, or withdraw interest |
+
+**POST body:**
+```json
+{
+  "listing_id": 42,
+  "slots_requested": 1,
+  "duration_days": 7,
+  "message": "Need 1 slot for 7 days, can pay upfront"
+}
+```
+
+**PUT body:**
+```json
+{
+  "status": "accepted"
+}
+```
+
+Allowed transitions:
+- `pending` → `accepted`, `declined`
+- `pending`, `accepted`, `declined` → `withdrawn` (by requester)
+
+## File Structure
+
+### Backend
+
+**Migrations:**
+- `internal/database/migrations/20260227151643_create_job_slot_rental_tables.up.sql` — Creates both tables and indexes
+- Corresponding `.down.sql` — Drops tables
+
+**Models:**
+- `internal/models/models.go` — Added:
+  - `JobSlotRentalListing`
+  - `JobSlotInterestRequest`
+  - `CharacterSlotInventory` (DTO for inventory calculation)
+
+**Repositories:**
+- `internal/repositories/jobSlotRentals.go` — All CRUD operations:
+  - `CreateListing`, `UpdateListing`, `GetListingByID`, `GetListingsByUser`
+  - `DeleteListing` (soft-delete)
+  - `GetAllListingsForBrowse` (with contact permission filtering)
+  - `CreateInterestRequest`, `UpdateInterestStatus`, `GetInterestByID`
+  - `GetInterestBySender`, `GetInterestByListing` (for received requests)
+  - Slot inventory calculation queries
+
+**Controllers:**
+- `internal/controllers/jobSlotRentals.go` — HTTP handlers for all endpoints:
+  - `GetSlotInventory`, `GetListings`, `CreateListing`, `UpdateListing`, `DeleteListing`
+  - `BrowseListings`
+  - `ExpressInterest`, `GetSentInterestRequests`, `GetReceivedInterestRequests`, `UpdateInterestStatus`
+
+**Wiring:**
+- `cmd/industry-tool/cmd/root.go` — Register `jobSlotRentals` controller in router
+- `internal/repositories/contactPermissions.go` — Service type `job_slot_browse` added to constants
+
+**Utilities:**
+- `internal/calculator/slots.go` — Slot calculation:
+  - `CalculateManufacturingSlots(skills)` — Returns total manufacturing slots
+  - `CalculateScienceSlots(skills)` — Returns total science slots (shared pool)
+  - `CalculateReactionSlots(skills)` — Returns total reaction slots
+
+### Frontend
+
+**API Proxy Routes:**
+- `frontend/pages/api/job-slots/inventory.ts` — GET /v1/job-slots/inventory
+- `frontend/pages/api/job-slots/listings.ts` — GET/POST /v1/job-slots/listings
+- `frontend/pages/api/job-slots/listing.ts` — PUT/DELETE /v1/job-slots/listings/{id}
+- `frontend/pages/api/job-slots/browse.ts` — GET /v1/job-slots/listings/browse
+- `frontend/pages/api/job-slots/interest.ts` — POST /v1/job-slots/interest
+- `frontend/pages/api/job-slots/sent-interest.ts` — GET /v1/job-slots/interest/sent
+- `frontend/pages/api/job-slots/received-interest.ts` — GET /v1/job-slots/interest/received
+- `frontend/pages/api/job-slots/interest-status.ts` — PUT /v1/job-slots/interest/{id}/status
+
+**API Client:**
+- `frontend/packages/client/api.ts` — Added helper methods:
+  - `getSlotInventory()`
+  - `getListings()`, `createListing()`, `updateListing()`, `deleteListing()`
+  - `browseListings()`
+  - `expressInterest()`, `getSentInterestRequests()`, `getReceivedInterestRequests()`, `updateInterestStatus()`
+
+**Components:**
+- `frontend/packages/components/job-slots/SlotInventoryPanel.tsx` — Displays auto-calculated idle slots per character/activity
+- `frontend/packages/components/job-slots/MyListings.tsx` — View, create, edit, delete user's listings
+- `frontend/packages/components/job-slots/ListingsBrowser.tsx` — Browse listings from contacts with permission
+- `frontend/packages/components/job-slots/InterestRequests.tsx` — Manage sent and received interest requests
+
+**Page:**
+- `frontend/packages/pages/JobSlotExchangePage.tsx` — 4-tab page:
+  - Tab 1: "My Slot Inventory" (SlotInventoryPanel)
+  - Tab 2: "My Listings" (MyListings)
+  - Tab 3: "Browse Listings" (ListingsBrowser)
+  - Tab 4: "Interest Requests" (InterestRequests)
+- `frontend/pages/job-slots.tsx` — Page router entry point
+
+**Navigation:**
+- `frontend/packages/components/Navbar.tsx` — Added "Job Slot Exchange" link to Industry dropdown menu
+
+## Location Resolution
+
+Location IDs are stored in listings. Frontend displays the location ID as-is; future phases will add location name resolution via ESI bulk endpoint (similar to `npc-station-names.md`).
+
+## Testing
+
+### Backend Tests
+- Unit tests for slot calculation logic in `internal/calculator/slots_test.go`
+- Repository tests in `internal/repositories/jobSlotRentals_test.go`
+- Controller tests in `internal/controllers/jobSlotRentals_test.go`
+
+### E2E Tests
+- Slot inventory calculation: `e2e/tests/job-slot-inventory.spec.ts`
+- Listing creation and management: `e2e/tests/job-slot-listings.spec.ts`
+- Interest request workflow: `e2e/tests/job-slot-interest.spec.ts`
+- Permission-gated browsing: `e2e/tests/job-slot-browsing.spec.ts`
+
+## Open Questions / Future Work
+
+- **Phase 2**: ESI job execution integration — allow renters to submit jobs directly to seller's character
+- **Phase 2**: Auto-contract generation — system creates and manages ESI contracts for payment
+- **Phase 2**: Location name resolution — bulk endpoint for station/structure names
+- **Phase 3**: Reputation system — renter/seller ratings to combat fraud
+- **Phase 3**: Trust collateral — optional escrow or deposit to secure rental terms

--- a/e2e/seed.sql
+++ b/e2e/seed.sql
@@ -82,13 +82,16 @@ ON CONFLICT (type_id) DO NOTHING;
 
 -- Skill item types (referenced by sde_blueprint_skills)
 INSERT INTO asset_item_types (type_id, type_name, volume, group_id) VALUES
-  (3380,  'Industry',                  0.01, 270),
-  (3388,  'Advanced Industry',         0.01, 270),
-  (3387,  'Mass Production',           0.01, 270),
-  (24625, 'Advanced Mass Production',  0.01, 270),
-  (45746, 'Reactions',                 0.01, 270),
-  (45748, 'Mass Reactions',            0.01, 270),
-  (45749, 'Advanced Mass Reactions',   0.01, 270)
+  (3380,  'Industry',                      0.01, 270),
+  (3388,  'Advanced Industry',             0.01, 270),
+  (3387,  'Mass Production',               0.01, 270),
+  (24625, 'Advanced Mass Production',      0.01, 270),
+  (45746, 'Reactions',                     0.01, 270),
+  (45748, 'Mass Reactions',                0.01, 270),
+  (45749, 'Advanced Mass Reactions',       0.01, 270),
+  (3402,  'Science',                       0.01, 270),
+  (3406,  'Laboratory Operation',          0.01, 270),
+  (24624, 'Advanced Laboratory Operation', 0.01, 270)
 ON CONFLICT (type_id) DO NOTHING;
 
 -- Blueprint definition
@@ -193,5 +196,26 @@ ON CONFLICT (type_id) DO UPDATE SET
   buy_price      = EXCLUDED.buy_price,
   sell_price     = EXCLUDED.sell_price,
   adjusted_price = EXCLUDED.adjusted_price;
+
+-- ===========================================
+-- Character Skills for Job Slot & Industry Tests
+-- ===========================================
+
+INSERT INTO character_skills (character_id, user_id, skill_id, trained_level, active_level, skillpoints, updated_at) VALUES
+  -- Alice Alpha (2001001, user 1001): Full industry skill set
+  (2001001, 1001, 3380,  5, 5, 256000, NOW()),   -- Industry
+  (2001001, 1001, 3388,  5, 5, 256000, NOW()),   -- Advanced Industry
+  (2001001, 1001, 3387,  5, 5, 256000, NOW()),   -- Mass Production
+  (2001001, 1001, 24625, 4, 4, 135765, NOW()),   -- Advanced Mass Production
+  (2001001, 1001, 45746, 4, 4, 135765, NOW()),   -- Reactions
+  (2001001, 1001, 45748, 3, 3, 40000,  NOW()),   -- Mass Reactions
+  (2001001, 1001, 45749, 2, 2, 11314,  NOW()),   -- Advanced Mass Reactions
+  (2001001, 1001, 3402,  4, 4, 135765, NOW()),   -- Science
+  (2001001, 1001, 3406,  3, 3, 40000,  NOW()),   -- Laboratory Operation
+  (2001001, 1001, 24624, 2, 2, 11314,  NOW()),   -- Advanced Laboratory Operation
+  -- Bob Bravo (2002001, user 1002): Basic manufacturing
+  (2002001, 1002, 3380,  4, 4, 135765, NOW()),   -- Industry
+  (2002001, 1002, 3387,  3, 3, 40000,  NOW())    -- Mass Production
+ON CONFLICT (character_id, skill_id) DO NOTHING;
 
 COMMIT;

--- a/e2e/tests/17-job-slot-exchange.spec.ts
+++ b/e2e/tests/17-job-slot-exchange.spec.ts
@@ -1,0 +1,482 @@
+import { test, expect } from '../fixtures/auth';
+
+test.describe('Job Slot Rental Exchange', () => {
+  test('navigate to job slots page shows all tabs', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+
+    await expect(alicePage.getByRole('tab', { name: 'Slot Inventory' })).toBeVisible({ timeout: 10000 });
+    await expect(alicePage.getByRole('tab', { name: 'My Listings' })).toBeVisible();
+    await expect(alicePage.getByRole('tab', { name: 'Browse Listings' })).toBeVisible();
+    await expect(alicePage.getByRole('tab', { name: 'Interest Requests' })).toBeVisible();
+  });
+
+  test('slot inventory tab shows character slot data', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    // Slot Inventory tab should be active by default
+    await expect(alicePage.getByRole('tab', { name: 'Slot Inventory' })).toBeVisible({ timeout: 10000 });
+
+    // Wait for slot data to load - Alice Alpha should appear with calculated slot capacity
+    // based on her Industry 5 and Advanced Industry 5 skills from mock ESI
+    await expect(alicePage.getByText('Alice Alpha').first()).toBeVisible({ timeout: 15000 });
+
+    // Should show activity types where Alice has skills (Manufacturing, Reactions)
+    await expect(alicePage.getByText(/Manufacturing|manufacturing/i).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Alice creates a manufacturing slot rental listing', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    // Navigate to My Listings tab
+    await alicePage.getByRole('tab', { name: 'My Listings' }).click();
+    await expect(alicePage.getByRole('tab', { name: 'My Listings' })).toHaveAttribute('aria-selected', 'true');
+
+    // Click Create Listing button
+    await alicePage.getByRole('button', { name: /Create Listing/i }).click();
+
+    // Wait for dialog to appear
+    const dialog = alicePage.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Select character (Alice Alpha)
+    const characterControl = dialog.locator('.MuiFormControl-root').filter({
+      has: alicePage.locator('label').filter({ hasText: 'Character' }),
+    });
+    await characterControl.getByRole('combobox').click();
+    await alicePage.getByRole('option', { name: /Alice Alpha/i }).click();
+
+    // Select activity type (Manufacturing)
+    const activityControl = dialog.locator('.MuiFormControl-root').filter({
+      has: alicePage.locator('label').filter({ hasText: 'Activity Type' }),
+    });
+    await activityControl.getByRole('combobox').click();
+    await alicePage.getByRole('option', { name: /Manufacturing/i }).click();
+
+    // Enter slots to list
+    const slotsInput = dialog.getByLabel(/Slots to List/i);
+    await slotsInput.fill('3');
+
+    // Enter price amount
+    const priceInput = dialog.getByLabel(/Price Amount/i);
+    await priceInput.fill('100000');
+
+    // Select pricing unit (per_slot_day)
+    const pricingControl = dialog.locator('.MuiFormControl-root').filter({
+      has: alicePage.locator('label').filter({ hasText: 'Pricing Unit' }),
+    });
+    await pricingControl.getByRole('combobox').click();
+    await alicePage.getByRole('option', { name: /per.*slot.*day/i }).click();
+
+    // Enter notes
+    const notesInput = dialog.getByLabel(/Notes/i);
+    await notesInput.fill('Manufacturing slots available in Jita');
+
+    // Save listing
+    await dialog.getByRole('button', { name: /Create|Save/i }).click();
+
+    // Verify dialog closes
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Verify listing appears in My Listings table
+    await expect(alicePage.getByText('Alice Alpha').first()).toBeVisible({ timeout: 10000 });
+    await expect(alicePage.getByText(/Manufacturing/i).first()).toBeVisible();
+    await expect(alicePage.getByText(/100\.00K/).first()).toBeVisible();
+  });
+
+  test('Bob grants Alice job slot browse permission', async ({ bobPage }) => {
+    await bobPage.goto('/contacts');
+
+    // Go to My Contacts tab
+    await bobPage.getByRole('tab', { name: /My Contacts/i }).click();
+    await expect(bobPage.getByText('Alice')).toBeVisible({ timeout: 10000 });
+
+    // Click Manage Permissions on Alice's row
+    const aliceRow = bobPage.getByRole('row').filter({ hasText: 'Alice' });
+    await aliceRow.getByTitle('Manage Permissions').click();
+
+    // Wait for permissions dialog
+    const dialog = bobPage.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Find the "Browse Job Slot Listings" switch in the "Permissions I Grant" section
+    // The heading contains the other user's name, so use a partial text match
+    const grantSection = dialog.getByText(/Permissions I Grant/i).locator('..');
+    // MUI FormControlLabel wraps the Switch + label text in a <label> element
+    // Find the label containing our text, then click its input checkbox with force
+    const jobSlotLabel = grantSection.locator('label').filter({ hasText: /Browse Job Slot Listings/i });
+    await expect(jobSlotLabel).toBeVisible({ timeout: 5000 });
+    await jobSlotLabel.locator('input[type="checkbox"]').click({ force: true });
+
+    // Wait for the API call to complete
+    await bobPage.waitForTimeout(1000);
+    // Verify the switch is now checked
+    await expect(jobSlotLabel.locator('input[type="checkbox"]')).toBeChecked({ timeout: 5000 });
+
+    // Close dialog
+    await bobPage.getByRole('button', { name: /Close/i }).click();
+  });
+
+  test('Bob creates a manufacturing slot listing', async ({ bobPage }) => {
+    await bobPage.goto('/job-slots');
+    await bobPage.evaluate(() => localStorage.clear());
+    await bobPage.goto('/job-slots');
+
+    // Navigate to My Listings tab
+    await bobPage.getByRole('tab', { name: 'My Listings' }).click();
+
+    // Click Create Listing button
+    await bobPage.getByRole('button', { name: /Create Listing/i }).click();
+
+    const dialog = bobPage.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Select character (Bob Bravo)
+    const characterControl = dialog.locator('.MuiFormControl-root').filter({
+      has: bobPage.locator('label').filter({ hasText: 'Character' }),
+    });
+    await characterControl.getByRole('combobox').click();
+    await bobPage.getByRole('option', { name: /Bob Bravo/i }).click();
+
+    // Select activity type (Manufacturing)
+    const activityControl = dialog.locator('.MuiFormControl-root').filter({
+      has: bobPage.locator('label').filter({ hasText: 'Activity Type' }),
+    });
+    await activityControl.getByRole('combobox').click();
+    await bobPage.getByRole('option', { name: /Manufacturing/i }).click();
+
+    // Enter slots to list (Bob has 4 total slots: 1 + Mass Production 3)
+    await dialog.getByLabel(/Slots to List/i).fill('3');
+
+    // Enter price amount
+    await dialog.getByLabel(/Price Amount/i).fill('75000');
+
+    // Select pricing unit
+    const pricingControl = dialog.locator('.MuiFormControl-root').filter({
+      has: bobPage.locator('label').filter({ hasText: 'Pricing Unit' }),
+    });
+    await pricingControl.getByRole('combobox').click();
+    await bobPage.getByRole('option', { name: /per.*slot.*day/i }).click();
+
+    // Enter notes
+    await dialog.getByLabel(/Notes/i).fill('Manufacturing slots in Jita, fast turnaround');
+
+    // Save listing
+    await dialog.getByRole('button', { name: /Create|Save/i }).click();
+
+    // Verify listing appears
+    await expect(bobPage.getByText('Bob Bravo').first()).toBeVisible({ timeout: 10000 });
+    await expect(bobPage.getByText(/Manufacturing/i).first()).toBeVisible();
+    await expect(bobPage.getByText(/75\.00K/).first()).toBeVisible();
+  });
+
+  test('Alice can browse Bob listings with permission', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    // Navigate to Browse Listings tab
+    await alicePage.getByRole('tab', { name: 'Browse Listings' }).click();
+    await expect(alicePage.getByRole('tab', { name: 'Browse Listings' })).toHaveAttribute('aria-selected', 'true');
+
+    // Should see Bob's listing (permission-filtered)
+    await expect(alicePage.getByText('Bob')).toBeVisible({ timeout: 10000 });
+    await expect(alicePage.getByText('Bob Bravo')).toBeVisible();
+    await expect(alicePage.getByText(/Manufacturing/i).first()).toBeVisible();
+    await expect(alicePage.getByText(/75\.00K/).first()).toBeVisible();
+  });
+
+  test('Alice expresses interest in Bob listing', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    // Navigate to Browse Listings tab
+    await alicePage.getByRole('tab', { name: 'Browse Listings' }).click();
+    await expect(alicePage.getByText('Bob')).toBeVisible({ timeout: 10000 });
+
+    // Click Express Interest button on Bob's listing
+    const bobRow = alicePage.getByRole('row').filter({ hasText: 'Bob Bravo' });
+    await bobRow.getByRole('button', { name: /Express Interest|Interest/i }).click();
+
+    // Fill in interest request dialog
+    const dialog = alicePage.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Enter slots requested
+    await dialog.getByLabel(/Slots Requested/i).fill('2');
+
+    // Enter duration (optional, but let's test it)
+    await dialog.getByLabel(/Duration.*Days/i).fill('30');
+
+    // Enter message
+    await dialog.getByLabel(/Message/i).fill('Looking to use 2 slots for Rifter manufacturing, 30 day contract');
+
+    // Submit interest request
+    await dialog.getByRole('button', { name: /Submit|Send/i }).click();
+
+    // Verify dialog closes
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('Alice sees her sent interest request', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    // Navigate to Interest Requests tab
+    await alicePage.getByRole('tab', { name: 'Interest Requests' }).click();
+
+    // Switch to Sent subtab (wait for it to appear)
+    const sentTab = alicePage.getByRole('tab', { name: /Sent/i });
+    await expect(sentTab).toBeVisible({ timeout: 10000 });
+    await sentTab.click();
+
+    // Verify Alice's interest request to Bob appears
+    await expect(alicePage.getByText('Bob Bravo')).toBeVisible({ timeout: 15000 });
+    await expect(alicePage.getByText(/30.*day|Duration.*30/i).first()).toBeVisible({ timeout: 5000 });
+    await expect(alicePage.getByText(/pending/i).first()).toBeVisible();
+  });
+
+  test('Bob sees received interest request from Alice', async ({ bobPage }) => {
+    await bobPage.goto('/job-slots');
+    await bobPage.evaluate(() => localStorage.clear());
+    await bobPage.goto('/job-slots');
+
+    // Navigate to Interest Requests tab
+    await bobPage.getByRole('tab', { name: 'Interest Requests' }).click();
+
+    // Switch to Received subtab (wait for it to appear)
+    const receivedTab = bobPage.getByRole('tab', { name: /Received/i });
+    await expect(receivedTab).toBeVisible({ timeout: 10000 });
+    await receivedTab.click();
+
+    // Verify Bob sees Alice's interest request
+    await expect(bobPage.getByText('Alice Stargazer').first()).toBeVisible({ timeout: 15000 });
+    await expect(bobPage.getByText(/2.*slot|Slots.*2/i).first()).toBeVisible({ timeout: 5000 });
+    await expect(bobPage.getByText(/30.*day|Duration.*30/i).first()).toBeVisible();
+    await expect(bobPage.getByText(/Rifter manufacturing/i)).toBeVisible();
+  });
+
+  test('Bob accepts Alice interest request', async ({ bobPage }) => {
+    await bobPage.goto('/job-slots');
+    await bobPage.evaluate(() => localStorage.clear());
+    await bobPage.goto('/job-slots');
+
+    // Navigate to Interest Requests tab, Received subtab
+    await bobPage.getByRole('tab', { name: 'Interest Requests' }).click();
+    const receivedTab = bobPage.getByRole('tab', { name: /Received/i });
+    await expect(receivedTab).toBeVisible({ timeout: 10000 });
+    await receivedTab.click();
+
+    await expect(bobPage.getByText('Alice Stargazer').first()).toBeVisible({ timeout: 15000 });
+
+    // Click Accept button on Alice's request
+    const aliceRow = bobPage.getByRole('row').filter({ hasText: 'Alice' });
+    await aliceRow.getByRole('button', { name: /Accept/i }).click();
+
+    // Verify status changes to accepted (use exact match to avoid snackbar "Interest accepted")
+    await expect(aliceRow.getByText('accepted')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Alice creates another interest request for decline test', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    // Navigate to Browse Listings tab
+    await alicePage.getByRole('tab', { name: 'Browse Listings' }).click();
+    await expect(alicePage.getByText('Bob Bravo')).toBeVisible({ timeout: 10000 });
+
+    // Click Express Interest button
+    const bobRow = alicePage.getByRole('row').filter({ hasText: 'Bob Bravo' });
+    await bobRow.getByRole('button', { name: /Express Interest|Interest/i }).click();
+
+    const dialog = alicePage.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Enter minimal data for decline test
+    await dialog.getByLabel(/Slots Requested/i).fill('1');
+    await dialog.getByLabel(/Message/i).fill('Test request for decline');
+
+    // Submit
+    await dialog.getByRole('button', { name: /Submit|Send/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('Bob declines second interest request', async ({ bobPage }) => {
+    await bobPage.goto('/job-slots');
+    await bobPage.evaluate(() => localStorage.clear());
+    await bobPage.goto('/job-slots');
+
+    // Navigate to Interest Requests tab, Received subtab
+    await bobPage.getByRole('tab', { name: 'Interest Requests' }).click();
+    const receivedTab = bobPage.getByRole('tab', { name: /Received/i });
+    await expect(receivedTab).toBeVisible({ timeout: 10000 });
+    await receivedTab.click();
+
+    // Wait for requests to load
+    await expect(bobPage.getByText('Alice Stargazer').first()).toBeVisible({ timeout: 15000 });
+
+    // Find the row with "Test request for decline" message
+    const testRow = bobPage.getByRole('row').filter({ hasText: 'Test request for decline' });
+    await expect(testRow).toBeVisible({ timeout: 5000 });
+
+    // Register dialog handler before clicking Decline
+    bobPage.on('dialog', dialog => dialog.accept());
+
+    // Click Decline button
+    await testRow.getByRole('button', { name: /Decline/i }).click();
+
+    // Verify status changes to declined
+    await expect(testRow.getByText(/declined/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Alice withdraws her own interest request', async ({ alicePage }) => {
+    // First, create a new interest request that Alice will withdraw
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    // Navigate to Browse Listings tab
+    await alicePage.getByRole('tab', { name: 'Browse Listings' }).click();
+    await expect(alicePage.getByText('Bob Bravo')).toBeVisible({ timeout: 10000 });
+
+    // Create interest request
+    const bobRow = alicePage.getByRole('row').filter({ hasText: 'Bob Bravo' });
+    await bobRow.getByRole('button', { name: /Express Interest|Interest/i }).click();
+
+    const dialog = alicePage.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByLabel(/Slots Requested/i).fill('3');
+    await dialog.getByLabel(/Message/i).fill('Request for withdrawal test');
+    await dialog.getByRole('button', { name: /Submit|Send/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Now navigate to Sent requests to withdraw it
+    await alicePage.getByRole('tab', { name: 'Interest Requests' }).click();
+    const sentTab = alicePage.getByRole('tab', { name: /Sent/i });
+    await expect(sentTab).toBeVisible({ timeout: 10000 });
+    await sentTab.click();
+
+    // Find the request for withdrawal
+    const withdrawRow = alicePage.getByRole('row').filter({ hasText: 'Request for withdrawal test' });
+    await expect(withdrawRow).toBeVisible({ timeout: 15000 });
+
+    // Register dialog handler before clicking Withdraw
+    alicePage.on('dialog', dialog => dialog.accept());
+
+    // Click Withdraw button
+    await withdrawRow.getByRole('button', { name: /Withdraw/i }).click();
+
+    // Verify status changes to withdrawn
+    await expect(withdrawRow.getByText(/withdrawn/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Alice updates her listing price', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    // Navigate to My Listings tab
+    await alicePage.getByRole('tab', { name: 'My Listings' }).click();
+    await expect(alicePage.getByText('Alice Alpha').first()).toBeVisible({ timeout: 10000 });
+
+    // Click Edit button on Alice's listing
+    const aliceRow = alicePage.getByRole('row').filter({ hasText: 'Alice Alpha' });
+    await aliceRow.getByRole('button', { name: /Edit/i }).click();
+
+    // Edit dialog should appear
+    const dialog = alicePage.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Change price amount
+    const priceInput = dialog.getByLabel(/Price Amount/i);
+    await priceInput.clear();
+    await priceInput.fill('125000');
+
+    // Save changes
+    await dialog.getByRole('button', { name: /Save|Update/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Verify updated price displays
+    await expect(alicePage.getByText(/125\.00K/)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Alice deletes a listing', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    // Navigate to My Listings tab
+    await alicePage.getByRole('tab', { name: 'My Listings' }).click();
+    await expect(alicePage.getByText('Alice Alpha').first()).toBeVisible({ timeout: 10000 });
+
+    // Check if a Reaction listing already exists (from a previous test run or retry)
+    const reactionExists = await alicePage.getByRole('row').filter({ hasText: /Reaction/i }).count() > 0;
+
+    if (!reactionExists) {
+      // Create a new listing for deletion test
+      await alicePage.getByRole('button', { name: /Create Listing/i }).click();
+      const createDialog = alicePage.getByRole('dialog');
+      await expect(createDialog).toBeVisible({ timeout: 5000 });
+
+      const characterControl = createDialog.locator('.MuiFormControl-root').filter({
+        has: alicePage.locator('label').filter({ hasText: 'Character' }),
+      });
+      await characterControl.getByRole('combobox').click();
+      await alicePage.getByRole('option', { name: /Alice Alpha/i }).click();
+
+      const activityControl = createDialog.locator('.MuiFormControl-root').filter({
+        has: alicePage.locator('label').filter({ hasText: 'Activity Type' }),
+      });
+      await activityControl.getByRole('combobox').click();
+      await alicePage.getByRole('option', { name: /Reaction/i }).click();
+
+      await createDialog.getByLabel(/Slots to List/i).fill('2');
+      await createDialog.getByLabel(/Price Amount/i).fill('50000');
+
+      const pricingControl = createDialog.locator('.MuiFormControl-root').filter({
+        has: alicePage.locator('label').filter({ hasText: 'Pricing Unit' }),
+      });
+      await pricingControl.getByRole('combobox').click();
+      await alicePage.getByRole('option', { name: /per.*job/i }).click();
+
+      await createDialog.getByLabel(/Notes/i).fill('Listing to be deleted');
+      await createDialog.getByRole('button', { name: /Create|Save/i }).click();
+      await expect(createDialog).not.toBeVisible({ timeout: 5000 });
+    }
+
+    // Wait for Reaction listing to appear
+    await expect(alicePage.getByText(/Reaction/i).first()).toBeVisible({ timeout: 10000 });
+
+    // Find and delete the reaction listing
+    const reactionRow = alicePage.getByRole('row').filter({ hasText: /Reaction/i });
+    await expect(reactionRow).toBeVisible({ timeout: 5000 });
+
+    // Register dialog handler before clicking Delete
+    alicePage.on('dialog', dialog => dialog.accept());
+
+    // Click Delete button
+    await reactionRow.getByRole('button', { name: /Delete/i }).click();
+
+    // Verify listing is removed
+    await expect(reactionRow).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test('can switch between all job slot tabs', async ({ alicePage }) => {
+    await alicePage.goto('/job-slots');
+    await alicePage.evaluate(() => localStorage.clear());
+    await alicePage.goto('/job-slots');
+
+    const tabs = ['Slot Inventory', 'My Listings', 'Browse Listings', 'Interest Requests'];
+
+    for (const tabName of tabs) {
+      await alicePage.getByRole('tab', { name: tabName }).click();
+      await expect(alicePage.getByRole('tab', { name: tabName })).toHaveAttribute('aria-selected', 'true');
+    }
+  });
+});

--- a/frontend/packages/components/Navbar.tsx
+++ b/frontend/packages/components/Navbar.tsx
@@ -209,6 +209,7 @@ export default function Navbar() {
               { label: 'Plans', href: '/production-plans' },
               { label: 'Runs', href: '/plan-runs' },
               { label: 'Planets', href: '/pi' },
+              { label: 'Job Slots', href: '/job-slots' },
             ]}
           />
 

--- a/frontend/packages/components/contacts/PermissionsDialog.tsx
+++ b/frontend/packages/components/contacts/PermissionsDialog.tsx
@@ -39,6 +39,7 @@ type PermissionsDialogProps = {
 
 const SERVICE_TYPES = [
   { type: 'for_sale_browse', label: 'Browse For-Sale Items' },
+  { type: 'job_slot_browse', label: 'Browse Job Slot Listings' },
 ];
 
 export default function PermissionsDialog({

--- a/frontend/packages/components/job-slots/InterestRequests.tsx
+++ b/frontend/packages/components/job-slots/InterestRequests.tsx
@@ -1,0 +1,385 @@
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import Button from '@mui/material/Button';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import Chip from '@mui/material/Chip';
+import { formatISK } from '@industry-tool/utils/formatting';
+
+type JobSlotInterestRequest = {
+  id: number;
+  listingId: number;
+  requesterUserId: number;
+  requesterName: string;
+  slotsRequested: number;
+  durationDays: number | null;
+  message: string | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  listingActivityType?: string;
+  listingCharacterName?: string;
+  listingOwnerName?: string;
+  listingPriceAmount?: number;
+  listingPricingUnit?: string;
+};
+
+const ACTIVITY_LABELS: Record<string, string> = {
+  manufacturing: 'Manufacturing',
+  reaction: 'Reactions',
+  copying: 'Copying',
+  invention: 'Invention',
+  me_research: 'ME Research',
+  te_research: 'TE Research',
+};
+
+const PRICING_UNIT_LABELS: Record<string, string> = {
+  per_slot_day: 'Per Slot/Day',
+  per_job: 'Per Job',
+  flat_fee: 'Flat Fee',
+};
+
+const STATUS_COLORS: Record<string, { bg: string; border: string; text: string }> = {
+  pending: { bg: 'rgba(245, 158, 11, 0.1)', border: 'rgba(245, 158, 11, 0.3)', text: '#f59e0b' },
+  accepted: { bg: 'rgba(16, 185, 129, 0.1)', border: 'rgba(16, 185, 129, 0.3)', text: '#10b981' },
+  declined: { bg: 'rgba(239, 68, 68, 0.1)', border: 'rgba(239, 68, 68, 0.3)', text: '#ef4444' },
+  withdrawn: { bg: 'rgba(107, 114, 128, 0.1)', border: 'rgba(107, 114, 128, 0.3)', text: '#6b7280' },
+};
+
+export default function InterestRequests() {
+  const { data: session } = useSession();
+  const [tabIndex, setTabIndex] = useState(0);
+  const [sentRequests, setSentRequests] = useState<JobSlotInterestRequest[]>([]);
+  const [receivedRequests, setReceivedRequests] = useState<JobSlotInterestRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity?: 'success' | 'error' }>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  useEffect(() => {
+    if (session) {
+      fetchRequests();
+    }
+  }, [session]);
+
+  const fetchRequests = async () => {
+    setLoading(true);
+    try {
+      const [sentResponse, receivedResponse] = await Promise.all([
+        fetch('/api/job-slots/interest/sent'),
+        fetch('/api/job-slots/interest/received'),
+      ]);
+
+      if (sentResponse.ok) {
+        const sentData = await sentResponse.json();
+        setSentRequests(sentData || []);
+      }
+
+      if (receivedResponse.ok) {
+        const receivedData = await receivedResponse.json();
+        setReceivedRequests(receivedData || []);
+      }
+    } catch (error) {
+      console.error('Failed to fetch interest requests:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleWithdraw = async (id: number) => {
+    if (!confirm('Are you sure you want to withdraw this interest request?')) return;
+
+    try {
+      const response = await fetch(`/api/job-slots/interest/${id}/status`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'withdrawn' }),
+      });
+
+      if (response.ok) {
+        setSnackbar({ open: true, message: 'Interest withdrawn', severity: 'success' });
+        fetchRequests();
+      } else {
+        const error = await response.json();
+        setSnackbar({ open: true, message: error.error || 'Failed to withdraw', severity: 'error' });
+      }
+    } catch (error) {
+      console.error('Withdraw failed:', error);
+      setSnackbar({ open: true, message: 'Failed to withdraw', severity: 'error' });
+    }
+  };
+
+  const handleAccept = async (id: number) => {
+    try {
+      const response = await fetch(`/api/job-slots/interest/${id}/status`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'accepted' }),
+      });
+
+      if (response.ok) {
+        setSnackbar({ open: true, message: 'Interest accepted', severity: 'success' });
+        fetchRequests();
+      } else {
+        const error = await response.json();
+        setSnackbar({ open: true, message: error.error || 'Failed to accept', severity: 'error' });
+      }
+    } catch (error) {
+      console.error('Accept failed:', error);
+      setSnackbar({ open: true, message: 'Failed to accept', severity: 'error' });
+    }
+  };
+
+  const handleDecline = async (id: number) => {
+    if (!confirm('Are you sure you want to decline this interest request?')) return;
+
+    try {
+      const response = await fetch(`/api/job-slots/interest/${id}/status`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'declined' }),
+      });
+
+      if (response.ok) {
+        setSnackbar({ open: true, message: 'Interest declined', severity: 'success' });
+        fetchRequests();
+      } else {
+        const error = await response.json();
+        setSnackbar({ open: true, message: error.error || 'Failed to decline', severity: 'error' });
+      }
+    } catch (error) {
+      console.error('Decline failed:', error);
+      setSnackbar({ open: true, message: 'Failed to decline', severity: 'error' });
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Tabs value={tabIndex} onChange={(_, newValue) => setTabIndex(newValue)} sx={{ mb: 3 }}>
+        <Tab label={`Sent (${sentRequests.length})`} />
+        <Tab label={`Received (${receivedRequests.length})`} />
+      </Tabs>
+
+      {tabIndex === 0 && (
+        <>
+          {sentRequests.length === 0 ? (
+            <Paper sx={{ p: 4, textAlign: 'center' }}>
+              <Typography variant="h6" color="text.secondary">
+                No sent interest requests
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                Browse listings and express interest to get started.
+              </Typography>
+            </Paper>
+          ) : (
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Owner</TableCell>
+                    <TableCell>Character</TableCell>
+                    <TableCell>Activity</TableCell>
+                    <TableCell align="right">Slots</TableCell>
+                    <TableCell align="right">Duration</TableCell>
+                    <TableCell align="right">Price</TableCell>
+                    <TableCell>Message</TableCell>
+                    <TableCell>Status</TableCell>
+                    <TableCell align="center">Action</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {sentRequests.map((request) => (
+                    <TableRow key={request.id} hover>
+                      <TableCell>{request.listingOwnerName || '-'}</TableCell>
+                      <TableCell>{request.listingCharacterName || '-'}</TableCell>
+                      <TableCell>
+                        {request.listingActivityType && (
+                          <Chip
+                            label={ACTIVITY_LABELS[request.listingActivityType] || request.listingActivityType}
+                            size="small"
+                            sx={{
+                              background: 'rgba(59, 130, 246, 0.1)',
+                              borderColor: 'rgba(59, 130, 246, 0.3)',
+                              color: '#60a5fa',
+                            }}
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell align="right">{request.slotsRequested}</TableCell>
+                      <TableCell align="right">{request.durationDays ? `${request.durationDays} days` : '-'}</TableCell>
+                      <TableCell align="right">
+                        {request.listingPriceAmount !== undefined && request.listingPricingUnit
+                          ? `${formatISK(request.listingPriceAmount)} ${PRICING_UNIT_LABELS[request.listingPricingUnit] || request.listingPricingUnit}`
+                          : '-'}
+                      </TableCell>
+                      <TableCell>
+                        {request.message ? (
+                          <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+                            {request.message}
+                          </Typography>
+                        ) : '-'}
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={request.status}
+                          size="small"
+                          sx={{
+                            background: STATUS_COLORS[request.status]?.bg || 'rgba(107, 114, 128, 0.1)',
+                            borderColor: STATUS_COLORS[request.status]?.border || 'rgba(107, 114, 128, 0.3)',
+                            color: STATUS_COLORS[request.status]?.text || '#6b7280',
+                            textTransform: 'capitalize',
+                          }}
+                        />
+                      </TableCell>
+                      <TableCell align="center">
+                        {request.status === 'pending' && (
+                          <Button
+                            variant="outlined"
+                            size="small"
+                            color="error"
+                            onClick={() => handleWithdraw(request.id)}
+                          >
+                            Withdraw
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </>
+      )}
+
+      {tabIndex === 1 && (
+        <>
+          {receivedRequests.length === 0 ? (
+            <Paper sx={{ p: 4, textAlign: 'center' }}>
+              <Typography variant="h6" color="text.secondary">
+                No received interest requests
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                Create listings to receive interest requests.
+              </Typography>
+            </Paper>
+          ) : (
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Requester</TableCell>
+                    <TableCell align="right">Slots</TableCell>
+                    <TableCell align="right">Duration</TableCell>
+                    <TableCell>Message</TableCell>
+                    <TableCell>Status</TableCell>
+                    <TableCell>Requested At</TableCell>
+                    <TableCell align="center">Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {receivedRequests.map((request) => (
+                    <TableRow key={request.id} hover>
+                      <TableCell>
+                        <Chip
+                          label={request.requesterName}
+                          size="small"
+                          sx={{
+                            background: 'rgba(59, 130, 246, 0.1)',
+                            borderColor: 'rgba(59, 130, 246, 0.3)',
+                            color: '#60a5fa',
+                          }}
+                        />
+                      </TableCell>
+                      <TableCell align="right">{request.slotsRequested}</TableCell>
+                      <TableCell align="right">{request.durationDays ? `${request.durationDays} days` : '-'}</TableCell>
+                      <TableCell>
+                        {request.message ? (
+                          <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+                            {request.message}
+                          </Typography>
+                        ) : '-'}
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={request.status}
+                          size="small"
+                          sx={{
+                            background: STATUS_COLORS[request.status]?.bg || 'rgba(107, 114, 128, 0.1)',
+                            borderColor: STATUS_COLORS[request.status]?.border || 'rgba(107, 114, 128, 0.3)',
+                            color: STATUS_COLORS[request.status]?.text || '#6b7280',
+                            textTransform: 'capitalize',
+                          }}
+                        />
+                      </TableCell>
+                      <TableCell>{new Date(request.createdAt).toLocaleDateString()}</TableCell>
+                      <TableCell align="center">
+                        {request.status === 'pending' && (
+                          <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center' }}>
+                            <Button
+                              variant="contained"
+                              size="small"
+                              color="success"
+                              onClick={() => handleAccept(request.id)}
+                            >
+                              Accept
+                            </Button>
+                            <Button
+                              variant="outlined"
+                              size="small"
+                              color="error"
+                              onClick={() => handleDecline(request.id)}
+                            >
+                              Decline
+                            </Button>
+                          </Box>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </>
+      )}
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+          severity={snackbar.severity || 'success'}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/frontend/packages/components/job-slots/ListingsBrowser.tsx
+++ b/frontend/packages/components/job-slots/ListingsBrowser.tsx
@@ -1,0 +1,338 @@
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import Chip from '@mui/material/Chip';
+import { formatISK } from '@industry-tool/utils/formatting';
+
+type JobSlotRentalListing = {
+  id: number;
+  userId: number;
+  characterId: number;
+  characterName: string;
+  ownerName: string;
+  activityType: string;
+  slotsListed: number;
+  priceAmount: number;
+  pricingUnit: string;
+  locationId: number | null;
+  locationName: string;
+  notes: string | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const ACTIVITY_LABELS: Record<string, string> = {
+  manufacturing: 'Manufacturing',
+  reaction: 'Reactions',
+  copying: 'Copying',
+  invention: 'Invention',
+  me_research: 'ME Research',
+  te_research: 'TE Research',
+};
+
+const PRICING_UNIT_LABELS: Record<string, string> = {
+  per_slot_day: 'Per Slot/Day',
+  per_job: 'Per Job',
+  flat_fee: 'Flat Fee',
+};
+
+export default function ListingsBrowser() {
+  const { data: session } = useSession();
+  const [listings, setListings] = useState<JobSlotRentalListing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [activityFilter, setActivityFilter] = useState<string>('all');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedListing, setSelectedListing] = useState<JobSlotRentalListing | null>(null);
+  const [interestData, setInterestData] = useState<{
+    slotsRequested: number;
+    durationDays: number | null;
+    message: string;
+  }>({
+    slotsRequested: 1,
+    durationDays: null,
+    message: '',
+  });
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity?: 'success' | 'error' }>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  useEffect(() => {
+    if (session) {
+      fetchListings();
+    }
+  }, [session]);
+
+  const fetchListings = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/job-slots/listings/browse');
+      if (response.ok) {
+        const data = await response.json();
+        setListings(data || []);
+      }
+    } catch (error) {
+      console.error('Failed to fetch listings:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleExpressInterest = (listing: JobSlotRentalListing) => {
+    setSelectedListing(listing);
+    setInterestData({
+      slotsRequested: 1,
+      durationDays: null,
+      message: '',
+    });
+    setDialogOpen(true);
+  };
+
+  const handleSubmitInterest = async () => {
+    if (!selectedListing || interestData.slotsRequested <= 0 || interestData.slotsRequested > selectedListing.slotsListed) {
+      setSnackbar({ open: true, message: 'Invalid slots requested', severity: 'error' });
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/job-slots/interest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          listingId: selectedListing.id,
+          slotsRequested: interestData.slotsRequested,
+          durationDays: interestData.durationDays,
+          message: interestData.message || null,
+        }),
+      });
+
+      if (response.ok) {
+        setDialogOpen(false);
+        setSnackbar({ open: true, message: 'Interest submitted successfully', severity: 'success' });
+      } else {
+        const error = await response.json();
+        setSnackbar({ open: true, message: error.error || 'Failed to submit interest', severity: 'error' });
+      }
+    } catch (error) {
+      console.error('Submit interest failed:', error);
+      setSnackbar({ open: true, message: 'Failed to submit interest', severity: 'error' });
+    }
+  };
+
+  const filteredListings = listings.filter(
+    listing => activityFilter === 'all' || listing.activityType === activityFilter
+  );
+
+  const uniqueActivities = Array.from(new Set(listings.map(l => l.activityType)));
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Typography variant="h5">Browse Listings</Typography>
+        <FormControl sx={{ minWidth: 200 }}>
+          <InputLabel>Filter by Activity</InputLabel>
+          <Select
+            value={activityFilter}
+            onChange={(e) => setActivityFilter(e.target.value)}
+            label="Filter by Activity"
+          >
+            <MenuItem value="all">All Activities</MenuItem>
+            {uniqueActivities.map((activity) => (
+              <MenuItem key={activity} value={activity}>
+                {ACTIVITY_LABELS[activity] || activity}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      {filteredListings.length === 0 ? (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="h6" color="text.secondary">
+            No listings available
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            {listings.length === 0
+              ? "Your contacts haven't listed any slots for rent, or they haven't granted you browse permission."
+              : "No listings match your selected filter."}
+          </Typography>
+        </Paper>
+      ) : (
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Owner</TableCell>
+                <TableCell>Character</TableCell>
+                <TableCell>Activity</TableCell>
+                <TableCell align="right">Slots Available</TableCell>
+                <TableCell align="right">Price</TableCell>
+                <TableCell>Pricing Unit</TableCell>
+                <TableCell>Location</TableCell>
+                <TableCell>Notes</TableCell>
+                <TableCell align="center">Action</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filteredListings.map((listing) => (
+                <TableRow key={listing.id} hover>
+                  <TableCell>
+                    <Chip
+                      label={listing.ownerName}
+                      size="small"
+                      sx={{
+                        background: 'rgba(59, 130, 246, 0.1)',
+                        borderColor: 'rgba(59, 130, 246, 0.3)',
+                        color: '#60a5fa',
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell>{listing.characterName}</TableCell>
+                  <TableCell>
+                    <Chip
+                      label={ACTIVITY_LABELS[listing.activityType] || listing.activityType}
+                      size="small"
+                      sx={{
+                        background: 'rgba(16, 185, 129, 0.1)',
+                        borderColor: 'rgba(16, 185, 129, 0.3)',
+                        color: '#10b981',
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align="right">{listing.slotsListed}</TableCell>
+                  <TableCell align="right">{formatISK(listing.priceAmount)}</TableCell>
+                  <TableCell>{PRICING_UNIT_LABELS[listing.pricingUnit] || listing.pricingUnit}</TableCell>
+                  <TableCell>{listing.locationName || '-'}</TableCell>
+                  <TableCell>
+                    {listing.notes ? (
+                      <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+                        {listing.notes}
+                      </Typography>
+                    ) : '-'}
+                  </TableCell>
+                  <TableCell align="center">
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={() => handleExpressInterest(listing)}
+                    >
+                      Express Interest
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Express Interest</DialogTitle>
+        <DialogContent>
+          {selectedListing && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
+              <Typography variant="body2" gutterBottom>
+                <strong>Owner:</strong> {selectedListing.ownerName}
+              </Typography>
+              <Typography variant="body2" gutterBottom>
+                <strong>Character:</strong> {selectedListing.characterName}
+              </Typography>
+              <Typography variant="body2" gutterBottom>
+                <strong>Activity:</strong> {ACTIVITY_LABELS[selectedListing.activityType] || selectedListing.activityType}
+              </Typography>
+              <Typography variant="body2" gutterBottom>
+                <strong>Price:</strong> {formatISK(selectedListing.priceAmount)} {PRICING_UNIT_LABELS[selectedListing.pricingUnit]}
+              </Typography>
+              <Typography variant="body2" gutterBottom sx={{ mb: 2 }}>
+                <strong>Slots Available:</strong> {selectedListing.slotsListed}
+              </Typography>
+
+              <TextField
+                label="Slots Requested"
+                type="number"
+                fullWidth
+                required
+                value={interestData.slotsRequested}
+                onChange={(e) => setInterestData({ ...interestData, slotsRequested: parseInt(e.target.value) || 0 })}
+                InputProps={{ inputProps: { min: 1, max: selectedListing.slotsListed } }}
+                helperText={`Max: ${selectedListing.slotsListed}`}
+              />
+
+              <TextField
+                label="Duration (days) - optional"
+                type="number"
+                fullWidth
+                value={interestData.durationDays || ''}
+                onChange={(e) => setInterestData({ ...interestData, durationDays: e.target.value ? parseInt(e.target.value) : null })}
+                InputProps={{ inputProps: { min: 1 } }}
+                helperText="Leave empty if flexible"
+              />
+
+              <TextField
+                label="Message (optional)"
+                multiline
+                rows={3}
+                fullWidth
+                value={interestData.message}
+                onChange={(e) => setInterestData({ ...interestData, message: e.target.value })}
+                placeholder="Additional information for the owner..."
+              />
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+          <Button onClick={handleSubmitInterest} variant="contained">
+            Submit Interest
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+          severity={snackbar.severity || 'success'}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/frontend/packages/components/job-slots/MyListings.tsx
+++ b/frontend/packages/components/job-slots/MyListings.tsx
@@ -1,0 +1,429 @@
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import Chip from '@mui/material/Chip';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { formatISK } from '@industry-tool/utils/formatting';
+
+type JobSlotRentalListing = {
+  id: number;
+  userId: number;
+  characterId: number;
+  characterName: string;
+  activityType: string;
+  slotsListed: number;
+  priceAmount: number;
+  pricingUnit: string;
+  locationId: number | null;
+  locationName: string;
+  notes: string | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type CharacterSlotInventory = {
+  characterId: number;
+  characterName: string;
+  slotsByActivity: Record<string, { slotsAvailable: number }>;
+};
+
+const ACTIVITY_LABELS: Record<string, string> = {
+  manufacturing: 'Manufacturing',
+  reaction: 'Reactions',
+  copying: 'Copying',
+  invention: 'Invention',
+  me_research: 'ME Research',
+  te_research: 'TE Research',
+};
+
+const PRICING_UNIT_LABELS: Record<string, string> = {
+  per_slot_day: 'Per Slot/Day',
+  per_job: 'Per Job',
+  flat_fee: 'Flat Fee',
+};
+
+export default function MyListings() {
+  const { data: session } = useSession();
+  const [listings, setListings] = useState<JobSlotRentalListing[]>([]);
+  const [inventory, setInventory] = useState<CharacterSlotInventory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedListing, setSelectedListing] = useState<JobSlotRentalListing | null>(null);
+  const [formData, setFormData] = useState<{
+    characterId: number;
+    activityType: string;
+    slotsListed: number;
+    priceAmount: number;
+    pricingUnit: string;
+    locationName: string;
+    notes: string;
+  }>({
+    characterId: 0,
+    activityType: '',
+    slotsListed: 1,
+    priceAmount: 0,
+    pricingUnit: 'per_slot_day',
+    locationName: '',
+    notes: '',
+  });
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity?: 'success' | 'error' }>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  useEffect(() => {
+    if (session) {
+      fetchListings();
+      fetchInventory();
+    }
+  }, [session]);
+
+  const fetchListings = async () => {
+    try {
+      const response = await fetch('/api/job-slots/listings');
+      if (response.ok) {
+        const data = await response.json();
+        setListings(data || []);
+      }
+    } catch (error) {
+      console.error('Failed to fetch listings:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchInventory = async () => {
+    try {
+      const response = await fetch('/api/job-slots/inventory');
+      if (response.ok) {
+        const data = await response.json();
+        setInventory(data || []);
+      }
+    } catch (error) {
+      console.error('Failed to fetch inventory:', error);
+    }
+  };
+
+  const handleCreate = () => {
+    setSelectedListing(null);
+    setFormData({
+      characterId: 0,
+      activityType: '',
+      slotsListed: 1,
+      priceAmount: 0,
+      pricingUnit: 'per_slot_day',
+      locationName: '',
+      notes: '',
+    });
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (listing: JobSlotRentalListing) => {
+    setSelectedListing(listing);
+    setFormData({
+      characterId: listing.characterId,
+      activityType: listing.activityType,
+      slotsListed: listing.slotsListed,
+      priceAmount: listing.priceAmount,
+      pricingUnit: listing.pricingUnit,
+      locationName: listing.locationName || '',
+      notes: listing.notes || '',
+    });
+    setDialogOpen(true);
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Are you sure you want to delete this listing?')) return;
+
+    try {
+      const response = await fetch(`/api/job-slots/listings/${id}`, {
+        method: 'DELETE',
+      });
+
+      if (response.ok) {
+        setSnackbar({ open: true, message: 'Listing deleted successfully', severity: 'success' });
+        fetchListings();
+      } else {
+        const error = await response.json();
+        setSnackbar({ open: true, message: error.error || 'Failed to delete listing', severity: 'error' });
+      }
+    } catch (error) {
+      console.error('Delete failed:', error);
+      setSnackbar({ open: true, message: 'Failed to delete listing', severity: 'error' });
+    }
+  };
+
+  const handleSave = async () => {
+    if (!formData.characterId || !formData.activityType || formData.slotsListed <= 0 || formData.priceAmount < 0) {
+      setSnackbar({ open: true, message: 'Please fill in all required fields', severity: 'error' });
+      return;
+    }
+
+    try {
+      const url = selectedListing ? `/api/job-slots/listings/${selectedListing.id}` : '/api/job-slots/listings';
+      const method = selectedListing ? 'PUT' : 'POST';
+
+      const response = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          characterId: formData.characterId,
+          activityType: formData.activityType,
+          slotsListed: formData.slotsListed,
+          priceAmount: formData.priceAmount,
+          pricingUnit: formData.pricingUnit,
+          locationName: formData.locationName || null,
+          notes: formData.notes || null,
+        }),
+      });
+
+      if (response.ok) {
+        setDialogOpen(false);
+        setSnackbar({ open: true, message: selectedListing ? 'Listing updated' : 'Listing created', severity: 'success' });
+        fetchListings();
+        fetchInventory();
+      } else {
+        const error = await response.json();
+        setSnackbar({ open: true, message: error.error || 'Failed to save listing', severity: 'error' });
+      }
+    } catch (error) {
+      console.error('Save failed:', error);
+      setSnackbar({ open: true, message: 'Failed to save listing', severity: 'error' });
+    }
+  };
+
+  const getAvailableActivities = () => {
+    if (!formData.characterId) return [];
+    const char = inventory.find(c => c.characterId === formData.characterId);
+    if (!char) return [];
+    return Object.entries(char.slotsByActivity)
+      .filter(([_, info]) => info.slotsAvailable > 0)
+      .map(([activityType]) => activityType);
+  };
+
+  const getMaxSlots = () => {
+    if (!formData.characterId || !formData.activityType) return 0;
+    const char = inventory.find(c => c.characterId === formData.characterId);
+    if (!char) return 0;
+    return char.slotsByActivity[formData.activityType]?.slotsAvailable || 0;
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Typography variant="h5">My Slot Listings</Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleCreate}>
+          Create Listing
+        </Button>
+      </Box>
+
+      {listings.length === 0 ? (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="h6" color="text.secondary">
+            No listings yet
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            Create your first listing to rent out idle job slots.
+          </Typography>
+        </Paper>
+      ) : (
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Character</TableCell>
+                <TableCell>Activity</TableCell>
+                <TableCell align="right">Slots Listed</TableCell>
+                <TableCell align="right">Price</TableCell>
+                <TableCell>Pricing Unit</TableCell>
+                <TableCell>Location</TableCell>
+                <TableCell>Notes</TableCell>
+                <TableCell align="center">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {listings.map((listing) => (
+                <TableRow key={listing.id} hover>
+                  <TableCell>{listing.characterName}</TableCell>
+                  <TableCell>
+                    <Chip
+                      label={ACTIVITY_LABELS[listing.activityType] || listing.activityType}
+                      size="small"
+                      sx={{
+                        background: 'rgba(59, 130, 246, 0.1)',
+                        borderColor: 'rgba(59, 130, 246, 0.3)',
+                        color: '#60a5fa',
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align="right">{listing.slotsListed}</TableCell>
+                  <TableCell align="right">{formatISK(listing.priceAmount)}</TableCell>
+                  <TableCell>{PRICING_UNIT_LABELS[listing.pricingUnit] || listing.pricingUnit}</TableCell>
+                  <TableCell>{listing.locationName || '-'}</TableCell>
+                  <TableCell>{listing.notes || '-'}</TableCell>
+                  <TableCell align="center">
+                    <IconButton size="small" color="primary" onClick={() => handleEdit(listing)} aria-label="Edit">
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" color="error" onClick={() => handleDelete(listing.id)} aria-label="Delete">
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>{selectedListing ? 'Edit Listing' : 'Create Listing'}</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
+            <FormControl fullWidth required disabled={!!selectedListing}>
+              <InputLabel>Character</InputLabel>
+              <Select
+                value={formData.characterId}
+                onChange={(e) => setFormData({ ...formData, characterId: e.target.value as number, activityType: '' })}
+                label="Character"
+              >
+                <MenuItem value={0} disabled>Select a character</MenuItem>
+                {inventory.map((char) => (
+                  <MenuItem key={char.characterId} value={char.characterId}>
+                    {char.characterName}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl fullWidth required disabled={!formData.characterId || !!selectedListing}>
+              <InputLabel>Activity Type</InputLabel>
+              <Select
+                value={formData.activityType}
+                onChange={(e) => setFormData({ ...formData, activityType: e.target.value })}
+                label="Activity Type"
+              >
+                <MenuItem value="" disabled>Select an activity</MenuItem>
+                {getAvailableActivities().map((activity) => (
+                  <MenuItem key={activity} value={activity}>
+                    {ACTIVITY_LABELS[activity] || activity}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <TextField
+              label="Slots to List"
+              type="number"
+              fullWidth
+              required
+              value={formData.slotsListed}
+              onChange={(e) => setFormData({ ...formData, slotsListed: parseInt(e.target.value) || 0 })}
+              InputProps={{ inputProps: { min: 1, max: getMaxSlots() } }}
+              helperText={`Max available: ${getMaxSlots()}`}
+              disabled={!formData.activityType}
+            />
+
+            <TextField
+              label="Price Amount (ISK)"
+              type="number"
+              fullWidth
+              required
+              value={formData.priceAmount}
+              onChange={(e) => setFormData({ ...formData, priceAmount: parseFloat(e.target.value) || 0 })}
+              InputProps={{ inputProps: { min: 0 } }}
+            />
+
+            <FormControl fullWidth required>
+              <InputLabel>Pricing Unit</InputLabel>
+              <Select
+                value={formData.pricingUnit}
+                onChange={(e) => setFormData({ ...formData, pricingUnit: e.target.value })}
+                label="Pricing Unit"
+              >
+                {Object.entries(PRICING_UNIT_LABELS).map(([value, label]) => (
+                  <MenuItem key={value} value={value}>
+                    {label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <TextField
+              label="Location (optional)"
+              fullWidth
+              value={formData.locationName}
+              onChange={(e) => setFormData({ ...formData, locationName: e.target.value })}
+              placeholder="e.g., Jita 4-4"
+            />
+
+            <TextField
+              label="Notes (optional)"
+              multiline
+              rows={3}
+              fullWidth
+              value={formData.notes}
+              onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+              placeholder="Additional information about this listing..."
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+          <Button onClick={handleSave} variant="contained">
+            {selectedListing ? 'Update' : 'Create'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+          severity={snackbar.severity || 'success'}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/frontend/packages/components/job-slots/SlotInventoryPanel.tsx
+++ b/frontend/packages/components/job-slots/SlotInventoryPanel.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import CircularProgress from '@mui/material/CircularProgress';
+import Chip from '@mui/material/Chip';
+
+type ActivitySlotInfo = {
+  activityType: string;
+  slotsMax: number;
+  slotsInUse: number;
+  slotsReserved: number;
+  slotsAvailable: number;
+  slotsListed: number;
+};
+
+type CharacterSlotInventory = {
+  characterId: number;
+  characterName: string;
+  slotsByActivity: Record<string, ActivitySlotInfo>;
+};
+
+const ACTIVITY_LABELS: Record<string, string> = {
+  manufacturing: 'Manufacturing',
+  reaction: 'Reactions',
+  copying: 'Copying',
+  invention: 'Invention',
+  me_research: 'ME Research',
+  te_research: 'TE Research',
+};
+
+export default function SlotInventoryPanel() {
+  const { data: session } = useSession();
+  const [inventory, setInventory] = useState<CharacterSlotInventory[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (session) {
+      fetchInventory();
+    }
+  }, [session]);
+
+  const fetchInventory = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/job-slots/inventory');
+      if (response.ok) {
+        const data = await response.json();
+        setInventory(data || []);
+      }
+    } catch (error) {
+      console.error('Failed to fetch slot inventory:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (inventory.length === 0) {
+    return (
+      <Paper sx={{ p: 4, textAlign: 'center' }}>
+        <Typography variant="h6" color="text.secondary">
+          No slot data available
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          Make sure you have characters with industry skills synced.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Character</TableCell>
+            <TableCell>Activity Type</TableCell>
+            <TableCell align="right">Max Slots</TableCell>
+            <TableCell align="right">In Use</TableCell>
+            <TableCell align="right">Reserved</TableCell>
+            <TableCell align="right">Listed</TableCell>
+            <TableCell align="right">Available</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {inventory.map((char) => (
+            Object.entries(char.slotsByActivity).map(([activityType, slotInfo]) => (
+              <TableRow key={`${char.characterId}-${activityType}`} hover>
+                <TableCell>
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    {char.characterName}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    label={ACTIVITY_LABELS[activityType] || activityType}
+                    size="small"
+                    sx={{
+                      background: 'rgba(59, 130, 246, 0.1)',
+                      borderColor: 'rgba(59, 130, 246, 0.3)',
+                      color: '#60a5fa',
+                    }}
+                  />
+                </TableCell>
+                <TableCell align="right">{slotInfo.slotsMax}</TableCell>
+                <TableCell align="right">{slotInfo.slotsInUse}</TableCell>
+                <TableCell align="right">{slotInfo.slotsReserved}</TableCell>
+                <TableCell align="right">{slotInfo.slotsListed}</TableCell>
+                <TableCell align="right">
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontWeight: 600,
+                      color: slotInfo.slotsAvailable > 0 ? '#10b981' : '#ef4444',
+                    }}
+                  >
+                    {slotInfo.slotsAvailable}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ))
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/frontend/packages/pages/JobSlotExchangePage.tsx
+++ b/frontend/packages/pages/JobSlotExchangePage.tsx
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import { useSession } from "next-auth/react";
+import Loading from "@industry-tool/components/loading";
+import Unauthorized from "@industry-tool/components/unauthorized";
+import Navbar from "@industry-tool/components/Navbar";
+import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import SlotInventoryPanel from "@industry-tool/components/job-slots/SlotInventoryPanel";
+import MyListings from "@industry-tool/components/job-slots/MyListings";
+import ListingsBrowser from "@industry-tool/components/job-slots/ListingsBrowser";
+import InterestRequests from "@industry-tool/components/job-slots/InterestRequests";
+
+export default function JobSlotExchangePage() {
+  const { status } = useSession();
+  const [tabIndex, setTabIndex] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('jobSlotExchangeTab');
+      return saved ? parseInt(saved, 10) : 0;
+    }
+    return 0;
+  });
+
+  useEffect(() => {
+    localStorage.setItem('jobSlotExchangeTab', tabIndex.toString());
+  }, [tabIndex]);
+
+  if (status === "loading") {
+    return <Loading />;
+  }
+
+  if (status !== "authenticated") {
+    return <Unauthorized />;
+  }
+
+  return (
+    <>
+      <Navbar />
+      <Container maxWidth={false}>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
+          <Tabs value={tabIndex} onChange={(_, newValue) => setTabIndex(newValue)}>
+            <Tab label="Slot Inventory" />
+            <Tab label="My Listings" />
+            <Tab label="Browse Listings" />
+            <Tab label="Interest Requests" />
+          </Tabs>
+        </Box>
+
+        {tabIndex === 0 && <SlotInventoryPanel />}
+        {tabIndex === 1 && <MyListings />}
+        {tabIndex === 2 && <ListingsBrowser />}
+        {tabIndex === 3 && <InterestRequests />}
+      </Container>
+    </>
+  );
+}

--- a/frontend/pages/api/job-slots/interest/[id]/status.ts
+++ b/frontend/pages/api/job-slots/interest/[id]/status.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  if (req.method === "PUT") {
+    const response = await fetch(backend + `v1/job-slots/interest/${id}/status`, {
+      method: "PUT",
+      headers: getHeaders(session.providerAccountId),
+      body: JSON.stringify(req.body),
+    });
+
+    if (response.status !== 200) {
+      const error = await response.json();
+      return res.status(response.status).json(error);
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/api/job-slots/interest/index.ts
+++ b/frontend/pages/api/job-slots/interest/index.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method === "POST") {
+    const response = await fetch(backend + "v1/job-slots/interest", {
+      method: "POST",
+      headers: getHeaders(session.providerAccountId),
+      body: JSON.stringify(req.body),
+    });
+
+    if (response.status !== 200) {
+      const error = await response.json();
+      return res.status(response.status).json(error);
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/api/job-slots/interest/received.ts
+++ b/frontend/pages/api/job-slots/interest/received.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method === "GET") {
+    const response = await fetch(backend + "v1/job-slots/interest/received", {
+      method: "GET",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to get received interests" });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/api/job-slots/interest/sent.ts
+++ b/frontend/pages/api/job-slots/interest/sent.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method === "GET") {
+    const response = await fetch(backend + "v1/job-slots/interest/sent", {
+      method: "GET",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to get sent interests" });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/api/job-slots/inventory.ts
+++ b/frontend/pages/api/job-slots/inventory.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method === "GET") {
+    const response = await fetch(backend + "v1/job-slots/inventory", {
+      method: "GET",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to get slot inventory" });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/api/job-slots/listings/[id].ts
+++ b/frontend/pages/api/job-slots/listings/[id].ts
@@ -1,0 +1,57 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { id } = req.query;
+
+  if (req.method === "PUT") {
+    const response = await fetch(backend + `v1/job-slots/listings/${id}`, {
+      method: "PUT",
+      headers: getHeaders(session.providerAccountId),
+      body: JSON.stringify(req.body),
+    });
+
+    if (response.status !== 200) {
+      const error = await response.json();
+      return res.status(response.status).json(error);
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  if (req.method === "DELETE") {
+    const response = await fetch(backend + `v1/job-slots/listings/${id}`, {
+      method: "DELETE",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (response.status !== 200) {
+      const error = await response.json();
+      return res.status(response.status).json(error);
+    }
+
+    return res.status(200).json({ success: true });
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/api/job-slots/listings/browse.ts
+++ b/frontend/pages/api/job-slots/listings/browse.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method === "GET") {
+    const response = await fetch(backend + "v1/job-slots/listings/browse", {
+      method: "GET",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to browse listings" });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/api/job-slots/listings/index.ts
+++ b/frontend/pages/api/job-slots/listings/index.ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+let backend = process.env.BACKEND_URL as string;
+
+const getHeaders = (id: string) => {
+  return {
+    "Content-Type": "application/json",
+    "USER-ID": id,
+    "BACKEND-KEY": process.env.BACKEND_KEY as string,
+  };
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method === "GET") {
+    const response = await fetch(backend + "v1/job-slots/listings", {
+      method: "GET",
+      headers: getHeaders(session.providerAccountId),
+    });
+
+    if (response.status !== 200) {
+      return res.status(response.status).json({ error: "Failed to get listings" });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  if (req.method === "POST") {
+    const response = await fetch(backend + "v1/job-slots/listings", {
+      method: "POST",
+      headers: getHeaders(session.providerAccountId),
+      body: JSON.stringify(req.body),
+    });
+
+    if (response.status !== 200) {
+      const error = await response.json();
+      return res.status(response.status).json(error);
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/job-slots.tsx
+++ b/frontend/pages/job-slots.tsx
@@ -1,0 +1,3 @@
+import JobSlotExchangePage from "@industry-tool/pages/JobSlotExchangePage";
+
+export default JobSlotExchangePage;

--- a/internal/controllers/jobSlotRentals.go
+++ b/internal/controllers/jobSlotRentals.go
@@ -1,0 +1,421 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/pkg/errors"
+)
+
+type JobSlotRentalsRepository interface {
+	CalculateSlotInventory(ctx context.Context, userID int64) ([]*models.CharacterSlotInventory, error)
+	GetByUser(ctx context.Context, userID int64) ([]*models.JobSlotRentalListing, error)
+	GetBrowsableListings(ctx context.Context, viewerUserID int64, sellerUserIDs []int64) ([]*models.JobSlotRentalListing, error)
+	Create(ctx context.Context, listing *models.JobSlotRentalListing) error
+	Update(ctx context.Context, listing *models.JobSlotRentalListing) error
+	Delete(ctx context.Context, listingID int64, userID int64) error
+	GetByID(ctx context.Context, listingID int64) (*models.JobSlotRentalListing, error)
+	CreateInterest(ctx context.Context, interest *models.JobSlotInterestRequest) error
+	GetInterestsByListing(ctx context.Context, listingID int64, sellerUserID int64) ([]*models.JobSlotInterestRequest, error)
+	GetInterestsByRequester(ctx context.Context, requesterUserID int64) ([]*models.JobSlotInterestRequest, error)
+	UpdateInterestStatus(ctx context.Context, interestID int64, userID int64, status string) error
+	GetReceivedInterests(ctx context.Context, userID int64) ([]*models.JobSlotInterestRequest, error)
+}
+
+type JobSlotRentals struct {
+	repository            JobSlotRentalsRepository
+	permissionsRepository ContactPermissionsRepository
+}
+
+func NewJobSlotRentals(router Routerer, repository JobSlotRentalsRepository, permissionsRepository ContactPermissionsRepository) *JobSlotRentals {
+	controller := &JobSlotRentals{
+		repository:            repository,
+		permissionsRepository: permissionsRepository,
+	}
+
+	router.RegisterRestAPIRoute("/v1/job-slots/inventory", web.AuthAccessUser, controller.GetSlotInventory, "GET")
+	router.RegisterRestAPIRoute("/v1/job-slots/listings", web.AuthAccessUser, controller.GetMyListings, "GET")
+	router.RegisterRestAPIRoute("/v1/job-slots/listings", web.AuthAccessUser, controller.CreateListing, "POST")
+	router.RegisterRestAPIRoute("/v1/job-slots/listings/{id}", web.AuthAccessUser, controller.UpdateListing, "PUT")
+	router.RegisterRestAPIRoute("/v1/job-slots/listings/{id}", web.AuthAccessUser, controller.DeleteListing, "DELETE")
+	router.RegisterRestAPIRoute("/v1/job-slots/listings/browse", web.AuthAccessUser, controller.BrowseListings, "GET")
+	router.RegisterRestAPIRoute("/v1/job-slots/interest", web.AuthAccessUser, controller.CreateInterest, "POST")
+	router.RegisterRestAPIRoute("/v1/job-slots/interest/sent", web.AuthAccessUser, controller.GetSentInterests, "GET")
+	router.RegisterRestAPIRoute("/v1/job-slots/interest/received", web.AuthAccessUser, controller.GetReceivedInterests, "GET")
+	router.RegisterRestAPIRoute("/v1/job-slots/interest/{id}/status", web.AuthAccessUser, controller.UpdateInterestStatus, "PUT")
+
+	return controller
+}
+
+// GetSlotInventory returns slot inventory for all characters
+func (c *JobSlotRentals) GetSlotInventory(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	inventory, err := c.repository.CalculateSlotInventory(args.Request.Context(), userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to calculate slot inventory")}
+	}
+
+	return inventory, nil
+}
+
+// GetMyListings returns all active listings owned by the authenticated user
+func (c *JobSlotRentals) GetMyListings(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	listings, err := c.repository.GetByUser(args.Request.Context(), userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get job slot listings")}
+	}
+
+	return listings, nil
+}
+
+// CreateListing creates a new job slot rental listing
+func (c *JobSlotRentals) CreateListing(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	var req models.CreateJobSlotListingRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	// Validate required fields
+	if req.CharacterID == 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("characterId is required")}
+	}
+	if req.ActivityType == "" {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("activityType is required")}
+	}
+	if req.SlotsListed <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("slotsListed must be greater than 0")}
+	}
+	if req.PriceAmount < 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("priceAmount must be non-negative")}
+	}
+	if req.PricingUnit == "" {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("pricingUnit is required")}
+	}
+
+	// Validate activity type
+	validActivities := []string{"manufacturing", "reaction", "te_research", "me_research", "copying", "invention"}
+	validActivity := false
+	for _, activity := range validActivities {
+		if req.ActivityType == activity {
+			validActivity = true
+			break
+		}
+	}
+	if !validActivity {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("invalid activityType")}
+	}
+
+	// Check slot availability
+	inventory, err := c.repository.CalculateSlotInventory(args.Request.Context(), userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to check slot availability")}
+	}
+
+	// Find the character and verify slot availability
+	var charInventory *models.CharacterSlotInventory
+	for _, inv := range inventory {
+		if inv.CharacterID == req.CharacterID {
+			charInventory = inv
+			break
+		}
+	}
+
+	if charInventory == nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("character not found or does not belong to user")}
+	}
+
+	activityInfo, ok := charInventory.SlotsByActivity[req.ActivityType]
+	if !ok {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("activity type not available for character")}
+	}
+
+	if activityInfo.SlotsAvailable < req.SlotsListed {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("not enough slots available")}
+	}
+
+	listing := &models.JobSlotRentalListing{
+		UserID:       userID,
+		CharacterID:  req.CharacterID,
+		ActivityType: req.ActivityType,
+		SlotsListed:  req.SlotsListed,
+		PriceAmount:  req.PriceAmount,
+		PricingUnit:  req.PricingUnit,
+		LocationID:   req.LocationID,
+		Notes:        req.Notes,
+		IsActive:     true,
+	}
+
+	if err := c.repository.Create(args.Request.Context(), listing); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to create listing")}
+	}
+
+	return listing, nil
+}
+
+// UpdateListing updates an existing listing
+func (c *JobSlotRentals) UpdateListing(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	listingIDStr, ok := args.Params["id"]
+	if !ok {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("listing ID is required")}
+	}
+
+	listingID, err := strconv.ParseInt(listingIDStr, 10, 64)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("invalid listing ID")}
+	}
+
+	// Get existing listing to verify ownership
+	existingListing, err := c.repository.GetByID(args.Request.Context(), listingID)
+	if err != nil {
+		if errors.Cause(err).Error() == "job slot listing not found" {
+			return nil, &web.HttpError{StatusCode: 404, Error: errors.New("job slot listing not found")}
+		}
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get job slot listing")}
+	}
+
+	if existingListing.UserID != userID {
+		return nil, &web.HttpError{StatusCode: 403, Error: errors.New("not authorized to update this listing")}
+	}
+
+	var req models.UpdateJobSlotListingRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	// Validate updates
+	if req.SlotsListed <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("slotsListed must be greater than 0")}
+	}
+	if req.PriceAmount < 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("priceAmount must be non-negative")}
+	}
+	if req.PricingUnit == "" {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("pricingUnit is required")}
+	}
+
+	// Update fields
+	existingListing.SlotsListed = req.SlotsListed
+	existingListing.PriceAmount = req.PriceAmount
+	existingListing.PricingUnit = req.PricingUnit
+	existingListing.LocationID = req.LocationID
+	existingListing.Notes = req.Notes
+	if req.IsActive != nil {
+		existingListing.IsActive = *req.IsActive
+	}
+
+	if err := c.repository.Update(args.Request.Context(), existingListing); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to update listing")}
+	}
+
+	return existingListing, nil
+}
+
+// DeleteListing soft-deletes a listing
+func (c *JobSlotRentals) DeleteListing(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	listingIDStr, ok := args.Params["id"]
+	if !ok {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("listing ID is required")}
+	}
+
+	listingID, err := strconv.ParseInt(listingIDStr, 10, 64)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("invalid listing ID")}
+	}
+
+	if err := c.repository.Delete(args.Request.Context(), listingID, userID); err != nil {
+		if err.Error() == "job slot listing not found or user is not the owner" {
+			return nil, &web.HttpError{StatusCode: 404, Error: err}
+		}
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to delete listing")}
+	}
+
+	return nil, nil
+}
+
+// BrowseListings returns listings from contacts who granted browse permission
+func (c *JobSlotRentals) BrowseListings(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	// Get list of users who granted this user permission to browse their job slot listings
+	sellerUserIDs, err := c.permissionsRepository.GetUserPermissionsForService(args.Request.Context(), userID, "job_slot_browse")
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get permissions")}
+	}
+
+	// Get browsable listings from those sellers
+	listings, err := c.repository.GetBrowsableListings(args.Request.Context(), userID, sellerUserIDs)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get browsable listings")}
+	}
+
+	return listings, nil
+}
+
+// CreateInterest creates a new interest request
+func (c *JobSlotRentals) CreateInterest(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	var req models.CreateInterestRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	// Validate required fields
+	if req.ListingID == 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("listingId is required")}
+	}
+	if req.SlotsRequested <= 0 {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("slotsRequested must be greater than 0")}
+	}
+
+	// Get listing to verify it exists and isn't self-interest
+	listing, err := c.repository.GetByID(args.Request.Context(), req.ListingID)
+	if err != nil {
+		if errors.Cause(err).Error() == "job slot listing not found" {
+			return nil, &web.HttpError{StatusCode: 404, Error: errors.New("job slot listing not found")}
+		}
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get listing")}
+	}
+
+	// Prevent self-interest
+	if listing.UserID == userID {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("cannot express interest in your own listing")}
+	}
+
+	interest := &models.JobSlotInterestRequest{
+		ListingID:       req.ListingID,
+		RequesterUserID: userID,
+		SlotsRequested:  req.SlotsRequested,
+		DurationDays:    req.DurationDays,
+		Message:         req.Message,
+		Status:          "pending",
+	}
+
+	if err := c.repository.CreateInterest(args.Request.Context(), interest); err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to create interest request")}
+	}
+
+	return interest, nil
+}
+
+// GetSentInterests returns all interest requests sent by the user
+func (c *JobSlotRentals) GetSentInterests(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	interests, err := c.repository.GetInterestsByRequester(args.Request.Context(), userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get sent interests")}
+	}
+
+	return interests, nil
+}
+
+// GetReceivedInterests returns all interest requests received for user's listings
+func (c *JobSlotRentals) GetReceivedInterests(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	interests, err := c.repository.GetReceivedInterests(args.Request.Context(), userID)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to get received interests")}
+	}
+
+	return interests, nil
+}
+
+// UpdateInterestStatus updates the status of an interest request
+func (c *JobSlotRentals) UpdateInterestStatus(args *web.HandlerArgs) (any, *web.HttpError) {
+	if args.User == nil {
+		return nil, &web.HttpError{StatusCode: 401, Error: errors.New("unauthorized")}
+	}
+
+	userID := *args.User
+
+	interestIDStr, ok := args.Params["id"]
+	if !ok {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("interest ID is required")}
+	}
+
+	interestID, err := strconv.ParseInt(interestIDStr, 10, 64)
+	if err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("invalid interest ID")}
+	}
+
+	var req models.UpdateInterestStatusRequest
+	if err := json.NewDecoder(args.Request.Body).Decode(&req); err != nil {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.Wrap(err, "invalid request body")}
+	}
+
+	if req.Status == "" {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("status is required")}
+	}
+
+	// Validate status
+	validStatuses := []string{"pending", "accepted", "declined", "withdrawn"}
+	validStatus := false
+	for _, status := range validStatuses {
+		if req.Status == status {
+			validStatus = true
+			break
+		}
+	}
+	if !validStatus {
+		return nil, &web.HttpError{StatusCode: 400, Error: errors.New("invalid status")}
+	}
+
+	if err := c.repository.UpdateInterestStatus(args.Request.Context(), interestID, userID, req.Status); err != nil {
+		if err.Error() == "interest request not found or user not authorized" {
+			return nil, &web.HttpError{StatusCode: 404, Error: err}
+		}
+		return nil, &web.HttpError{StatusCode: 500, Error: errors.Wrap(err, "failed to update interest status")}
+	}
+
+	return nil, nil
+}

--- a/internal/controllers/jobSlotRentals_test.go
+++ b/internal/controllers/jobSlotRentals_test.go
@@ -1,0 +1,751 @@
+package controllers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/controllers"
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// Mock JobSlotRentalsRepository
+type MockJobSlotRentalsRepository struct {
+	mock.Mock
+}
+
+func (m *MockJobSlotRentalsRepository) CalculateSlotInventory(ctx context.Context, userID int64) ([]*models.CharacterSlotInventory, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.CharacterSlotInventory), args.Error(1)
+}
+
+func (m *MockJobSlotRentalsRepository) GetByUser(ctx context.Context, userID int64) ([]*models.JobSlotRentalListing, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.JobSlotRentalListing), args.Error(1)
+}
+
+func (m *MockJobSlotRentalsRepository) GetBrowsableListings(ctx context.Context, viewerUserID int64, sellerUserIDs []int64) ([]*models.JobSlotRentalListing, error) {
+	args := m.Called(ctx, viewerUserID, sellerUserIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.JobSlotRentalListing), args.Error(1)
+}
+
+func (m *MockJobSlotRentalsRepository) Create(ctx context.Context, listing *models.JobSlotRentalListing) error {
+	args := m.Called(ctx, listing)
+	return args.Error(0)
+}
+
+func (m *MockJobSlotRentalsRepository) Update(ctx context.Context, listing *models.JobSlotRentalListing) error {
+	args := m.Called(ctx, listing)
+	return args.Error(0)
+}
+
+func (m *MockJobSlotRentalsRepository) Delete(ctx context.Context, listingID int64, userID int64) error {
+	args := m.Called(ctx, listingID, userID)
+	return args.Error(0)
+}
+
+func (m *MockJobSlotRentalsRepository) GetByID(ctx context.Context, listingID int64) (*models.JobSlotRentalListing, error) {
+	args := m.Called(ctx, listingID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.JobSlotRentalListing), args.Error(1)
+}
+
+func (m *MockJobSlotRentalsRepository) CreateInterest(ctx context.Context, interest *models.JobSlotInterestRequest) error {
+	args := m.Called(ctx, interest)
+	return args.Error(0)
+}
+
+func (m *MockJobSlotRentalsRepository) GetInterestsByListing(ctx context.Context, listingID int64, sellerUserID int64) ([]*models.JobSlotInterestRequest, error) {
+	args := m.Called(ctx, listingID, sellerUserID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.JobSlotInterestRequest), args.Error(1)
+}
+
+func (m *MockJobSlotRentalsRepository) GetInterestsByRequester(ctx context.Context, requesterUserID int64) ([]*models.JobSlotInterestRequest, error) {
+	args := m.Called(ctx, requesterUserID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.JobSlotInterestRequest), args.Error(1)
+}
+
+func (m *MockJobSlotRentalsRepository) UpdateInterestStatus(ctx context.Context, interestID int64, userID int64, status string) error {
+	args := m.Called(ctx, interestID, userID, status)
+	return args.Error(0)
+}
+
+func (m *MockJobSlotRentalsRepository) GetReceivedInterests(ctx context.Context, userID int64) ([]*models.JobSlotInterestRequest, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.JobSlotInterestRequest), args.Error(1)
+}
+
+func Test_JobSlotRentalsController_GetSlotInventory_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	expectedInventory := []*models.CharacterSlotInventory{
+		{
+			CharacterID:   456,
+			CharacterName: "Test Character",
+			SlotsByActivity: map[string]*models.ActivitySlotInfo{
+				"manufacturing": {
+					ActivityType:   "manufacturing",
+					SlotsMax:       11,
+					SlotsInUse:     0,
+					SlotsReserved:  0,
+					SlotsAvailable: 11,
+					SlotsListed:    0,
+				},
+			},
+		},
+	}
+
+	mockRepo.On("CalculateSlotInventory", mock.Anything, userID).Return(expectedInventory, nil)
+
+	req := httptest.NewRequest("GET", "/v1/job-slots/inventory", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.GetSlotInventory(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	inventory := result.([]*models.CharacterSlotInventory)
+	assert.Len(t, inventory, 1)
+	assert.Equal(t, "Test Character", inventory[0].CharacterName)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_GetMyListings_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	expectedListings := []*models.JobSlotRentalListing{
+		{
+			ID:            1,
+			UserID:        userID,
+			CharacterID:   456,
+			CharacterName: "Test Character",
+			ActivityType:  "manufacturing",
+			SlotsListed:   2,
+			PriceAmount:   100000,
+			PricingUnit:   "per_slot_day",
+			IsActive:      true,
+		},
+	}
+
+	mockRepo.On("GetByUser", mock.Anything, userID).Return(expectedListings, nil)
+
+	req := httptest.NewRequest("GET", "/v1/job-slots/listings", nil)
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.GetMyListings(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	listings := result.([]*models.JobSlotRentalListing)
+	assert.Len(t, listings, 1)
+	assert.Equal(t, "manufacturing", listings[0].ActivityType)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_CreateListing_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	charID := int64(456)
+
+	// Mock slot inventory showing available slots
+	inventory := []*models.CharacterSlotInventory{
+		{
+			CharacterID:   charID,
+			CharacterName: "Test Character",
+			SlotsByActivity: map[string]*models.ActivitySlotInfo{
+				"manufacturing": {
+					ActivityType:   "manufacturing",
+					SlotsMax:       11,
+					SlotsInUse:     0,
+					SlotsReserved:  0,
+					SlotsAvailable: 11,
+					SlotsListed:    0,
+				},
+			},
+		},
+	}
+
+	mockRepo.On("CalculateSlotInventory", mock.Anything, userID).Return(inventory, nil)
+	mockRepo.On("Create", mock.Anything, mock.MatchedBy(func(listing *models.JobSlotRentalListing) bool {
+		return listing.UserID == userID &&
+			listing.CharacterID == charID &&
+			listing.ActivityType == "manufacturing" &&
+			listing.SlotsListed == 2
+	})).Return(nil)
+
+	body := map[string]interface{}{
+		"characterId":  charID,
+		"activityType": "manufacturing",
+		"slotsListed":  2,
+		"priceAmount":  100000,
+		"pricingUnit":  "per_slot_day",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/job-slots/listings", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.CreateListing(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_CreateListing_InsufficientSlots(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	charID := int64(456)
+
+	// Mock slot inventory showing only 1 slot available
+	inventory := []*models.CharacterSlotInventory{
+		{
+			CharacterID:   charID,
+			CharacterName: "Test Character",
+			SlotsByActivity: map[string]*models.ActivitySlotInfo{
+				"manufacturing": {
+					ActivityType:   "manufacturing",
+					SlotsMax:       11,
+					SlotsInUse:     8,
+					SlotsReserved:  2,
+					SlotsAvailable: 1,
+					SlotsListed:    0,
+				},
+			},
+		},
+	}
+
+	mockRepo.On("CalculateSlotInventory", mock.Anything, userID).Return(inventory, nil)
+
+	body := map[string]interface{}{
+		"characterId":  charID,
+		"activityType": "manufacturing",
+		"slotsListed":  2, // Requesting 2 but only 1 available
+		"priceAmount":  100000,
+		"pricingUnit":  "per_slot_day",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/job-slots/listings", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.CreateListing(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+	assert.Contains(t, httpErr.Error.Error(), "not enough slots available")
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_UpdateListing_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	listingID := int64(1)
+
+	existingListing := &models.JobSlotRentalListing{
+		ID:           listingID,
+		UserID:       userID,
+		CharacterID:  456,
+		ActivityType: "manufacturing",
+		SlotsListed:  2,
+		PriceAmount:  100000,
+		PricingUnit:  "per_slot_day",
+		IsActive:     true,
+	}
+
+	mockRepo.On("GetByID", mock.Anything, listingID).Return(existingListing, nil)
+	mockRepo.On("Update", mock.Anything, mock.MatchedBy(func(listing *models.JobSlotRentalListing) bool {
+		return listing.ID == listingID &&
+			listing.SlotsListed == 3 &&
+			listing.PriceAmount == 125000
+	})).Return(nil)
+
+	body := map[string]interface{}{
+		"slotsListed": 3,
+		"priceAmount": 125000,
+		"pricingUnit": "per_slot_day",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/job-slots/listings/1", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.UpdateListing(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_UpdateListing_NotOwner(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	otherUserID := int64(999)
+	listingID := int64(1)
+
+	existingListing := &models.JobSlotRentalListing{
+		ID:           listingID,
+		UserID:       otherUserID, // Different owner
+		CharacterID:  456,
+		ActivityType: "manufacturing",
+		SlotsListed:  2,
+		PriceAmount:  100000,
+		PricingUnit:  "per_slot_day",
+		IsActive:     true,
+	}
+
+	mockRepo.On("GetByID", mock.Anything, listingID).Return(existingListing, nil)
+
+	body := map[string]interface{}{
+		"slotsListed": 3,
+		"priceAmount": 125000,
+		"pricingUnit": "per_slot_day",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/job-slots/listings/1", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.UpdateListing(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 403, httpErr.StatusCode)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_DeleteListing_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	listingID := int64(1)
+
+	mockRepo.On("Delete", mock.Anything, listingID, userID).Return(nil)
+
+	req := httptest.NewRequest("DELETE", "/v1/job-slots/listings/1", nil)
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.DeleteListing(args)
+
+	assert.Nil(t, httpErr)
+	assert.Nil(t, result)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_BrowseListings_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockPermRepo := new(MockContactPermissionsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	sellerUserIDs := []int64{200, 300}
+
+	expectedListings := []*models.JobSlotRentalListing{
+		{
+			ID:            1,
+			UserID:        200,
+			CharacterID:   2000,
+			CharacterName: "Seller Character",
+			ActivityType:  "manufacturing",
+			SlotsListed:   2,
+			PriceAmount:   100000,
+			PricingUnit:   "per_slot_day",
+			IsActive:      true,
+		},
+	}
+
+	mockPermRepo.On("GetUserPermissionsForService", mock.Anything, userID, "job_slot_browse").Return(sellerUserIDs, nil)
+	mockRepo.On("GetBrowsableListings", mock.Anything, userID, sellerUserIDs).Return(expectedListings, nil)
+
+	req := httptest.NewRequest("GET", "/v1/job-slots/listings/browse", nil)
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, mockPermRepo)
+	result, httpErr := controller.BrowseListings(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	listings := result.([]*models.JobSlotRentalListing)
+	assert.Len(t, listings, 1)
+
+	mockRepo.AssertExpectations(t)
+	mockPermRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_CreateInterest_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	listingID := int64(1)
+
+	// Listing owned by a different user
+	listing := &models.JobSlotRentalListing{
+		ID:            listingID,
+		UserID:        999,
+		CharacterID:   9990,
+		CharacterName: "Seller Character",
+		ActivityType:  "manufacturing",
+		SlotsListed:   3,
+		PriceAmount:   100000,
+		PricingUnit:   "per_slot_day",
+		IsActive:      true,
+	}
+
+	mockRepo.On("GetByID", mock.Anything, listingID).Return(listing, nil)
+	mockRepo.On("CreateInterest", mock.Anything, mock.MatchedBy(func(interest *models.JobSlotInterestRequest) bool {
+		return interest.ListingID == listingID &&
+			interest.RequesterUserID == userID &&
+			interest.SlotsRequested == 2 &&
+			interest.Status == "pending"
+	})).Return(nil)
+
+	body := map[string]interface{}{
+		"listingId":      listingID,
+		"slotsRequested": 2,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/job-slots/interest", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.CreateInterest(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_CreateInterest_SelfInterest(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	listingID := int64(1)
+
+	// Listing owned by the same user
+	listing := &models.JobSlotRentalListing{
+		ID:            listingID,
+		UserID:        userID,
+		CharacterID:   456,
+		CharacterName: "My Character",
+		ActivityType:  "manufacturing",
+		SlotsListed:   3,
+		PriceAmount:   100000,
+		PricingUnit:   "per_slot_day",
+		IsActive:      true,
+	}
+
+	mockRepo.On("GetByID", mock.Anything, listingID).Return(listing, nil)
+
+	body := map[string]interface{}{
+		"listingId":      listingID,
+		"slotsRequested": 2,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/v1/job-slots/interest", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.CreateInterest(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+	assert.Contains(t, httpErr.Error.Error(), "cannot express interest in your own listing")
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_GetSentInterests_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	expectedInterests := []*models.JobSlotInterestRequest{
+		{
+			ID:                   1,
+			ListingID:            10,
+			RequesterUserID:      userID,
+			RequesterName:        "Test User",
+			SlotsRequested:       2,
+			Status:               "pending",
+			ListingActivityType:  "manufacturing",
+			ListingCharacterName: "Seller Character",
+			ListingOwnerName:     "Seller User",
+		},
+	}
+
+	mockRepo.On("GetInterestsByRequester", mock.Anything, userID).Return(expectedInterests, nil)
+
+	req := httptest.NewRequest("GET", "/v1/job-slots/interest/sent", nil)
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.GetSentInterests(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	interests := result.([]*models.JobSlotInterestRequest)
+	assert.Len(t, interests, 1)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_GetReceivedInterests_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	expectedInterests := []*models.JobSlotInterestRequest{
+		{
+			ID:                   1,
+			ListingID:            10,
+			RequesterUserID:      999,
+			RequesterName:        "Buyer User",
+			SlotsRequested:       2,
+			Status:               "pending",
+			ListingActivityType:  "manufacturing",
+			ListingCharacterName: "My Character",
+		},
+	}
+
+	mockRepo.On("GetReceivedInterests", mock.Anything, userID).Return(expectedInterests, nil)
+
+	req := httptest.NewRequest("GET", "/v1/job-slots/interest/received", nil)
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.GetReceivedInterests(args)
+
+	assert.Nil(t, httpErr)
+	assert.NotNil(t, result)
+
+	interests := result.([]*models.JobSlotInterestRequest)
+	assert.Len(t, interests, 1)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_UpdateInterestStatus_Success(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	interestID := int64(1)
+
+	mockRepo.On("UpdateInterestStatus", mock.Anything, interestID, userID, "accepted").Return(nil)
+
+	body := map[string]interface{}{
+		"status": "accepted",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/job-slots/interest/1/status", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.UpdateInterestStatus(args)
+
+	assert.Nil(t, httpErr)
+	assert.Nil(t, result)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_JobSlotRentalsController_UpdateInterestStatus_InvalidStatus(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+
+	body := map[string]interface{}{
+		"status": "invalid_status",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/job-slots/interest/1/status", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "1"},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.UpdateInterestStatus(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+	assert.Contains(t, httpErr.Error.Error(), "invalid status")
+}
+
+func Test_JobSlotRentalsController_UpdateInterestStatus_NotFound(t *testing.T) {
+	mockRepo := new(MockJobSlotRentalsRepository)
+	mockRouter := &MockRouter{}
+
+	userID := int64(123)
+	interestID := int64(999)
+
+	mockRepo.On("UpdateInterestStatus", mock.Anything, interestID, userID, "accepted").Return(errors.New("interest request not found or user not authorized"))
+
+	body := map[string]interface{}{
+		"status": "accepted",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("PUT", "/v1/job-slots/interest/999/status", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	args := &web.HandlerArgs{
+		Request: req,
+		User:    &userID,
+		Params:  map[string]string{"id": "999"},
+	}
+
+	controller := controllers.NewJobSlotRentals(mockRouter, mockRepo, &MockContactPermissionsRepository{})
+	result, httpErr := controller.UpdateInterestStatus(args)
+
+	assert.Nil(t, result)
+	assert.NotNil(t, httpErr)
+	assert.Equal(t, 404, httpErr.StatusCode)
+
+	mockRepo.AssertExpectations(t)
+}

--- a/internal/database/migrations/20260227151643_create_job_slot_rental_tables.down.sql
+++ b/internal/database/migrations/20260227151643_create_job_slot_rental_tables.down.sql
@@ -1,0 +1,6 @@
+-- Migration: create_job_slot_rental_tables
+-- Created: Thu Feb 27 03:16:43 PM UTC 2026
+
+-- Drop tables in reverse order (child before parent due to FK)
+drop table if exists job_slot_interest_requests;
+drop table if exists job_slot_rental_listings;

--- a/internal/database/migrations/20260227151643_create_job_slot_rental_tables.up.sql
+++ b/internal/database/migrations/20260227151643_create_job_slot_rental_tables.up.sql
@@ -1,0 +1,58 @@
+-- Migration: create_job_slot_rental_tables
+-- Created: Thu Feb 27 03:16:43 PM UTC 2026
+
+-- Job Slot Rental Listings
+-- Users list their idle industry job slots for rent
+create table job_slot_rental_listings (
+	id bigserial primary key,
+	user_id bigint not null references users(id),
+	character_id bigint not null,
+	activity_type text not null,
+	slots_listed int not null,
+	price_amount double precision not null,
+	pricing_unit text not null,
+	location_id bigint,
+	notes text,
+	is_active boolean not null default true,
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	constraint job_slot_listings_positive_slots check (slots_listed > 0),
+	constraint job_slot_listings_positive_price check (price_amount >= 0),
+	constraint job_slot_listings_valid_activity check (
+		activity_type in ('manufacturing', 'reaction', 'copying', 'invention', 'me_research', 'te_research')
+	),
+	constraint job_slot_listings_valid_pricing check (
+		pricing_unit in ('per_slot_day', 'per_job', 'flat_fee')
+	)
+);
+
+-- Prevent duplicate active listings for same user/character/activity combo
+create unique index idx_job_slot_listings_unique_active on job_slot_rental_listings(
+	user_id, character_id, activity_type
+) where is_active = true;
+
+create index idx_job_slot_listings_user on job_slot_rental_listings(user_id);
+create index idx_job_slot_listings_character on job_slot_rental_listings(character_id);
+create index idx_job_slot_listings_activity on job_slot_rental_listings(activity_type) where is_active = true;
+
+-- Job Slot Interest Requests
+-- Buyers express interest in renting slots from a listing
+create table job_slot_interest_requests (
+	id bigserial primary key,
+	listing_id bigint not null references job_slot_rental_listings(id) on delete cascade,
+	requester_user_id bigint not null references users(id),
+	slots_requested int not null,
+	duration_days int,
+	message text,
+	status text not null default 'pending',
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	constraint job_slot_requests_positive_slots check (slots_requested > 0),
+	constraint job_slot_requests_valid_status check (
+		status in ('pending', 'accepted', 'declined', 'withdrawn')
+	)
+);
+
+create index idx_job_slot_requests_listing on job_slot_interest_requests(listing_id);
+create index idx_job_slot_requests_requester on job_slot_interest_requests(requester_user_id);
+create index idx_job_slot_requests_status on job_slot_interest_requests(status);

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1216,3 +1216,86 @@ type BlueprintLevel struct {
 	OwnerName          string `json:"ownerName"`
 	Runs               int    `json:"runs"`
 }
+
+// --- Job Slot Rental Models ---
+
+type JobSlotRentalListing struct {
+	ID            int64     `json:"id"`
+	UserID        int64     `json:"userId"`
+	CharacterID   int64     `json:"characterId"`
+	CharacterName string    `json:"characterName"`
+	ActivityType  string    `json:"activityType"`
+	SlotsListed   int       `json:"slotsListed"`
+	PriceAmount   float64   `json:"priceAmount"`
+	PricingUnit   string    `json:"pricingUnit"`
+	LocationID    *int64    `json:"locationId"`
+	LocationName  string    `json:"locationName"`
+	Notes         *string   `json:"notes"`
+	IsActive      bool      `json:"isActive"`
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
+type JobSlotInterestRequest struct {
+	ID              int64     `json:"id"`
+	ListingID       int64     `json:"listingId"`
+	RequesterUserID int64     `json:"requesterUserId"`
+	RequesterName   string    `json:"requesterName"`
+	SlotsRequested  int       `json:"slotsRequested"`
+	DurationDays    *int      `json:"durationDays"`
+	Message         *string   `json:"message"`
+	Status          string    `json:"status"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+	// Enriched fields for buyer view
+	ListingActivityType  string  `json:"listingActivityType,omitempty"`
+	ListingCharacterName string  `json:"listingCharacterName,omitempty"`
+	ListingOwnerName     string  `json:"listingOwnerName,omitempty"`
+	ListingPriceAmount   float64 `json:"listingPriceAmount,omitempty"`
+	ListingPricingUnit   string  `json:"listingPricingUnit,omitempty"`
+}
+
+type CharacterSlotInventory struct {
+	CharacterID     int64                       `json:"characterId"`
+	CharacterName   string                      `json:"characterName"`
+	SlotsByActivity map[string]*ActivitySlotInfo `json:"slotsByActivity"`
+}
+
+type ActivitySlotInfo struct {
+	ActivityType   string `json:"activityType"`
+	SlotsMax       int    `json:"slotsMax"`
+	SlotsInUse     int    `json:"slotsInUse"`
+	SlotsReserved  int    `json:"slotsReserved"`
+	SlotsAvailable int    `json:"slotsAvailable"`
+	SlotsListed    int    `json:"slotsListed"`
+}
+
+type CreateJobSlotListingRequest struct {
+	CharacterID  int64   `json:"characterId"`
+	ActivityType string  `json:"activityType"`
+	SlotsListed  int     `json:"slotsListed"`
+	PriceAmount  float64 `json:"priceAmount"`
+	PricingUnit  string  `json:"pricingUnit"`
+	LocationID   *int64  `json:"locationId"`
+	Notes        *string `json:"notes"`
+}
+
+type UpdateJobSlotListingRequest struct {
+	SlotsListed int     `json:"slotsListed"`
+	PriceAmount float64 `json:"priceAmount"`
+	PricingUnit string  `json:"pricingUnit"`
+	LocationID  *int64  `json:"locationId"`
+	Notes       *string `json:"notes"`
+	IsActive    *bool   `json:"isActive"`
+}
+
+type CreateInterestRequest struct {
+	ListingID      int64   `json:"listingId"`
+	SlotsRequested int     `json:"slotsRequested"`
+	DurationDays   *int    `json:"durationDays"`
+	Message        *string `json:"message"`
+}
+
+type UpdateInterestStatusRequest struct {
+	Status string `json:"status"`
+}

--- a/internal/repositories/contactPermissions.go
+++ b/internal/repositories/contactPermissions.go
@@ -153,7 +153,7 @@ func (r *ContactPermissions) GetUserPermissionsForService(ctx context.Context, v
 // InitializePermissionsForContact creates default (all denied) permissions when contact accepted
 func (r *ContactPermissions) InitializePermissionsForContact(ctx context.Context, tx *sql.Tx, contactID, userID1, userID2 int64) error {
 	// Default service types
-	serviceTypes := []string{"for_sale_browse"}
+	serviceTypes := []string{"for_sale_browse", "job_slot_browse"}
 
 	query := `
 		INSERT INTO contact_permissions

--- a/internal/repositories/jobSlotRentals.go
+++ b/internal/repositories/jobSlotRentals.go
@@ -1,0 +1,776 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+type JobSlotRentals struct {
+	db *sql.DB
+}
+
+func NewJobSlotRentals(db *sql.DB) *JobSlotRentals {
+	return &JobSlotRentals{db: db}
+}
+
+// CalculateSlotInventory computes available slots per character per activity.
+// Queries character_skills, esi_industry_jobs, industry_job_queue, and existing listings.
+func (r *JobSlotRentals) CalculateSlotInventory(ctx context.Context, userID int64) ([]*models.CharacterSlotInventory, error) {
+	// Get all characters for this user with their slot capacities from skills
+	charQuery := `
+		SELECT DISTINCT c.id, c.name
+		FROM characters c
+		WHERE c.user_id = $1
+		ORDER BY c.name
+	`
+	rows, err := r.db.QueryContext(ctx, charQuery, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query characters")
+	}
+	defer rows.Close()
+
+	type charInfo struct {
+		id   int64
+		name string
+	}
+	var chars []*charInfo
+	for rows.Next() {
+		var c charInfo
+		if err := rows.Scan(&c.id, &c.name); err != nil {
+			return nil, errors.Wrap(err, "failed to scan character")
+		}
+		chars = append(chars, &c)
+	}
+
+	if len(chars) == 0 {
+		return []*models.CharacterSlotInventory{}, nil
+	}
+
+	// Get skills for all characters
+	skillsQuery := `
+		SELECT character_id, skill_id, trained_level
+		FROM character_skills
+		WHERE user_id = $1 AND skill_id = ANY($2)
+	`
+	skillIDs := []int64{3380, 3387, 24625, 45746, 45748, 45749, 3402, 3406, 24624}
+	skillRows, err := r.db.QueryContext(ctx, skillsQuery, userID, pq.Array(skillIDs))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query character skills")
+	}
+	defer skillRows.Close()
+
+	skillsByChar := make(map[int64]map[int64]int)
+	for skillRows.Next() {
+		var charID, skillID int64
+		var level int
+		if err := skillRows.Scan(&charID, &skillID, &level); err != nil {
+			return nil, errors.Wrap(err, "failed to scan skill")
+		}
+		if skillsByChar[charID] == nil {
+			skillsByChar[charID] = make(map[int64]int)
+		}
+		skillsByChar[charID][skillID] = level
+	}
+
+	// Calculate max slots per character per activity
+	type slotMax struct {
+		mfg     int
+		react   int
+		science int
+	}
+	maxByChar := make(map[int64]slotMax)
+	for _, c := range chars {
+		skills := skillsByChar[c.id]
+		if skills == nil {
+			skills = make(map[int64]int)
+		}
+
+		// Manufacturing: 1 + MassProduction + AdvMassProduction
+		mfg := 1 + skills[3387] + skills[24625]
+
+		// Reactions: require Reactions >= 1, then 1 + MassReactions + AdvMassReactions
+		react := 0
+		if skills[45746] >= 1 {
+			react = 1 + skills[45748] + skills[45749]
+		}
+
+		// Science: require Science >= 1, then 1 + LabOp + AdvLabOp
+		science := 0
+		if skills[3402] >= 1 {
+			science = 1 + skills[3406] + skills[24624]
+		}
+
+		maxByChar[c.id] = slotMax{mfg: mfg, react: react, science: science}
+	}
+
+	// Get in-use slots from ESI industry jobs (active jobs)
+	esiJobsQuery := `
+		SELECT installer_id, activity_id, COUNT(*)
+		FROM esi_industry_jobs
+		WHERE user_id = $1 AND status IN ('active', 'paused')
+		GROUP BY installer_id, activity_id
+	`
+	esiRows, err := r.db.QueryContext(ctx, esiJobsQuery, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query ESI industry jobs")
+	}
+	defer esiRows.Close()
+
+	inUseByChar := make(map[int64]map[string]int)
+	for esiRows.Next() {
+		var charID int64
+		var activityID int
+		var count int
+		if err := esiRows.Scan(&charID, &activityID, &count); err != nil {
+			return nil, errors.Wrap(err, "failed to scan ESI job")
+		}
+
+		if inUseByChar[charID] == nil {
+			inUseByChar[charID] = make(map[string]int)
+		}
+
+		// Map ESI activity_id to our activity names
+		// 1→manufacturing, 3→te_research, 4→me_research, 5→copying, 8→invention, 9→reaction
+		switch activityID {
+		case 1:
+			inUseByChar[charID]["manufacturing"] += count
+		case 3:
+			inUseByChar[charID]["te_research"] += count
+		case 4:
+			inUseByChar[charID]["me_research"] += count
+		case 5:
+			inUseByChar[charID]["copying"] += count
+		case 8:
+			inUseByChar[charID]["invention"] += count
+		case 9:
+			inUseByChar[charID]["reaction"] += count
+		}
+	}
+
+	// Get reserved slots from industry_job_queue (planned jobs)
+	queueQuery := `
+		SELECT character_id, activity, COUNT(*)
+		FROM industry_job_queue
+		WHERE user_id = $1 AND status IN ('planned', 'active')
+		GROUP BY character_id, activity
+	`
+	queueRows, err := r.db.QueryContext(ctx, queueQuery, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query job queue")
+	}
+	defer queueRows.Close()
+
+	reservedByChar := make(map[int64]map[string]int)
+	for queueRows.Next() {
+		var charID sql.NullInt64
+		var activity string
+		var count int
+		if err := queueRows.Scan(&charID, &activity, &count); err != nil {
+			return nil, errors.Wrap(err, "failed to scan queue entry")
+		}
+
+		// Skip entries with null character_id
+		if !charID.Valid {
+			continue
+		}
+
+		if reservedByChar[charID.Int64] == nil {
+			reservedByChar[charID.Int64] = make(map[string]int)
+		}
+		reservedByChar[charID.Int64][activity] += count
+	}
+
+	// Get listed slots from job_slot_rental_listings
+	listingsQuery := `
+		SELECT character_id, activity_type, SUM(slots_listed)
+		FROM job_slot_rental_listings
+		WHERE user_id = $1 AND is_active = true
+		GROUP BY character_id, activity_type
+	`
+	listingRows, err := r.db.QueryContext(ctx, listingsQuery, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query job slot listings")
+	}
+	defer listingRows.Close()
+
+	listedByChar := make(map[int64]map[string]int)
+	for listingRows.Next() {
+		var charID int64
+		var activityType string
+		var slotsListed int
+		if err := listingRows.Scan(&charID, &activityType, &slotsListed); err != nil {
+			return nil, errors.Wrap(err, "failed to scan listing")
+		}
+
+		if listedByChar[charID] == nil {
+			listedByChar[charID] = make(map[string]int)
+		}
+		listedByChar[charID][activityType] += slotsListed
+	}
+
+	// Build inventory for each character
+	result := []*models.CharacterSlotInventory{}
+	for _, c := range chars {
+		max := maxByChar[c.id]
+		inUse := inUseByChar[c.id]
+		if inUse == nil {
+			inUse = make(map[string]int)
+		}
+		reserved := reservedByChar[c.id]
+		if reserved == nil {
+			reserved = make(map[string]int)
+		}
+		listed := listedByChar[c.id]
+		if listed == nil {
+			listed = make(map[string]int)
+		}
+
+		// Science activities share a single slot pool
+		scienceInUse := inUse["te_research"] + inUse["me_research"] + inUse["copying"] + inUse["invention"]
+		scienceReserved := reserved["te_research"] + reserved["me_research"] + reserved["copying"] + reserved["invention"]
+
+		slotsByActivity := make(map[string]*models.ActivitySlotInfo)
+
+		// Manufacturing
+		mfgAvail := max.mfg - inUse["manufacturing"] - reserved["manufacturing"] - listed["manufacturing"]
+		if mfgAvail < 0 {
+			mfgAvail = 0
+		}
+		slotsByActivity["manufacturing"] = &models.ActivitySlotInfo{
+			ActivityType:   "manufacturing",
+			SlotsMax:       max.mfg,
+			SlotsInUse:     inUse["manufacturing"],
+			SlotsReserved:  reserved["manufacturing"],
+			SlotsAvailable: mfgAvail,
+			SlotsListed:    listed["manufacturing"],
+		}
+
+		// Reaction
+		reactAvail := max.react - inUse["reaction"] - reserved["reaction"] - listed["reaction"]
+		if reactAvail < 0 {
+			reactAvail = 0
+		}
+		slotsByActivity["reaction"] = &models.ActivitySlotInfo{
+			ActivityType:   "reaction",
+			SlotsMax:       max.react,
+			SlotsInUse:     inUse["reaction"],
+			SlotsReserved:  reserved["reaction"],
+			SlotsAvailable: reactAvail,
+			SlotsListed:    listed["reaction"],
+		}
+
+		// Science activities - all share the same pool
+		sciActivities := []string{"te_research", "me_research", "copying", "invention"}
+		for _, act := range sciActivities {
+			sciListedTotal := listed["te_research"] + listed["me_research"] + listed["copying"] + listed["invention"]
+			sciAvail := max.science - scienceInUse - scienceReserved - sciListedTotal
+			if sciAvail < 0 {
+				sciAvail = 0
+			}
+
+			slotsByActivity[act] = &models.ActivitySlotInfo{
+				ActivityType:   act,
+				SlotsMax:       max.science,
+				SlotsInUse:     scienceInUse,
+				SlotsReserved:  scienceReserved,
+				SlotsAvailable: sciAvail,
+				SlotsListed:    sciListedTotal,
+			}
+		}
+
+		result = append(result, &models.CharacterSlotInventory{
+			CharacterID:     c.id,
+			CharacterName:   c.name,
+			SlotsByActivity: slotsByActivity,
+		})
+	}
+
+	return result, nil
+}
+
+// GetByUser returns all listings for a user
+func (r *JobSlotRentals) GetByUser(ctx context.Context, userID int64) ([]*models.JobSlotRentalListing, error) {
+	query := `
+		SELECT
+			l.id,
+			l.user_id,
+			l.character_id,
+			c.name AS character_name,
+			l.activity_type,
+			l.slots_listed,
+			l.price_amount,
+			l.pricing_unit,
+			l.location_id,
+			'' AS location_name,
+			l.notes,
+			l.is_active,
+			l.created_at,
+			l.updated_at
+		FROM job_slot_rental_listings l
+		JOIN characters c ON l.character_id = c.id AND c.user_id = l.user_id
+		WHERE l.user_id = $1 AND l.is_active = true
+		ORDER BY l.created_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query job slot listings")
+	}
+	defer rows.Close()
+
+	listings := []*models.JobSlotRentalListing{}
+	for rows.Next() {
+		var listing models.JobSlotRentalListing
+		err = rows.Scan(
+			&listing.ID,
+			&listing.UserID,
+			&listing.CharacterID,
+			&listing.CharacterName,
+			&listing.ActivityType,
+			&listing.SlotsListed,
+			&listing.PriceAmount,
+			&listing.PricingUnit,
+			&listing.LocationID,
+			&listing.LocationName,
+			&listing.Notes,
+			&listing.IsActive,
+			&listing.CreatedAt,
+			&listing.UpdatedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan job slot listing")
+		}
+		listings = append(listings, &listing)
+	}
+
+	return listings, nil
+}
+
+// GetBrowsableListings returns listings from permitted sellers
+func (r *JobSlotRentals) GetBrowsableListings(ctx context.Context, viewerUserID int64, sellerUserIDs []int64) ([]*models.JobSlotRentalListing, error) {
+	if len(sellerUserIDs) == 0 {
+		return []*models.JobSlotRentalListing{}, nil
+	}
+
+	query := `
+		SELECT
+			l.id,
+			l.user_id,
+			l.character_id,
+			c.name AS character_name,
+			l.activity_type,
+			l.slots_listed,
+			l.price_amount,
+			l.pricing_unit,
+			l.location_id,
+			'' AS location_name,
+			l.notes,
+			l.is_active,
+			l.created_at,
+			l.updated_at
+		FROM job_slot_rental_listings l
+		JOIN characters c ON l.character_id = c.id AND c.user_id = l.user_id
+		WHERE l.user_id = ANY($1) AND l.is_active = true
+		ORDER BY l.created_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, pq.Array(sellerUserIDs))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query browsable job slot listings")
+	}
+	defer rows.Close()
+
+	listings := []*models.JobSlotRentalListing{}
+	for rows.Next() {
+		var listing models.JobSlotRentalListing
+		err = rows.Scan(
+			&listing.ID,
+			&listing.UserID,
+			&listing.CharacterID,
+			&listing.CharacterName,
+			&listing.ActivityType,
+			&listing.SlotsListed,
+			&listing.PriceAmount,
+			&listing.PricingUnit,
+			&listing.LocationID,
+			&listing.LocationName,
+			&listing.Notes,
+			&listing.IsActive,
+			&listing.CreatedAt,
+			&listing.UpdatedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan browsable job slot listing")
+		}
+		listings = append(listings, &listing)
+	}
+
+	return listings, nil
+}
+
+// Create inserts a new listing
+func (r *JobSlotRentals) Create(ctx context.Context, listing *models.JobSlotRentalListing) error {
+	query := `
+		INSERT INTO job_slot_rental_listings
+		(user_id, character_id, activity_type, slots_listed, price_amount, pricing_unit, location_id, notes, is_active)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING id, created_at, updated_at
+	`
+
+	err := r.db.QueryRowContext(ctx, query,
+		listing.UserID,
+		listing.CharacterID,
+		listing.ActivityType,
+		listing.SlotsListed,
+		listing.PriceAmount,
+		listing.PricingUnit,
+		listing.LocationID,
+		listing.Notes,
+		listing.IsActive,
+	).Scan(&listing.ID, &listing.CreatedAt, &listing.UpdatedAt)
+
+	if err != nil {
+		return errors.Wrap(err, "failed to create job slot listing")
+	}
+
+	return nil
+}
+
+// Update modifies an existing listing
+func (r *JobSlotRentals) Update(ctx context.Context, listing *models.JobSlotRentalListing) error {
+	query := `
+		UPDATE job_slot_rental_listings
+		SET slots_listed = $1, price_amount = $2, pricing_unit = $3, location_id = $4, notes = $5, is_active = $6, updated_at = NOW()
+		WHERE id = $7 AND user_id = $8
+	`
+
+	result, err := r.db.ExecContext(ctx, query,
+		listing.SlotsListed,
+		listing.PriceAmount,
+		listing.PricingUnit,
+		listing.LocationID,
+		listing.Notes,
+		listing.IsActive,
+		listing.ID,
+		listing.UserID,
+	)
+
+	if err != nil {
+		return errors.Wrap(err, "failed to update job slot listing")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("job slot listing not found or user is not the owner")
+	}
+
+	return nil
+}
+
+// Delete soft-deletes a listing
+func (r *JobSlotRentals) Delete(ctx context.Context, listingID int64, userID int64) error {
+	query := `
+		UPDATE job_slot_rental_listings
+		SET is_active = false, updated_at = NOW()
+		WHERE id = $1 AND user_id = $2
+	`
+
+	result, err := r.db.ExecContext(ctx, query, listingID, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete job slot listing")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("job slot listing not found or user is not the owner")
+	}
+
+	return nil
+}
+
+// GetByID returns a specific listing
+func (r *JobSlotRentals) GetByID(ctx context.Context, listingID int64) (*models.JobSlotRentalListing, error) {
+	query := `
+		SELECT
+			l.id,
+			l.user_id,
+			l.character_id,
+			c.name AS character_name,
+			l.activity_type,
+			l.slots_listed,
+			l.price_amount,
+			l.pricing_unit,
+			l.location_id,
+			'' AS location_name,
+			l.notes,
+			l.is_active,
+			l.created_at,
+			l.updated_at
+		FROM job_slot_rental_listings l
+		JOIN characters c ON l.character_id = c.id AND c.user_id = l.user_id
+		WHERE l.id = $1
+	`
+
+	var listing models.JobSlotRentalListing
+	err := r.db.QueryRowContext(ctx, query, listingID).Scan(
+		&listing.ID,
+		&listing.UserID,
+		&listing.CharacterID,
+		&listing.CharacterName,
+		&listing.ActivityType,
+		&listing.SlotsListed,
+		&listing.PriceAmount,
+		&listing.PricingUnit,
+		&listing.LocationID,
+		&listing.LocationName,
+		&listing.Notes,
+		&listing.IsActive,
+		&listing.CreatedAt,
+		&listing.UpdatedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, errors.New("job slot listing not found")
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get job slot listing")
+	}
+
+	return &listing, nil
+}
+
+// CreateInterest inserts a new interest request
+func (r *JobSlotRentals) CreateInterest(ctx context.Context, interest *models.JobSlotInterestRequest) error {
+	query := `
+		INSERT INTO job_slot_interest_requests
+		(listing_id, requester_user_id, slots_requested, duration_days, message, status)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, created_at, updated_at
+	`
+
+	err := r.db.QueryRowContext(ctx, query,
+		interest.ListingID,
+		interest.RequesterUserID,
+		interest.SlotsRequested,
+		interest.DurationDays,
+		interest.Message,
+		interest.Status,
+	).Scan(&interest.ID, &interest.CreatedAt, &interest.UpdatedAt)
+
+	if err != nil {
+		return errors.Wrap(err, "failed to create interest request")
+	}
+
+	return nil
+}
+
+// GetInterestsByListing returns all interest requests for a listing (seller view)
+func (r *JobSlotRentals) GetInterestsByListing(ctx context.Context, listingID int64, sellerUserID int64) ([]*models.JobSlotInterestRequest, error) {
+	query := `
+		SELECT
+			i.id,
+			i.listing_id,
+			i.requester_user_id,
+			u.name AS requester_name,
+			i.slots_requested,
+			i.duration_days,
+			i.message,
+			i.status,
+			i.created_at,
+			i.updated_at
+		FROM job_slot_interest_requests i
+		JOIN job_slot_rental_listings l ON i.listing_id = l.id
+		JOIN users u ON i.requester_user_id = u.id
+		WHERE i.listing_id = $1 AND l.user_id = $2
+		ORDER BY i.created_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, listingID, sellerUserID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query interests by listing")
+	}
+	defer rows.Close()
+
+	interests := []*models.JobSlotInterestRequest{}
+	for rows.Next() {
+		var interest models.JobSlotInterestRequest
+		err = rows.Scan(
+			&interest.ID,
+			&interest.ListingID,
+			&interest.RequesterUserID,
+			&interest.RequesterName,
+			&interest.SlotsRequested,
+			&interest.DurationDays,
+			&interest.Message,
+			&interest.Status,
+			&interest.CreatedAt,
+			&interest.UpdatedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan interest request")
+		}
+		interests = append(interests, &interest)
+	}
+
+	return interests, nil
+}
+
+// GetInterestsByRequester returns all interest requests sent by a user (buyer view)
+func (r *JobSlotRentals) GetInterestsByRequester(ctx context.Context, requesterUserID int64) ([]*models.JobSlotInterestRequest, error) {
+	query := `
+		SELECT
+			i.id,
+			i.listing_id,
+			i.requester_user_id,
+			u1.name AS requester_name,
+			i.slots_requested,
+			i.duration_days,
+			i.message,
+			i.status,
+			i.created_at,
+			i.updated_at,
+			l.activity_type AS listing_activity_type,
+			c.name AS listing_character_name,
+			u2.name AS listing_owner_name,
+			l.price_amount AS listing_price_amount,
+			l.pricing_unit AS listing_pricing_unit
+		FROM job_slot_interest_requests i
+		JOIN users u1 ON i.requester_user_id = u1.id
+		JOIN job_slot_rental_listings l ON i.listing_id = l.id
+		JOIN characters c ON l.character_id = c.id AND c.user_id = l.user_id
+		JOIN users u2 ON l.user_id = u2.id
+		WHERE i.requester_user_id = $1
+		ORDER BY i.created_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, requesterUserID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query interests by requester")
+	}
+	defer rows.Close()
+
+	interests := []*models.JobSlotInterestRequest{}
+	for rows.Next() {
+		var interest models.JobSlotInterestRequest
+		err = rows.Scan(
+			&interest.ID,
+			&interest.ListingID,
+			&interest.RequesterUserID,
+			&interest.RequesterName,
+			&interest.SlotsRequested,
+			&interest.DurationDays,
+			&interest.Message,
+			&interest.Status,
+			&interest.CreatedAt,
+			&interest.UpdatedAt,
+			&interest.ListingActivityType,
+			&interest.ListingCharacterName,
+			&interest.ListingOwnerName,
+			&interest.ListingPriceAmount,
+			&interest.ListingPricingUnit,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan interest request with listing details")
+		}
+		interests = append(interests, &interest)
+	}
+
+	return interests, nil
+}
+
+// UpdateInterestStatus updates the status of an interest request
+func (r *JobSlotRentals) UpdateInterestStatus(ctx context.Context, interestID int64, userID int64, status string) error {
+	// Verify that the user is either the requester (can withdraw) or listing owner (can accept/decline)
+	query := `
+		UPDATE job_slot_interest_requests i
+		SET status = $1, updated_at = NOW()
+		FROM job_slot_rental_listings l
+		WHERE i.id = $2
+			AND i.listing_id = l.id
+			AND (i.requester_user_id = $3 OR l.user_id = $3)
+	`
+
+	result, err := r.db.ExecContext(ctx, query, status, interestID, userID)
+	if err != nil {
+		return errors.Wrap(err, "failed to update interest status")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "failed to get rows affected")
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("interest request not found or user not authorized")
+	}
+
+	return nil
+}
+
+// GetReceivedInterests returns all interests across all of a user's listings
+func (r *JobSlotRentals) GetReceivedInterests(ctx context.Context, userID int64) ([]*models.JobSlotInterestRequest, error) {
+	query := `
+		SELECT
+			i.id,
+			i.listing_id,
+			i.requester_user_id,
+			u.name AS requester_name,
+			i.slots_requested,
+			i.duration_days,
+			i.message,
+			i.status,
+			i.created_at,
+			i.updated_at,
+			l.activity_type AS listing_activity_type,
+			c.name AS listing_character_name
+		FROM job_slot_interest_requests i
+		JOIN job_slot_rental_listings l ON i.listing_id = l.id
+		JOIN users u ON i.requester_user_id = u.id
+		JOIN characters c ON l.character_id = c.id AND c.user_id = l.user_id
+		WHERE l.user_id = $1
+		ORDER BY i.created_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query received interests")
+	}
+	defer rows.Close()
+
+	interests := []*models.JobSlotInterestRequest{}
+	for rows.Next() {
+		var interest models.JobSlotInterestRequest
+		err = rows.Scan(
+			&interest.ID,
+			&interest.ListingID,
+			&interest.RequesterUserID,
+			&interest.RequesterName,
+			&interest.SlotsRequested,
+			&interest.DurationDays,
+			&interest.Message,
+			&interest.Status,
+			&interest.CreatedAt,
+			&interest.UpdatedAt,
+			&interest.ListingActivityType,
+			&interest.ListingCharacterName,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan received interest request")
+		}
+		interests = append(interests, &interest)
+	}
+
+	return interests, nil
+}

--- a/internal/repositories/jobSlotRentals_test.go
+++ b/internal/repositories/jobSlotRentals_test.go
@@ -1,0 +1,466 @@
+package repositories_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/annymsMthd/industry-tool/internal/models"
+	"github.com/annymsMthd/industry-tool/internal/repositories"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupJobSlotRentalTestData(t *testing.T, db *sql.DB, userID, charID int64) {
+	userRepo := repositories.NewUserRepository(db)
+	characterRepo := repositories.NewCharacterRepository(db)
+
+	user := &repositories.User{ID: userID, Name: "Test User"}
+	err := userRepo.Add(context.Background(), user)
+	assert.NoError(t, err)
+
+	char := &repositories.Character{ID: charID, Name: "Test Character", UserID: userID}
+	err = characterRepo.Add(context.Background(), char)
+	assert.NoError(t, err)
+
+	// Add some test skills for slot calculation
+	_, err = db.ExecContext(context.Background(),
+		`INSERT INTO character_skills (character_id, user_id, skill_id, trained_level, active_level, skillpoints, updated_at)
+		VALUES ($1, $2, 3387, 5, 5, 100000, NOW()),
+		       ($1, $2, 24625, 5, 5, 100000, NOW()),
+		       ($1, $2, 45746, 4, 4, 80000, NOW()),
+		       ($1, $2, 45748, 3, 3, 60000, NOW()),
+		       ($1, $2, 3402, 3, 3, 60000, NOW()),
+		       ($1, $2, 3406, 2, 2, 40000, NOW())`,
+		charID, userID)
+	assert.NoError(t, err)
+
+	// Create region, constellation, and solar system
+	_, err = db.ExecContext(context.Background(),
+		"INSERT INTO regions (region_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+		10000002, "The Forge")
+	assert.NoError(t, err)
+
+	_, err = db.ExecContext(context.Background(),
+		"INSERT INTO constellations (constellation_id, name, region_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+		20000020, "Kimotoro", 10000002)
+	assert.NoError(t, err)
+
+	_, err = db.ExecContext(context.Background(),
+		"INSERT INTO solar_systems (solar_system_id, name, constellation_id, security) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
+		30000142, "Jita", 20000020, 0.9)
+	assert.NoError(t, err)
+}
+
+func Test_JobSlotRentalsCreateListing(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userID := int64(8000)
+	charID := int64(80000)
+	setupJobSlotRentalTestData(t, db, userID, charID)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	locationID := int64(30000142)
+	listing := &models.JobSlotRentalListing{
+		UserID:       userID,
+		CharacterID:  charID,
+		ActivityType: "manufacturing",
+		SlotsListed:  2,
+		PriceAmount:  100000,
+		PricingUnit:  "per_slot_day",
+		LocationID:   &locationID,
+		IsActive:     true,
+	}
+
+	err = repo.Create(context.Background(), listing)
+	assert.NoError(t, err)
+	assert.NotZero(t, listing.ID)
+	assert.NotZero(t, listing.CreatedAt)
+}
+
+func Test_JobSlotRentalsGetByUser(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userID := int64(8100)
+	charID := int64(81000)
+	setupJobSlotRentalTestData(t, db, userID, charID)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	locationID := int64(30000142)
+	listing := &models.JobSlotRentalListing{
+		UserID:       userID,
+		CharacterID:  charID,
+		ActivityType: "reaction",
+		SlotsListed:  1,
+		PriceAmount:  50000,
+		PricingUnit:  "per_job",
+		LocationID:   &locationID,
+		IsActive:     true,
+	}
+
+	err = repo.Create(context.Background(), listing)
+	assert.NoError(t, err)
+
+	listings, err := repo.GetByUser(context.Background(), userID)
+	assert.NoError(t, err)
+	assert.Len(t, listings, 1)
+	assert.Equal(t, "reaction", listings[0].ActivityType)
+	assert.Equal(t, 1, listings[0].SlotsListed)
+	assert.Equal(t, "Test Character", listings[0].CharacterName)
+}
+
+func Test_JobSlotRentalsUpdateListing(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userID := int64(8200)
+	charID := int64(82000)
+	setupJobSlotRentalTestData(t, db, userID, charID)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	locationID := int64(30000142)
+	listing := &models.JobSlotRentalListing{
+		UserID:       userID,
+		CharacterID:  charID,
+		ActivityType: "invention",
+		SlotsListed:  2,
+		PriceAmount:  75000,
+		PricingUnit:  "per_slot_day",
+		LocationID:   &locationID,
+		IsActive:     true,
+	}
+
+	err = repo.Create(context.Background(), listing)
+	assert.NoError(t, err)
+
+	// Update
+	listing.SlotsListed = 3
+	listing.PriceAmount = 90000
+	err = repo.Update(context.Background(), listing)
+	assert.NoError(t, err)
+
+	// Verify
+	updated, err := repo.GetByID(context.Background(), listing.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, updated.SlotsListed)
+	assert.Equal(t, float64(90000), updated.PriceAmount)
+}
+
+func Test_JobSlotRentalsDeleteListing(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userID := int64(8300)
+	charID := int64(83000)
+	setupJobSlotRentalTestData(t, db, userID, charID)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	locationID := int64(30000142)
+	listing := &models.JobSlotRentalListing{
+		UserID:       userID,
+		CharacterID:  charID,
+		ActivityType: "copying",
+		SlotsListed:  1,
+		PriceAmount:  25000,
+		PricingUnit:  "per_slot_day",
+		LocationID:   &locationID,
+		IsActive:     true,
+	}
+
+	err = repo.Create(context.Background(), listing)
+	assert.NoError(t, err)
+
+	// Delete
+	err = repo.Delete(context.Background(), listing.ID, userID)
+	assert.NoError(t, err)
+
+	// Verify no longer active
+	listings, err := repo.GetByUser(context.Background(), userID)
+	assert.NoError(t, err)
+	assert.Len(t, listings, 0)
+}
+
+func Test_JobSlotRentalsCalculateSlotInventory(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userID := int64(8400)
+	charID := int64(84000)
+	setupJobSlotRentalTestData(t, db, userID, charID)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	// Calculate inventory
+	inventory, err := repo.CalculateSlotInventory(context.Background(), userID)
+	assert.NoError(t, err)
+	assert.Len(t, inventory, 1)
+	assert.Equal(t, charID, inventory[0].CharacterID)
+	assert.Equal(t, "Test Character", inventory[0].CharacterName)
+
+	// Verify manufacturing slots (1 + MassProd(5) + AdvMassProd(5) = 11)
+	mfg := inventory[0].SlotsByActivity["manufacturing"]
+	assert.NotNil(t, mfg)
+	assert.Equal(t, 11, mfg.SlotsMax)
+	assert.Equal(t, 0, mfg.SlotsInUse)
+	assert.Equal(t, 11, mfg.SlotsAvailable)
+
+	// Verify reaction slots (1 + MassReactions(3) = 4)
+	react := inventory[0].SlotsByActivity["reaction"]
+	assert.NotNil(t, react)
+	assert.Equal(t, 4, react.SlotsMax)
+
+	// Verify science slots (1 + LabOp(2) = 3)
+	invention := inventory[0].SlotsByActivity["invention"]
+	assert.NotNil(t, invention)
+	assert.Equal(t, 3, invention.SlotsMax)
+}
+
+func Test_JobSlotRentalsCalculateSlotInventoryWithListings(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	userID := int64(8500)
+	charID := int64(85000)
+	setupJobSlotRentalTestData(t, db, userID, charID)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	// Create a listing for 2 manufacturing slots
+	locationID := int64(30000142)
+	listing := &models.JobSlotRentalListing{
+		UserID:       userID,
+		CharacterID:  charID,
+		ActivityType: "manufacturing",
+		SlotsListed:  2,
+		PriceAmount:  100000,
+		PricingUnit:  "per_slot_day",
+		LocationID:   &locationID,
+		IsActive:     true,
+	}
+
+	err = repo.Create(context.Background(), listing)
+	assert.NoError(t, err)
+
+	// Calculate inventory
+	inventory, err := repo.CalculateSlotInventory(context.Background(), userID)
+	assert.NoError(t, err)
+	assert.Len(t, inventory, 1)
+
+	// Verify manufacturing slots show 2 listed
+	mfg := inventory[0].SlotsByActivity["manufacturing"]
+	assert.Equal(t, 2, mfg.SlotsListed)
+	assert.Equal(t, 9, mfg.SlotsAvailable) // 11 max - 2 listed = 9 available
+}
+
+func Test_JobSlotRentalsCreateInterest(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	sellerUserID := int64(8600)
+	sellerCharID := int64(86000)
+	buyerUserID := int64(8601)
+	setupJobSlotRentalTestData(t, db, sellerUserID, sellerCharID)
+
+	// Create buyer user
+	userRepo := repositories.NewUserRepository(db)
+	buyer := &repositories.User{ID: buyerUserID, Name: "Buyer User"}
+	err = userRepo.Add(context.Background(), buyer)
+	assert.NoError(t, err)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	// Create listing
+	locationID := int64(30000142)
+	listing := &models.JobSlotRentalListing{
+		UserID:       sellerUserID,
+		CharacterID:  sellerCharID,
+		ActivityType: "manufacturing",
+		SlotsListed:  3,
+		PriceAmount:  100000,
+		PricingUnit:  "per_slot_day",
+		LocationID:   &locationID,
+		IsActive:     true,
+	}
+
+	err = repo.Create(context.Background(), listing)
+	assert.NoError(t, err)
+
+	// Create interest
+	durationDays := 7
+	interest := &models.JobSlotInterestRequest{
+		ListingID:       listing.ID,
+		RequesterUserID: buyerUserID,
+		SlotsRequested:  2,
+		DurationDays:    &durationDays,
+		Status:          "pending",
+	}
+
+	err = repo.CreateInterest(context.Background(), interest)
+	assert.NoError(t, err)
+	assert.NotZero(t, interest.ID)
+}
+
+func Test_JobSlotRentalsGetInterestsByListing(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	sellerUserID := int64(8700)
+	sellerCharID := int64(87000)
+	buyerUserID := int64(8701)
+	setupJobSlotRentalTestData(t, db, sellerUserID, sellerCharID)
+
+	// Create buyer user
+	userRepo := repositories.NewUserRepository(db)
+	buyer := &repositories.User{ID: buyerUserID, Name: "Buyer User"}
+	err = userRepo.Add(context.Background(), buyer)
+	assert.NoError(t, err)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	// Create listing
+	locationID := int64(30000142)
+	listing := &models.JobSlotRentalListing{
+		UserID:       sellerUserID,
+		CharacterID:  sellerCharID,
+		ActivityType: "reaction",
+		SlotsListed:  2,
+		PriceAmount:  50000,
+		PricingUnit:  "per_job",
+		LocationID:   &locationID,
+		IsActive:     true,
+	}
+
+	err = repo.Create(context.Background(), listing)
+	assert.NoError(t, err)
+
+	// Create interest
+	interest := &models.JobSlotInterestRequest{
+		ListingID:       listing.ID,
+		RequesterUserID: buyerUserID,
+		SlotsRequested:  1,
+		Status:          "pending",
+	}
+
+	err = repo.CreateInterest(context.Background(), interest)
+	assert.NoError(t, err)
+
+	// Get interests
+	interests, err := repo.GetInterestsByListing(context.Background(), listing.ID, sellerUserID)
+	assert.NoError(t, err)
+	assert.Len(t, interests, 1)
+	assert.Equal(t, "Buyer User", interests[0].RequesterName)
+	assert.Equal(t, 1, interests[0].SlotsRequested)
+}
+
+func Test_JobSlotRentalsGetInterestsByRequester(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	sellerUserID := int64(8800)
+	sellerCharID := int64(88000)
+	buyerUserID := int64(8801)
+	setupJobSlotRentalTestData(t, db, sellerUserID, sellerCharID)
+
+	// Create buyer user
+	userRepo := repositories.NewUserRepository(db)
+	buyer := &repositories.User{ID: buyerUserID, Name: "Buyer User"}
+	err = userRepo.Add(context.Background(), buyer)
+	assert.NoError(t, err)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	// Create listing
+	locationID := int64(30000142)
+	listing := &models.JobSlotRentalListing{
+		UserID:       sellerUserID,
+		CharacterID:  sellerCharID,
+		ActivityType: "invention",
+		SlotsListed:  2,
+		PriceAmount:  75000,
+		PricingUnit:  "per_slot_day",
+		LocationID:   &locationID,
+		IsActive:     true,
+	}
+
+	err = repo.Create(context.Background(), listing)
+	assert.NoError(t, err)
+
+	// Create interest
+	interest := &models.JobSlotInterestRequest{
+		ListingID:       listing.ID,
+		RequesterUserID: buyerUserID,
+		SlotsRequested:  2,
+		Status:          "pending",
+	}
+
+	err = repo.CreateInterest(context.Background(), interest)
+	assert.NoError(t, err)
+
+	// Get interests by requester
+	interests, err := repo.GetInterestsByRequester(context.Background(), buyerUserID)
+	assert.NoError(t, err)
+	assert.Len(t, interests, 1)
+	assert.Equal(t, "invention", interests[0].ListingActivityType)
+	assert.Equal(t, "Test Character", interests[0].ListingCharacterName)
+	assert.Equal(t, "Test User", interests[0].ListingOwnerName)
+}
+
+func Test_JobSlotRentalsUpdateInterestStatus(t *testing.T) {
+	db, err := setupDatabase(t)
+	assert.NoError(t, err)
+
+	sellerUserID := int64(8900)
+	sellerCharID := int64(89000)
+	buyerUserID := int64(8901)
+	setupJobSlotRentalTestData(t, db, sellerUserID, sellerCharID)
+
+	// Create buyer user
+	userRepo := repositories.NewUserRepository(db)
+	buyer := &repositories.User{ID: buyerUserID, Name: "Buyer User"}
+	err = userRepo.Add(context.Background(), buyer)
+	assert.NoError(t, err)
+
+	repo := repositories.NewJobSlotRentals(db)
+
+	// Create listing
+	locationID := int64(30000142)
+	listing := &models.JobSlotRentalListing{
+		UserID:       sellerUserID,
+		CharacterID:  sellerCharID,
+		ActivityType: "manufacturing",
+		SlotsListed:  3,
+		PriceAmount:  100000,
+		PricingUnit:  "per_slot_day",
+		LocationID:   &locationID,
+		IsActive:     true,
+	}
+
+	err = repo.Create(context.Background(), listing)
+	assert.NoError(t, err)
+
+	// Create interest
+	interest := &models.JobSlotInterestRequest{
+		ListingID:       listing.ID,
+		RequesterUserID: buyerUserID,
+		SlotsRequested:  2,
+		Status:          "pending",
+	}
+
+	err = repo.CreateInterest(context.Background(), interest)
+	assert.NoError(t, err)
+
+	// Seller accepts
+	err = repo.UpdateInterestStatus(context.Background(), interest.ID, sellerUserID, "accepted")
+	assert.NoError(t, err)
+
+	// Verify status
+	interests, err := repo.GetInterestsByListing(context.Background(), listing.ID, sellerUserID)
+	assert.NoError(t, err)
+	assert.Len(t, interests, 1)
+	assert.Equal(t, "accepted", interests[0].Status)
+}


### PR DESCRIPTION
## Summary
- Job slot rental matchmaking board: users list idle industry slots for rent, contacts browse and express interest
- Three slot pools calculated from character skills: manufacturing, science, reactions
- 11 API endpoints for inventory, listings CRUD, browse (permission-gated), and interest request lifecycle
- 4-tab frontend page: Slot Inventory, My Listings, Browse Listings, Interest Requests
- New `job_slot_browse` contact permission for browse access
- 15 E2E tests covering full workflow (listing CRUD, permissions, interest requests, accept/decline/withdraw)

## Test plan
- [x] `make test-backend` — all Go tests pass
- [x] `make test-frontend` — snapshot tests pass
- [x] `make test-e2e-ci` — 123 E2E tests pass (0 failures)
- [x] `make build-production` — production images build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)