### PR TITLE
Fix job slot browse for pre-existing contacts

### DIFF
--- a/internal/database/migrations/20260228170404_backfill_job_slot_browse_permissions.down.sql
+++ b/internal/database/migrations/20260228170404_backfill_job_slot_browse_permissions.down.sql
@@ -1,0 +1,6 @@
+-- Migration: backfill_job_slot_browse_permissions
+-- Created: Sat Feb 28 05:04:04 PM PST 2026
+
+-- Remove all job_slot_browse permission rows
+-- Safe to remove all since feature would be rolled back anyway
+delete from contact_permissions where service_type = 'job_slot_browse';

--- a/internal/database/migrations/20260228170404_backfill_job_slot_browse_permissions.up.sql
+++ b/internal/database/migrations/20260228170404_backfill_job_slot_browse_permissions.up.sql
@@ -1,0 +1,17 @@
+-- Migration: backfill_job_slot_browse_permissions
+-- Created: Sat Feb 28 05:04:04 PM PST 2026
+
+-- Backfill job_slot_browse permission rows for existing contacts
+-- Mirrors for_sale_browse rows to ensure users can see job slot listings
+insert into contact_permissions (contact_id, granting_user_id, receiving_user_id, service_type, can_access, created_at, updated_at)
+select
+	contact_id,
+	granting_user_id,
+	receiving_user_id,
+	'job_slot_browse' as service_type,
+	can_access,
+	now() as created_at,
+	now() as updated_at
+from contact_permissions
+where service_type = 'for_sale_browse'
+on conflict (contact_id, granting_user_id, receiving_user_id, service_type) do nothing;


### PR DESCRIPTION
## Summary
- Contacts accepted before the job slot rental feature was deployed have no `job_slot_browse` permission rows, causing the Browse Listings tab to show nothing for other users
- Adds a backfill migration that copies `for_sale_browse` rows to create matching `job_slot_browse` entries, preserving the existing `can_access` value
- Uses `ON CONFLICT DO NOTHING` to safely skip contacts that already have `job_slot_browse` rows

## Test plan
- [x] Backend tests pass (1,072 tests)
- [x] Production build passes
- [ ] Deploy and verify other users can see job slot listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)