### PR TITLE
chore: agent improvements from job slot rental phases 2 & 3

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -421,6 +421,36 @@ sde_categories → sde_groups → asset_item_types
 sde_blueprints → sde_blueprint_activities → materials/products/skills
 ```
 
+## Notification After Create — CRITICAL Anti-Pattern
+
+When a handler creates a new record and immediately fires a Discord notification (or any notifier), **never pass the freshly-constructed struct** to the notifier. A freshly-built struct only has the fields you set directly — JOIN-populated fields (e.g., `RequesterName`, `OwnerName`, relationship names) will be empty strings or zero values.
+
+**Always call `GetByID` (or an equivalent enriched fetch) first to get the fully-populated model, then pass that to the notifier:**
+
+```go
+// BAD — freshly-constructed struct has empty RequesterName
+newRecord := &models.JobSlotInterest{
+    SlotID:      req.SlotID,
+    RequesterID: userID,
+}
+if err := r.repo.Create(ctx, newRecord); err != nil {
+    return nil, err
+}
+go r.notifier.NotifyInterestReceived(ctx, newRecord) // RequesterName is ""
+
+// GOOD — fetch enriched record first, then notify
+created, err := r.repo.Create(ctx, &models.JobSlotInterest{SlotID: req.SlotID, RequesterID: userID})
+if err != nil {
+    return nil, err
+}
+enriched, err := r.repo.GetByID(ctx, created.ID, userID)
+if err == nil {
+    go r.notifier.NotifyInterestReceived(ctx, enriched) // RequesterName populated
+}
+```
+
+This applies to any notification that includes human-readable names resolved via SQL JOINs.
+
 ## Output
 
 When you complete work, summarize:

--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -417,6 +417,29 @@ Snapshot tests that render timestamps or dates can produce different output depe
 
 Both must be set; setting only one will still produce mismatches between local and Docker runs.
 
+### Nested API Route Auth Import Path — CRITICAL
+
+API routes in `pages/api/` that use NextAuth's `getServerSession` must import from `../../auth/[...nextauth]` (relative to the file). **The number of `../` levels must match the directory depth of the API route file, not the folder nesting.**
+
+Count from the API route file up to `pages/api/`, then add one more level to reach `auth/[...nextauth]`:
+
+| File location | Correct import |
+|---|---|
+| `pages/api/foo/action.ts` | `../auth/[...nextauth]` |
+| `pages/api/foo/[id]/action.ts` | `../../auth/[...nextauth]` |
+| `pages/api/foo/bar/[id]/action.ts` | `../../../auth/[...nextauth]` |
+
+```ts
+// File: pages/api/job-slots/agreements/[id]/complete.ts
+// Depth from pages/api: foo/bar/[id] = 3 levels deep → 3 × ../
+import { authOptions } from '../../../auth/[...nextauth]';
+
+// BAD — one too many ../ for a 3-level-deep route
+import { authOptions } from '../../../../auth/[...nextauth]';
+```
+
+A wrong path causes a runtime import error that is invisible during Jest tests but fails immediately when the route is called in the browser or E2E tests.
+
 ### Running tests
 
 - **Full suite**: `make test-frontend` (runs all Jest tests in Docker)

--- a/.claude/agents/sdet.md
+++ b/.claude/agents/sdet.md
@@ -284,6 +284,48 @@ await expect(dialog).not.toBeVisible({ timeout: 5000 });
 page.on('dialog', dialog => dialog.accept());
 ```
 
+### Background Runner Data — Do Not Assert on Specific Records
+
+`esi_industry_jobs` (and similar tables populated by background runners) are only filled when the runner executes. In E2E tests, calling `setCharacterIndustryJobs()` via the admin API only controls what the mock ESI returns — it does NOT immediately insert rows into the database. The runner must actually fire and complete before the data appears.
+
+**Do NOT assert on specific job rows** unless you can wait with a retry loop for the runner to complete AND confirm the runner actually runs during the test. Instead:
+
+- Assert on the UI panel/section being visible (e.g., "Active Jobs" heading, "No active jobs" empty state)
+- Assert on the panel opening and closing
+- Assert on counts or empty states
+
+```typescript
+// BAD — assumes runner has already run and populated the table
+await expect(page.getByText('Rifter Manufacturing')).toBeVisible({ timeout: 5000 });
+
+// GOOD — assert on the panel/section presence, not specific job data
+const activeJobsSection = page.getByText('Active Industry Jobs');
+await expect(activeJobsSection).toBeVisible({ timeout: 5000 });
+// OR verify empty state if runner hasn't run
+await expect(page.getByText(/no active jobs/i)).toBeVisible({ timeout: 5000 });
+```
+
+If the test truly needs to verify job data is displayed, use a retry loop:
+```typescript
+await expect(async () => {
+  await page.reload();
+  await expect(page.getByText('Rifter', { exact: true })).toBeVisible({ timeout: 3000 });
+}).toPass({ timeout: 35000 });
+```
+
+### Always Verify Button Text Before Writing Selectors
+
+Before writing any `getByRole('button', { name: /text/i })` selector, **read the actual component source** or use the Playwright inspector to confirm the exact button label. Button text in this codebase is often shorter than expected:
+
+| What you might guess | Actual text |
+|---|---|
+| "Mark Complete" | "Complete" |
+| "View Jobs" | "Jobs" |
+| "Submit Interest" | "Express Interest" |
+| "Cancel Agreement" | "Cancel" |
+
+A wrong button name will silently not find the element and cause confusing timeout failures. When in doubt, use a partial regex (`/complete/i`) that is more permissive.
+
 ### shadcn/ui Dialogs with Required Field Dependencies
 
 Some dialogs (e.g., P&L entry) have Save buttons disabled until multiple required fields are set. The typical pattern:


### PR DESCRIPTION
## Summary
- Added anti-pattern to backend-dev: always call `GetByID` before passing struct to Discord notifiers (JOIN-populated fields like `RequesterName` won't be set on freshly-constructed structs)
- Added nested API route auth import depth table to frontend-dev: correct relative path levels for `pages/api/a/b/[id]/file.ts` is 3 levels up to reach `api/`, not 4
- Documented in sdet: `setCharacterIndustryJobs` only sets mock ESI data, not the `esi_industry_jobs` table; assert on empty state before interaction; verify button text from component source before writing selectors

## Test plan
- [ ] No code changes — agent instruction files only
- [ ] Verify `.claude/agents/backend-dev.md`, `frontend-dev.md`, and `sdet.md` contain the new conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)